### PR TITLE
chore: allow creating array constants in a type-safe way

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "cypress": "^14.4.0",
         "cypress-tags": "^1.2.2",
         "jsdom": "^26.1.0",
-        "openapi-typescript-codegen": "^0.29.0",
+        "openapi-typescript": "^7.8.0",
         "start-server-and-test": "^2.0.12",
         "typescript": "^5",
         "vitest": "^3.1.4",

--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -1,65 +1,57 @@
 #!/bin/bash
 set -e
 
+
 # Configuration
 API_URL="https://play.im.dhis2.org/dev/api/openapi.yaml"
-OUTPUT_DIR="./src/types/dhis2-openapi-schemas"
+TYPES_DIR="./src/types/dhis2-openapi-schemas"
 TEMP_DIR="./temp-openapi"
 AUTH_HEADER="Authorization: Basic $(echo -n "admin:district" | base64)"
 
 # Clean and create directories
-rm -rf "$TEMP_DIR" "$OUTPUT_DIR"
-mkdir -p "$TEMP_DIR" "$OUTPUT_DIR"
+rm -rf "$TEMP_DIR" "$TYPES_DIR"
+mkdir -p "$TEMP_DIR" "$TYPES_DIR"
 
 # Fetch OpenAPI spec
 echo "📥 Fetching OpenAPI specification..."
 curl -H "Accept: application/x-yaml" -H "$AUTH_HEADER" "$API_URL" -o "$TEMP_DIR/openapi.yaml"
 
-# Generate types with openapi-typescript-codegen
+# Generate types with openapi-typescript
 echo "⌛ Generating TypeScript types..."
-npx openapi-typescript-codegen generate \
-    --input "$TEMP_DIR/openapi.yaml" \
-    --output "$OUTPUT_DIR" \
-    --exportModels true \
-    --exportCore false \
-    --exportServices false
+npx openapi-typescript "$TEMP_DIR/openapi.yaml" --output "$TYPES_DIR/generated.d.ts"
 
-# Move models to root of generated directory
-echo "🔄 Organizing type files..."
-find "$OUTPUT_DIR/models" -name '*.ts' -exec mv {} "$OUTPUT_DIR" \;
-rm -rf "$OUTPUT_DIR/models"
+# Generate named type aliases
+echo "🔗 Generating named type aliases..."
+awk '
+BEGIN {
+    print "// AUTO-GENERATED FILE: Named type aliases for OpenAPI schemas"
+    print "// Regenerate this file if the OpenAPI spec changes.\n"
+    print "import type { components } from '\''./generated'\'';\n"
+    print "type Schemas = components['\''schemas'\''];\n"
+}
+$0 ~ /export interface components/ { in_components=1 }
+in_components && $0 ~ /schemas:/ { in_schemas=1 }
+in_schemas && /^[ ]{8}[A-Za-z0-9_]+(\??):/ {
+    key = $1
+    gsub(":", "", key)
+    gsub(/\?/, "", key)
+    if (key != "" && key != "parameters" && key != "requestBody" && key != "responses")
+        print "export type " key " = Schemas[\047" key "\047];"
+}
+in_schemas && /^[ ]{6}\}/ { in_schemas=0 }
+in_components && /^}/ { in_components=0 }
+' "$TYPES_DIR/generated.d.ts" > "$TYPES_DIR/index.d.ts"
 
