### PR TITLE
chore: generate .ts files instead of .d.ts

### DIFF
--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -18,7 +18,7 @@ curl -H "Accept: application/x-yaml" -H "$AUTH_HEADER" "$API_URL" -o "$TEMP_DIR/
 
 # Generate types with openapi-typescript
 echo "⌛ Generating TypeScript types..."
-npx openapi-typescript "$TEMP_DIR/openapi.yaml" --output "$TYPES_DIR/generated.d.ts"
+npx openapi-typescript "$TEMP_DIR/openapi.yaml" --output "$TYPES_DIR/generated.ts"
 
 # Generate named type aliases
 echo "🔗 Generating named type aliases..."
@@ -40,11 +40,11 @@ in_schemas && /^[ ]{8}[A-Za-z0-9_]+(\??):/ {
 }
 in_schemas && /^[ ]{6}\}/ { in_schemas=0 }
 in_components && /^}/ { in_components=0 }
-' "$TYPES_DIR/generated.d.ts" > "$TYPES_DIR/index.d.ts"
+' "$TYPES_DIR/generated.ts" > "$TYPES_DIR/index.ts"
 
 # # Generate named type aliases using Node.js script
 # echo "🔗 Generating named type aliases..."
-# node ./scripts/generate-type-aliases.cjs "$TYPES_DIR/generated.d.ts" "$TYPES_DIR/index.d.ts"
+# node ./scripts/generate-type-aliases.cjs "$TYPES_DIR/generated.ts" "$TYPES_DIR/index.ts"
 
 # Format the output
 echo "💅 Formatting output..."

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,9 +7,11 @@ import { ResponseErrorReport } from '../api/parse-engine-error'
  * `src/types/dhis2-openapi-schemas` anywhere else in the codebase.
  * The reason for this is so that we can apply manual overrides
  * for generated types here, as we have done for `SystemSettings` */
+/* eslint-disable import/export */
 export type * from './dhis2-openapi-schemas'
 export type { SystemSettings } from './system-settings'
 export type { MetadataItem } from './metadata-item'
+/* eslint-enable import/export */
 export type { PickWithFieldFilters } from './pick-with-field-filters'
 
 /* The SingleQuery type is a simpler, but for our use-case functionally


### PR DESCRIPTION
We to import the generated types and not make them automagically available. This makes the code more explicit in general, but it also ensures that type customisation works reliably, for example the type overrides in `src/types/index`