-# Create index file that exports all models
-echo "📄 Creating index file..."
-echo "// AUTO-GENERATED TYPES - DO NOT MODIFY" >"$OUTPUT_DIR/index.ts"
-echo "// Generated from $API_URL" >>"$OUTPUT_DIR/index.ts"
-echo "" >>"$OUTPUT_DIR/index.ts"
-
-for file in "$OUTPUT_DIR"/*.ts; do
-    if [ "$(basename "$file")" != "index.ts" ]; then
-        name=$(basename "$file" .ts)
-        echo "export * from './$name';" >>"$OUTPUT_DIR/index.ts"
-    fi
-done
+# # Generate named type aliases using Node.js script
+# echo "🔗 Generating named type aliases..."
+# node ./scripts/generate-type-aliases.cjs "$TYPES_DIR/generated.d.ts" "$TYPES_DIR/index.d.ts"
 
 # Format the output
 echo "💅 Formatting output..."
-# Prettier echoes each file it formats, even with --log-level silent
-# so just send it to the bit bucket
-npx prettier --write "$OUTPUT_DIR" >/dev/null
-
-# Remove eslint-disable comments from generated files (compatible with GNU and BSD sed)
-echo "🧹 Removing eslint-disable comments..."
-if sed --version >/dev/null 2>&1; then
-    # GNU sed (Linux, WSL, Git Bash)
-    find "$OUTPUT_DIR" -name '*.ts' -type f -exec sed -i '/^\/\* eslint-disable \*\/$/d' {} +
-else
-    # BSD sed (macOS)
-    find "$OUTPUT_DIR" -name '*.ts' -type f -exec sed -i '' '/^\/\* eslint-disable \*\/$/d' {} +
-fi
+npx prettier --write "$TYPES_DIR" >/dev/null
 
 # Cleanup
 echo "🧹 Cleaning up..."
 rm -rf "$TEMP_DIR"
 
-echo "✅ Types generated in $OUTPUT_DIR"
+echo "✅ Types generated in $TYPES_DIR"

--- a/src/app-wrapper/metadata-helpers/initial-metadata.ts
+++ b/src/app-wrapper/metadata-helpers/initial-metadata.ts
@@ -1,35 +1,14 @@
 import i18n from '@dhis2/d2-i18n'
-import type { RelativePeriodEnum } from '@types'
+import type { UserOrgUnit, SupportedRelativePeriod } from '../../constants'
 import type { AnyMetadataItemInput } from './types'
 
-type UserOrgUnits =
-    | 'USER_ORGUNIT'
-    | 'USER_ORGUNIT_CHILDREN'
-    | 'USER_ORGUNIT_GRANDCHILDREN'
-
-const getOrganisationUnits = (): Record<UserOrgUnits, string> => ({
+const getOrganisationUnits = (): Record<UserOrgUnit, string> => ({
     USER_ORGUNIT: i18n.t('User organisation unit'),
     USER_ORGUNIT_CHILDREN: i18n.t('User sub-units'),
     USER_ORGUNIT_GRANDCHILDREN: i18n.t('User sub-x2-units'),
 })
 
-type SupportedRelativePeriods = Exclude<
-    (typeof RelativePeriodEnum)[keyof typeof RelativePeriodEnum],
-    | 'LAST_5_YEARS'
-    | 'LAST_30_DAYS'
-    | 'LAST_60_DAYS'
-    | 'LAST_90_DAYS'
-    | 'LAST_180_DAYS'
-    | 'MONTHS_LAST_YEAR'
-    | 'QUARTERS_LAST_YEAR'
-    | 'LAST_10_YEARS'
-    | 'LAST_10_FINANCIAL_YEARS'
-    | 'THIS_BIWEEK'
-    | 'LAST_BIWEEK'
-    | 'LAST_4_BIWEEKS'
->
-
-const getRelativePeriods = (): Record<SupportedRelativePeriods, string> => ({
+const getRelativePeriods = (): Record<SupportedRelativePeriod, string> => ({
     TODAY: i18n.t('Today'),
     YESTERDAY: i18n.t('Yesterday'),
     LAST_3_DAYS: i18n.t('Last 3 days'),

--- a/src/constants/helpers.ts
+++ b/src/constants/helpers.ts
@@ -1,0 +1,13 @@
+/**
+ * Helper to create a type-safe array of string literals that is a subset of a given string literal type.
+ *
+ * Usage:
+ *   const allowed = asStringLiteralSubsetArray<'foo' | 'bar' | 'baz'>()(['foo', 'baz'] as const)
+ * This ensures:
+ *   - Only values from the string literal type U are allowed in the array.
+ *   - The resulting array is strongly typed as a readonly tuple of those values.
+ */
+export const asStringLiteralSubsetArray =
+    <U extends string>() =>
+    <T extends readonly U[]>(arr: T) =>
+        arr

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,55 @@
+import type { EventVisualizationType, RelativePeriodEnum } from '@types'
+import { asStringLiteralSubsetArray } from './helpers'
+
+export const SUPPORTED_VIS_TYPES =
+    asStringLiteralSubsetArray<EventVisualizationType>()([
+        'LINE_LIST',
+        'PIVOT_TABLE',
+    ] as const)
+export type SupportedVisType = (typeof SUPPORTED_VIS_TYPES)[number]
+
+export const SUPPORTED_RELATIVE_PERIODS =
+    asStringLiteralSubsetArray<RelativePeriodEnum>()([
+        'TODAY',
+        'YESTERDAY',
+        'LAST_3_DAYS',
+        'LAST_7_DAYS',
+        'LAST_14_DAYS',
+        'THIS_WEEK',
+        'LAST_WEEK',
+        'LAST_4_WEEKS',
+        'LAST_12_WEEKS',
+        'LAST_52_WEEKS',
+        'WEEKS_THIS_YEAR',
+        'THIS_MONTH',
+        'LAST_MONTH',
+        'LAST_3_MONTHS',
+        'LAST_6_MONTHS',
+        'LAST_12_MONTHS',
+        'MONTHS_THIS_YEAR',
+        'THIS_BIMONTH',
+        'LAST_BIMONTH',
+        'LAST_6_BIMONTHS',
+        'BIMONTHS_THIS_YEAR',
+        'THIS_QUARTER',
+        'LAST_QUARTER',
+        'LAST_4_QUARTERS',
+        'QUARTERS_THIS_YEAR',
+        'THIS_SIX_MONTH',
+        'LAST_SIX_MONTH',
+        'LAST_2_SIXMONTHS',
+        'THIS_FINANCIAL_YEAR',
+        'LAST_FINANCIAL_YEAR',
+        'LAST_5_FINANCIAL_YEARS',
+        'THIS_YEAR',
+        'LAST_YEAR',
+    ] as const)
+export type SupportedRelativePeriod =
+    (typeof SUPPORTED_RELATIVE_PERIODS)[number]
+
+export const USER_ORG_UNITS = [
+    'USER_ORGUNIT',
+    'USER_ORGUNIT_CHILDREN',
+    'USER_ORGUNIT_GRANDCHILDREN',
+] as const
+export type UserOrgUnit = (typeof USER_ORG_UNITS)[number]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,11 +7,9 @@ import { ResponseErrorReport } from '../api/parse-engine-error'
  * `src/types/dhis2-openapi-schemas` anywhere else in the codebase.
  * The reason for this is so that we can apply manual overrides
  * for generated types here, as we have done for `SystemSettings` */
-/* eslint-disable import/export */
 export type * from './dhis2-openapi-schemas'
 export type { SystemSettings } from './system-settings'
 export type { MetadataItem } from './metadata-item'
-/* eslint-enable import/export */
 export type { PickWithFieldFilters } from './pick-with-field-filters'
 
 /* The SingleQuery type is a simpler, but for our use-case functionally

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,15 +24,6 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@apidevtools/json-schema-ref-parser@^11.5.4":
-  version "11.9.3"
-  resolved "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz"
-  integrity sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==
-  dependencies:
-    "@jsdevtools/ono" "^7.1.3"
-    "@types/json-schema" "^7.0.15"
-    js-yaml "^4.1.0"
-
 "@asamuzakjp/css-color@^3.1.2":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@asamuzakjp/css-color/-/css-color-3.2.0.tgz#cc42f5b85c593f79f1fa4f25d2b9b321e61d1794"
@@ -44,7 +35,7 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.26.2", "@babel/code-frame@^7.27.1", "@babel/code-frame@^7.8.3":
   version "7.27.1"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -2870,11 +2861,6 @@
     jsbi "^4.1.0"
     tslib "^2.3.1"
 
-"@jsdevtools/ono@^7.1.3":
-  version "7.1.3"
-  resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz"
-  integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
-
 "@juggle/resize-observer@^3.3.1":
   version "3.4.0"
   resolved "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz"
@@ -2969,6 +2955,36 @@
   dependencies:
     "@react-hook/passive-layout-effect" "^1.2.0"
     "@react-hook/resize-observer" "^1.2.1"
+
+"@redocly/ajv@^8.11.2":
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/@redocly/ajv/-/ajv-8.11.3.tgz#4f148d1cec14ef3fd9d0efecedaa504159c959a6"
+  integrity sha512-4P3iZse91TkBiY+Dx5DUgxQ9GXkVJf++cmI0MOyLDxV9b5MUBI4II6ES8zA5JCbO72nKAJxWrw4PUPW+YP3ZDQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js-replace "^1.0.1"
+
+"@redocly/config@^0.22.0":
+  version "0.22.2"
+  resolved "https://registry.yarnpkg.com/@redocly/config/-/config-0.22.2.tgz#9a05e694816d53a5236cf8768d3cad0e49d8b116"
+  integrity sha512-roRDai8/zr2S9YfmzUfNhKjOF0NdcOIqF7bhf4MVC5UxpjIysDjyudvlAiVbpPHp3eDRWbdzUgtkK1a7YiDNyQ==
+
+"@redocly/openapi-core@^1.34.3":
+  version "1.34.5"
+  resolved "https://registry.yarnpkg.com/@redocly/openapi-core/-/openapi-core-1.34.5.tgz#9c2cf901d1098ceb626e789e2065c762fe63727f"
+  integrity sha512-0EbE8LRbkogtcCXU7liAyC00n9uNG9hJ+eMyHFdUsy9lB/WGqnEBgwjA9q2cyzAVcdTkQqTBBU1XePNnN3OijA==
+  dependencies:
+    "@redocly/ajv" "^8.11.2"
+    "@redocly/config" "^0.22.0"
+    colorette "^1.2.0"
+    https-proxy-agent "^7.0.5"
+    js-levenshtein "^1.1.6"
+    js-yaml "^4.1.0"
+    minimatch "^5.0.1"
+    pluralize "^8.0.0"
+    yaml-ast-parser "0.0.43"
 
 "@reduxjs/toolkit@^2.8.2":
   version "2.8.2"
@@ -4105,7 +4121,7 @@ ansi-align@^3.0.0:
   dependencies:
     string-width "^4.1.0"
 
-ansi-colors@^4.1.1:
+ansi-colors@^4.1.1, ansi-colors@^4.1.3:
   version "4.1.3"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-4.1.3.tgz#37611340eb2243e70cc604cad35d63270d48781b"
   integrity sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==
@@ -5168,7 +5184,7 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0, camelcase@^6.3.0:
+camelcase@^6.2.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -5228,6 +5244,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.2:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+change-case@^5.4.4:
+  version "5.4.4"
+  resolved "https://registry.yarnpkg.com/change-case/-/change-case-5.4.4.tgz#0d52b507d8fb8f204343432381d1a6d7bff97a02"
+  integrity sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==
 
 char-regex@^1.0.2:
   version "1.0.2"
@@ -5481,6 +5502,11 @@ colord@^2.9.1, colord@^2.9.3:
   resolved "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz"
   integrity sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==
 
+colorette@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.4.0.tgz#5190fbb87276259a86ad700bff2c6d6faa3fca40"
+  integrity sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==
+
 colorette@^2.0.10, colorette@^2.0.16:
   version "2.0.20"
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz"
@@ -5507,11 +5533,6 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
-
-commander@^12.0.0:
-  version "12.1.0"
-  resolved "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
 
 commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
@@ -7814,15 +7835,6 @@ fs-extra@^10.0.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
-fs-extra@^11.2.0:
-  version "11.3.0"
-  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz"
-  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
 fs-extra@^8.0.1, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz"
@@ -8216,7 +8228,7 @@ handle-thing@^2.0.0:
   resolved "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars@^4.3.3, handlebars@^4.7.8:
+handlebars@^4.3.3:
   version "4.7.8"
   resolved "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz"
   integrity sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==
@@ -8592,7 +8604,7 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@^7.0.6:
+https-proxy-agent@^7.0.5, https-proxy-agent@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
   integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
@@ -8741,6 +8753,11 @@ indent-string@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+
+index-to-position@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/index-to-position/-/index-to-position-1.1.0.tgz#2e50bd54c8040bdd6d9b3d95ec2a8fedf86b4d44"
+  integrity sha512-XPdx9Dq4t9Qk1mTMbWONJqU7boCoumEH7fRET37HX5+khDUl3J2W6PdALxhILYlIYx2amlwYcRPp28p0tSiojg==
 
 inflight@^1.0.4:
   version "1.0.6"
@@ -9843,6 +9860,11 @@ joi@^17.13.3:
     "@sideway/address" "^4.1.5"
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
+
+js-levenshtein@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/js-levenshtein/-/js-levenshtein-1.1.6.tgz#c6cee58eb3550372df8deb85fad5ce66ce01d59d"
+  integrity sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
@@ -11199,16 +11221,17 @@ open@^8.0.9, open@^8.4.0:
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
 
-openapi-typescript-codegen@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.npmjs.org/openapi-typescript-codegen/-/openapi-typescript-codegen-0.29.0.tgz"
-  integrity sha512-/wC42PkD0LGjDTEULa/XiWQbv4E9NwLjwLjsaJ/62yOsoYhwvmBR31kPttn1DzQ2OlGe5stACcF/EIkZk43M6w==
+openapi-typescript@^7.8.0:
+  version "7.8.0"
+  resolved "https://registry.yarnpkg.com/openapi-typescript/-/openapi-typescript-7.8.0.tgz#978e49fad4d6c1144bb1496550ea5f5fa8de4c08"
+  integrity sha512-1EeVWmDzi16A+siQlo/SwSGIT7HwaFAVjvMA7/jG5HMLSnrUOzPL7uSTRZZa4v/LCRxHTApHKtNY6glApEoiUQ==
   dependencies:
-    "@apidevtools/json-schema-ref-parser" "^11.5.4"
-    camelcase "^6.3.0"
-    commander "^12.0.0"
-    fs-extra "^11.2.0"
-    handlebars "^4.7.8"
+    "@redocly/openapi-core" "^1.34.3"
+    ansi-colors "^4.1.3"
+    change-case "^5.4.4"
+    parse-json "^8.3.0"
+    supports-color "^10.0.0"
+    yargs-parser "^21.1.1"
 
 optionator@^0.9.3:
   version "0.9.4"
@@ -11395,6 +11418,15 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-json@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-8.3.0.tgz#88a195a2157025139a2317a4f2f9252b61304ed5"
+  integrity sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    index-to-position "^1.1.0"
+    type-fest "^4.39.1"
 
 parse5@6.0.1, parse5@^6.0.0:
   version "6.0.1"
@@ -11589,6 +11621,11 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 posix-character-classes@^0.1.0:
   version "0.1.1"
@@ -13786,6 +13823,11 @@ subarg@^1.0.0:
   dependencies:
     minimist "^1.1.0"
 
+supports-color@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-10.1.0.tgz#78416c8bf60b8d34e0ac73046d991374cce1425f"
+  integrity sha512-GBuewsPrhJPftT+fqDa9oI/zc5HNsG9nREqwzoSFDOIqf0NggOZbHQj2TE1P1CDJK8ZogFnlZY9hWoUiur7I/A==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz"
@@ -14316,6 +14358,11 @@ type-fest@^0.8.1:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
+type-fest@^4.39.1:
+  version "4.41.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.41.0.tgz#6ae1c8e5731273c2bf1f58ad39cbae2c91a46c58"
+  integrity sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz"
@@ -14565,6 +14612,11 @@ update-notifier@^3.0.0:
     latest-version "^5.0.0"
     semver-diff "^2.0.0"
     xdg-basedir "^3.0.0"
+
+uri-js-replace@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/uri-js-replace/-/uri-js-replace-1.0.1.tgz#c285bb352b701c9dfdaeffc4da5be77f936c9048"
+  integrity sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -15437,6 +15489,11 @@ yallist@^4.0.0:
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
+yaml-ast-parser@0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser/-/yaml-ast-parser-0.0.43.tgz#e8a23e6fb4c38076ab92995c5dca33f3d3d7c9bb"
+  integrity sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==
+
 yaml@^1.10.0, yaml@^1.10.2, yaml@^1.7.2:
   version "1.10.2"
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
@@ -15454,6 +15511,11 @@ yargs-parser@^20.2.2, yargs-parser@^20.2.3:
   version "20.2.9"
   resolved "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==
+
+yargs-parser@^21.1.1:
+  version "21.1.1"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
+  integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
 yargs@^13.1.0:
   version "13.3.2"


### PR DESCRIPTION
I have a solution for these types of problems now. It was quite involved though:
- I am now using a different tool to generate the TS types from the openAPI specs, which produces string literals instead of enums
- I have a small helper that allows you to create an array constant that is only allowed to have entries that are present in one of those types
- And then you can create a new string literal type from that array-const