### PR TITLE
feat: implement Interpretations and detail toggler in toolbar

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-08-22T12:51:32.435Z\n"
-"PO-Revision-Date: 2025-08-22T12:51:32.436Z\n"
+"POT-Creation-Date: 2025-08-25T08:24:47.876Z\n"
+"PO-Revision-Date: 2025-08-25T08:24:47.877Z\n"
 
 msgid "ERROR"
 msgstr "ERROR"
@@ -128,58 +128,6 @@ msgstr "This year"
 msgid "Last year"
 msgstr "Last year"
 
-msgid "HTML"
-msgstr "HTML"
-
-msgid "HTML+CSS (.html+css)"
-msgstr "HTML+CSS (.html+css)"
-
-msgid "Plain data source"
-msgstr "Plain data source"
-
-msgid "JSON"
-msgstr "JSON"
-
-msgid "XML"
-msgstr "XML"
-
-msgid "Microsoft Excel"
-msgstr "Microsoft Excel"
-
-msgid "CSV"
-msgstr "CSV"
-
-msgid "Metadata ID scheme"
-msgstr "Metadata ID scheme"
-
-msgid "ID"
-msgstr "ID"
-
-msgid "Code"
-msgstr "Code"
-
-msgid "Name"
-msgstr "Name"
-
-msgid "Download"
-msgstr "Download"
-
-msgid "\"{{- deletedObject}}\" successfully deleted."
-msgstr "\"{{- deletedObject}}\" successfully deleted."
-
-msgid "Rename successful"
-msgstr "Rename successful"
-
-msgid ""
-"This visualization can't be deleted because it is used on one or more "
-"dashboards"
-msgstr ""
-"This visualization can't be deleted because it is used on one or more "
-"dashboards"
-
-msgid "Options"
-msgstr "Options"
-
 msgid "Show layout"
 msgstr "Show layout"
 
@@ -203,92 +151,6 @@ msgstr "View"
 
 msgid "Reset sidebar width"
 msgstr "Reset sidebar width"
-
-msgid "There is a problem with this visualization."
-msgstr "There is a problem with this visualization."
-
-msgid "There was a problem getting the data from the server."
-msgstr "There was a problem getting the data from the server."
-
-msgid "No data available"
-msgstr "No data available"
-
-msgid ""
-"The selected dimensions didn’t return any data. There may be no data, or "
-"you may not have access to it."
-msgstr ""
-"The selected dimensions didn’t return any data. There may be no data, or "
-"you may not have access to it."
-
-msgid "Visualization not found"
-msgstr "Visualization not found"
-
-msgid ""
-"The visualization you are trying to view could not be found, the ID could "
-"be incorrect or it could have been deleted."
-msgstr ""
-"The visualization you are trying to view could not be found, the ID could "
-"be incorrect or it could have been deleted."
-
-msgid "No tracked entity type selected"
-msgstr "No tracked entity type selected"
-
-msgid "Choose a type from the Input sidebar."
-msgstr "Choose a type from the Input sidebar."
-
-msgid "No program selected"
-msgstr "No program selected"
-
-msgid "Choose a program from the Input sidebar."
-msgstr "Choose a program from the Input sidebar."
-
-msgid "Columns is empty"
-msgstr "Columns is empty"
-
-msgid "Add at least one item to Columns."
-msgstr "Add at least one item to Columns."
-
-msgid "No organisation unit selected"
-msgstr "No organisation unit selected"
-
-msgid ""
-"Make sure to add the organisation unit dimension with at least one "
-"selection to the layout."
-msgstr ""
-"Make sure to add the organisation unit dimension with at least one "
-"selection to the layout."
-
-msgid "There's a problem with at least one selected indicator"
-msgstr "There's a problem with at least one selected indicator"
-
-msgid "Restricted access"
-msgstr "Restricted access"
-
-msgid ""
-"You don’t have access to the data in this visualization. Contact a system "
-"administrator."
-msgstr ""
-"You don’t have access to the data in this visualization. Contact a system "
-"administrator."
-
-msgid "You don’t have access to one or more of the chosen organisation units."
-msgstr "You don’t have access to one or more of the chosen organisation units."
-
-msgid "You don’t have access to event analytics. Contact a system administrator."
-msgstr "You don’t have access to event analytics. Contact a system administrator."
-
-msgid "Something went wrong"
-msgstr "Something went wrong"
-
-msgid ""
-"There's a problem with the generated analytics. Contact a system "
-"administrator."
-msgstr ""
-"There's a problem with the generated analytics. Contact a system "
-"administrator."
-
-msgid "There's a syntax problem with the analytics request."
-msgstr "There's a syntax problem with the analytics request."
 
 msgid ""
 "Track or compare changes over time. Recommend period as category. (adjust "

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-08-14T10:43:51.838Z\n"
-"PO-Revision-Date: 2025-08-14T10:43:51.840Z\n"
+"POT-Creation-Date: 2025-08-22T12:51:32.435Z\n"
+"PO-Revision-Date: 2025-08-22T12:51:32.436Z\n"
 
 msgid "ERROR"
 msgstr "ERROR"
@@ -127,6 +127,168 @@ msgstr "This year"
 
 msgid "Last year"
 msgstr "Last year"
+
+msgid "HTML"
+msgstr "HTML"
+
+msgid "HTML+CSS (.html+css)"
+msgstr "HTML+CSS (.html+css)"
+
+msgid "Plain data source"
+msgstr "Plain data source"
+
+msgid "JSON"
+msgstr "JSON"
+
+msgid "XML"
+msgstr "XML"
+
+msgid "Microsoft Excel"
+msgstr "Microsoft Excel"
+
+msgid "CSV"
+msgstr "CSV"
+
+msgid "Metadata ID scheme"
+msgstr "Metadata ID scheme"
+
+msgid "ID"
+msgstr "ID"
+
+msgid "Code"
+msgstr "Code"
+
+msgid "Name"
+msgstr "Name"
+
+msgid "Download"
+msgstr "Download"
+
+msgid "\"{{- deletedObject}}\" successfully deleted."
+msgstr "\"{{- deletedObject}}\" successfully deleted."
+
+msgid "Rename successful"
+msgstr "Rename successful"
+
+msgid ""
+"This visualization can't be deleted because it is used on one or more "
+"dashboards"
+msgstr ""
+"This visualization can't be deleted because it is used on one or more "
+"dashboards"
+
+msgid "Options"
+msgstr "Options"
+
+msgid "Show layout"
+msgstr "Show layout"
+
+msgid "Hide layout"
+msgstr "Hide layout"
+
+msgid "Show dimensions sidebar"
+msgstr "Show dimensions sidebar"
+
+msgid "Hide dimensions sidebar"
+msgstr "Hide dimensions sidebar"
+
+msgid "Hide interpretations and details"
+msgstr "Hide interpretations and details"
+
+msgid "Show interpretations and details"
+msgstr "Show interpretations and details"
+
+msgid "View"
+msgstr "View"
+
+msgid "Reset sidebar width"
+msgstr "Reset sidebar width"
+
+msgid "There is a problem with this visualization."
+msgstr "There is a problem with this visualization."
+
+msgid "There was a problem getting the data from the server."
+msgstr "There was a problem getting the data from the server."
+
+msgid "No data available"
+msgstr "No data available"
+
+msgid ""
+"The selected dimensions didn’t return any data. There may be no data, or "
+"you may not have access to it."
+msgstr ""
+"The selected dimensions didn’t return any data. There may be no data, or "
+"you may not have access to it."
+
+msgid "Visualization not found"
+msgstr "Visualization not found"
+
+msgid ""
+"The visualization you are trying to view could not be found, the ID could "
+"be incorrect or it could have been deleted."
+msgstr ""
+"The visualization you are trying to view could not be found, the ID could "
+"be incorrect or it could have been deleted."
+
+msgid "No tracked entity type selected"
+msgstr "No tracked entity type selected"
+
+msgid "Choose a type from the Input sidebar."
+msgstr "Choose a type from the Input sidebar."
+
+msgid "No program selected"
+msgstr "No program selected"
+
+msgid "Choose a program from the Input sidebar."
+msgstr "Choose a program from the Input sidebar."
+
+msgid "Columns is empty"
+msgstr "Columns is empty"
+
+msgid "Add at least one item to Columns."
+msgstr "Add at least one item to Columns."
+
+msgid "No organisation unit selected"
+msgstr "No organisation unit selected"
+
+msgid ""
+"Make sure to add the organisation unit dimension with at least one "
+"selection to the layout."
+msgstr ""
+"Make sure to add the organisation unit dimension with at least one "
+"selection to the layout."
+
+msgid "There's a problem with at least one selected indicator"
+msgstr "There's a problem with at least one selected indicator"
+
+msgid "Restricted access"
+msgstr "Restricted access"
+
+msgid ""
+"You don’t have access to the data in this visualization. Contact a system "
+"administrator."
+msgstr ""
+"You don’t have access to the data in this visualization. Contact a system "
+"administrator."
+
+msgid "You don’t have access to one or more of the chosen organisation units."
+msgstr "You don’t have access to one or more of the chosen organisation units."
+
+msgid "You don’t have access to event analytics. Contact a system administrator."
+msgstr "You don’t have access to event analytics. Contact a system administrator."
+
+msgid "Something went wrong"
+msgstr "Something went wrong"
+
+msgid ""
+"There's a problem with the generated analytics. Contact a system "
+"administrator."
+msgstr ""
+"There's a problem with the generated analytics. Contact a system "
+"administrator."
+
+msgid "There's a syntax problem with the analytics request."
+msgstr "There's a syntax problem with the analytics request."
 
 msgid ""
 "Track or compare changes over time. Recommend period as category. (adjust "

--- a/src/components/toolbar/interpretations-and-details-toggler.tsx
+++ b/src/components/toolbar/interpretations-and-details-toggler.tsx
@@ -2,14 +2,11 @@ import type { FC } from 'react'
 import { useCallback } from 'react'
 import { InterpretationsAndDetailsToggler as AnalyticsInterpretationsAndDetailsToggler } from '@dhis2/analytics'
 import { useAppSelector, useAppDispatch } from '@hooks'
-import { currentSlice } from '@store/current-slice'
-import { uiSlice, setUiDetailsPanelOpen } from '@store/ui-slice'
+import { getCurrentId } from '@store/current-slice'
+import { getUiDetailsPanelOpen, setUiDetailsPanelOpen } from '@store/ui-slice'
 
 export const InterpretationsAndDetailsToggler: FC = () => {
     const dispatch = useAppDispatch()
-
-    const { getCurrentId } = currentSlice.selectors
-    const { getUiDetailsPanelOpen } = uiSlice.selectors
 
     const id = useAppSelector(getCurrentId)
     const isDetailsPanelOpen = useAppSelector(getUiDetailsPanelOpen)

--- a/src/components/toolbar/interpretations-and-details-toggler.tsx
+++ b/src/components/toolbar/interpretations-and-details-toggler.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react'
+import { useCallback } from 'react'
+import { InterpretationsAndDetailsToggler as AnalyticsInterpretationsAndDetailsToggler } from '@dhis2/analytics'
+import { useAppSelector, useAppDispatch } from '@hooks'
+import { currentSlice } from '@store/current-slice'
+import { uiSlice, setUiDetailsPanelOpen } from '@store/ui-slice'
+
+export const InterpretationsAndDetailsToggler: FC = () => {
+    const dispatch = useAppDispatch()
+
+    const { getCurrentId } = currentSlice.selectors
+    const { getUiDetailsPanelOpen } = uiSlice.selectors
+
+    const id = useAppSelector((state) => getCurrentId(state))
+
+    const isDetailsPanelOpen = useAppSelector((state) =>
+        getUiDetailsPanelOpen(state)
+    )
+
+    const onClick = useCallback(() => {
+        dispatch(setUiDetailsPanelOpen(!isDetailsPanelOpen))
+    }, [dispatch, isDetailsPanelOpen])
+
+    return (
+        <AnalyticsInterpretationsAndDetailsToggler
+            disabled={!id}
+            onClick={onClick}
+            isShowing={isDetailsPanelOpen}
+        />
+    )
+}

--- a/src/components/toolbar/interpretations-and-details-toggler.tsx
+++ b/src/components/toolbar/interpretations-and-details-toggler.tsx
@@ -11,11 +11,8 @@ export const InterpretationsAndDetailsToggler: FC = () => {
     const { getCurrentId } = currentSlice.selectors
     const { getUiDetailsPanelOpen } = uiSlice.selectors
 
-    const id = useAppSelector((state) => getCurrentId(state))
-
-    const isDetailsPanelOpen = useAppSelector((state) =>
-        getUiDetailsPanelOpen(state)
-    )
+    const id = useAppSelector(getCurrentId)
+    const isDetailsPanelOpen = useAppSelector(getUiDetailsPanelOpen)
 
     const onClick = useCallback(() => {
         dispatch(setUiDetailsPanelOpen(!isDetailsPanelOpen))

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,9 +1,11 @@
 import type { FC } from 'react'
+import { InterpretationsAndDetailsToggler } from './interpretations-and-details-toggler'
 import { VisualizationTypeSelector } from './visualization-type-selector/visualization-type-selector'
 import { Toolbar as AnalyticsToolbar } from '@dhis2/analytics'
 
 export const Toolbar: FC = () => (
     <AnalyticsToolbar>
         <VisualizationTypeSelector />
+        <InterpretationsAndDetailsToggler />
     </AnalyticsToolbar>
 )

--- a/src/components/toolbar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
+++ b/src/components/toolbar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
@@ -2,7 +2,7 @@ import { screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { vi, describe, it, beforeEach, expect } from 'vitest'
 import { VisualizationTypeSelector } from '../visualization-type-selector'
-import { uiSlice, initialState, setUiState } from '@store/ui-slice'
+import { uiSlice, initialState, setUiVisualizationType } from '@store/ui-slice'
 import { renderWithReduxStoreProvider } from '@test-utils/render-with-redux-store-provider'
 import { setupStore } from '@test-utils/setup-store'
 import type { RootState } from '@types'
@@ -20,7 +20,7 @@ describe('VisualizationTypeSelector', () => {
         if (!store) {
             store = setupStore({ ui: uiSlice.reducer }, { ui: initialState })
         } else {
-            store.dispatch(setUiState(initialState))
+            store.dispatch(setUiVisualizationType('LINE_LIST'))
         }
     })
 

--- a/src/components/toolbar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
+++ b/src/components/toolbar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
@@ -8,7 +8,7 @@ import { setupStore } from '@test-utils/setup-store'
 import type { RootState } from '@types'
 
 vi.mock('@dhis2/app-runtime', () => ({
-    useConfig: jest.fn(() => ({ serverVersion: { minor: 43 } })),
+    useConfig: vi.fn(() => ({ serverVersion: { minor: 43 } })),
 }))
 
 describe('VisualizationTypeSelector', () => {
@@ -44,6 +44,4 @@ describe('VisualizationTypeSelector', () => {
         expect(within(modal).getByText('Line list')).toBeInTheDocument()
         expect(within(modal).getByText('Pivot table')).toBeInTheDocument()
     })
-
-    it('')
 })

--- a/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
@@ -18,9 +18,7 @@ export const VisualizationTypeSelector: FC = () => {
 
     const { getUiVisualizationType } = uiSlice.selectors
 
-    const visualizationType = useAppSelector((state) =>
-        getUiVisualizationType(state)
-    )
+    const visualizationType = useAppSelector(getUiVisualizationType)
 
     const [listIsOpen, setListIsOpen] = useState(false)
 

--- a/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
@@ -1,7 +1,7 @@
 import { Popper, Layer } from '@dhis2/ui'
 import cx from 'classnames'
-import { useState, useRef } from 'react'
 import type { FC } from 'react'
+import { useState, useRef } from 'react'
 import { ListItemIcon } from './list-item-icon'
 import classes from './styles/visualization-type-selector.module.css'
 import { VisualizationTypeListItem } from './visualization-type-list-item'
@@ -11,13 +11,15 @@ import { SUPPORTED_VIS_TYPES } from '@constants/visualization-types'
 import { visTypeDisplayNames, ToolbarSidebar } from '@dhis2/analytics'
 import { useAppDispatch, useAppSelector } from '@hooks'
 import { getVisTypeDescriptions } from '@modules/visualization'
-import { setUiState } from '@store/ui-slice'
+import { setUiVisualizationType, uiSlice } from '@store/ui-slice'
 
 export const VisualizationTypeSelector: FC = () => {
     const dispatch = useAppDispatch()
 
-    const visualizationType = useAppSelector(
-        (state) => state.ui.visualizationType
+    const { getUiVisualizationType } = uiSlice.selectors
+
+    const visualizationType = useAppSelector((state) =>
+        getUiVisualizationType(state)
     )
 
     const [listIsOpen, setListIsOpen] = useState(false)
@@ -29,7 +31,7 @@ export const VisualizationTypeSelector: FC = () => {
     }
 
     const handleListItemClick = (visualizationType: SupportedVisType) => () => {
-        dispatch(setUiState({ visualizationType }))
+        dispatch(setUiVisualizationType(visualizationType))
         onItemClick()
         toggleList()
     }

--- a/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/toolbar/visualization-type-selector/visualization-type-selector.tsx
@@ -11,12 +11,10 @@ import { SUPPORTED_VIS_TYPES } from '@constants/visualization-types'
 import { visTypeDisplayNames, ToolbarSidebar } from '@dhis2/analytics'
 import { useAppDispatch, useAppSelector } from '@hooks'
 import { getVisTypeDescriptions } from '@modules/visualization'
-import { setUiVisualizationType, uiSlice } from '@store/ui-slice'
+import { setUiVisualizationType, getUiVisualizationType } from '@store/ui-slice'
 
 export const VisualizationTypeSelector: FC = () => {
     const dispatch = useAppDispatch()
-
-    const { getUiVisualizationType } = uiSlice.selectors
 
     const visualizationType = useAppSelector(getUiVisualizationType)
 

--- a/src/store/current-slice.ts
+++ b/src/store/current-slice.ts
@@ -1,0 +1,25 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+import { EventVisualization } from '@types'
+
+type CurrentState = Partial<EventVisualization> | null
+
+const initialState: CurrentState = null
+
+export const currentSlice = createSlice({
+    name: 'current',
+    initialState,
+    reducers: {
+        setCurrent: (
+            state: CurrentState,
+            action: PayloadAction<CurrentState>
+        ) => {
+            state = action.payload
+        },
+    },
+    selectors: {
+        getCurrent: (state: CurrentState) => state ?? null,
+        getCurrentId: (state: CurrentState) => state?.id ?? null,
+    },
+})
+
+export const { setCurrent } = currentSlice.actions

--- a/src/store/current-slice.ts
+++ b/src/store/current-slice.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { EventVisualization } from '@types'
 
-type CurrentState = Partial<EventVisualization> | null
+type CurrentState = EventVisualization | null
 
 const initialState: CurrentState = null
 
@@ -23,3 +23,4 @@ export const currentSlice = createSlice({
 })
 
 export const { setCurrent } = currentSlice.actions
+export const { getCurrent, getCurrentId } = currentSlice.selectors

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { currentSlice } from './current-slice'
 import { navigationSlice } from './navigation-slice'
 import { uiSlice } from './ui-slice'
 import { api } from '@api/api'
@@ -12,6 +13,7 @@ export const createStore = (
     return configureStore({
         reducer: {
             [api.reducerPath]: api.reducer,
+            current: currentSlice.reducer,
             navigation: navigationSlice.reducer,
             ui: uiSlice.reducer,
         },

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -39,3 +39,5 @@ export const uiSlice = createSlice({
 })
 
 export const { setUiVisualizationType, setUiDetailsPanelOpen } = uiSlice.actions
+export const { getUiVisualizationType, getUiDetailsPanelOpen } =
+    uiSlice.selectors

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -3,25 +3,39 @@ import type { SupportedVisType } from '@constants/visualization-types'
 
 export interface UiState {
     visualizationType: SupportedVisType
+    showAccessoryPanel: boolean
+    showDetailsPanel: boolean
 }
 
 export const initialState: UiState = {
     visualizationType: 'LINE_LIST',
+    showAccessoryPanel: true,
+    showDetailsPanel: false,
 }
 
 export const uiSlice = createSlice({
     name: 'ui',
     initialState,
     reducers: {
-        setUiState: (
+        setUiVisualizationType: (
             state,
-            action: PayloadAction<{
-                visualizationType: SupportedVisType | 'LINE_LIST'
-            }>
+            action: PayloadAction<SupportedVisType>
         ) => {
-            state.visualizationType = action.payload.visualizationType
+            state.visualizationType = action.payload
         },
+        setUiDetailsPanelOpen: (state, action: PayloadAction<boolean>) => {
+            state.showDetailsPanel = action.payload
+            // Always close left sidebar when opening the right sidebar
+            // Leave left sidebar unaffected when closing the right sidebar
+            state.showAccessoryPanel = action.payload
+                ? false
+                : state.showAccessoryPanel
+        },
+    },
+    selectors: {
+        getUiVisualizationType: (state) => state.visualizationType,
+        getUiDetailsPanelOpen: (state) => state.showDetailsPanel,
     },
 })
 
-export const { setUiState } = uiSlice.actions
+export const { setUiVisualizationType, setUiDetailsPanelOpen } = uiSlice.actions

--- a/src/types/analytics/index.d.ts
+++ b/src/types/analytics/index.d.ts
@@ -2,6 +2,7 @@ import type {
     CachedDataQueryProvider,
     useCachedDataQuery,
 } from './cached-data-query-provider'
+import type { InterpretationsAndDetailsToggler } from './interpretations-and-details-toggler'
 import type { Toolbar } from './toolbar'
 import type { ToolbarSidebar } from './toolbar-sidebar'
 import type { EventVisualizationType, VisualizationType } from '@types'
@@ -9,6 +10,7 @@ import type { EventVisualizationType, VisualizationType } from '@types'
 declare module '@dhis2/analytics' {
     export const CachedDataQueryProvider: CachedDataQueryProvider
     export const useCachedDataQuery: useCachedDataQuery
+    export const InterpretationsAndDetailsToggler: InterpretationsAndDetailsToggler
     export const Toolbar: Toolbar
     export const ToolbarSidebar: ToolbarSidebar
     export const visTypeDisplayNames: Array<

--- a/src/types/analytics/interpretations-and-details-toggler.ts
+++ b/src/types/analytics/interpretations-and-details-toggler.ts
@@ -1,0 +1,11 @@
+import { FC } from 'react'
+
+type InterpretationsAndDetailsTogglerProps = {
+    onClick: () => void
+    dataTest?: string
+    disabled?: boolean
+    isShowing?: boolean
+}
+
+export type InterpretationsAndDetailsToggler =
+    FC<InterpretationsAndDetailsTogglerProps>

--- a/src/types/event-visualization.ts
+++ b/src/types/event-visualization.ts
@@ -1,0 +1,145 @@
+import type {
+    EventVisualization as EventVisualizationGenerated,
+    DimensionType,
+    EventRepetition,
+    Program,
+    ProgramStage,
+    ValueType,
+    LegendDisplayStrategy,
+    LegendDisplayStyle,
+} from './dhis2-openapi-schemas'
+
+type IdRecord = { id: string }
+type IdNameRecord = IdRecord & { name: string }
+
+type MetadataRecordArray<T extends string> = Array<Record<T, IdNameRecord>>
+
+type DimensionArray = Array<{
+    dimension: string
+    dimensionType: DimensionType
+    filter: string
+    program: IdRecord
+    programStage: IdRecord
+    optionSet: IdRecord
+    valueType: ValueType
+    legendSet: IdRecord
+    repetition: EventRepetition
+    items: Array<IdRecord>
+}>
+
+type ProgramStageRecord = Pick<
+    ProgramStage,
+    | 'id'
+    | 'displayExecutionDateLabel'
+    | 'displayDueDateLabel'
+    | 'hideDueDate'
+    | 'repeatable'
+> & {
+    name: string
+}
+
+type ProgramRecord = Pick<
+    Program,
+    | 'id'
+    | 'programType'
+    | 'displayEnrollmentDateLabel'
+    | 'displayIncidentDateLabel'
+    | 'displayIncidentDate'
+> & {
+    name: string
+    programStages: Array<
+        Pick<ProgramStage, 'id' | 'repeatable'> & {
+            name: string
+        }
+    >
+}
+
+type ProgramDimensionArray = Array<
+    Pick<
+        Program,
+        | 'id'
+        | 'enrollmentDateLabel'
+        | 'incidentDateLabel'
+        | 'programType'
+        | 'displayIncidentDate'
+        | 'displayEnrollmentDateLabel'
+        | 'displayIncidentDateLabel'
+    > & {
+        name: string
+        programStages: Array<ProgramStageRecord>
+    }
+>
+
+type DataElementDimensionArray = Array<{
+    legendSet: IdNameRecord
+    dataElement: IdNameRecord
+}>
+
+type SavedVisualization = Omit<
+    EventVisualizationGenerated,
+    | 'columns'
+    | 'rows'
+    | 'filters'
+    | 'program'
+    | 'programStage'
+    | 'programDimensions'
+    | 'dataElementDimensions'
+    | 'legend'
+    | 'trackedEntityType'
+    | 'attributeDimensions'
+    | 'programIndicatorDimensions'
+    | 'categoryDimensions'
+    | 'categoryOptionGroupSetDimensions'
+    | 'organisationUnitGroupSetDimensions'
+    | 'dataElementGroupSetDimensions'
+    | 'dataElementDimensions'
+    | 'interpretations'
+    | 'userGroupAccesses'
+    | 'publicAccess'
+    | 'displayDescription'
+    | 'rewindRelativePeriods'
+    | 'userOrganisationUnit'
+    | 'userOrganisationUnitChildren'
+    | 'userOrganisationUnitGrandChildren'
+    | 'externalAccess'
+    | 'relativePeriods'
+    | 'columnDimensions'
+    | 'rowDimensions'
+    | 'filterDimensions'
+    | 'organisationUnitGroups'
+    | 'itemOrganisationUnitGroups'
+    | 'indicators'
+    | 'dataElements'
+    | 'dataElementOperands'
+    | 'dataElementGroups'
+    | 'dataSets'
+    | 'periods'
+    | 'organisationUnitLevels'
+    | 'organisationUnits'
+    | 'user'
+> & {
+    dataElementDimensions: DataElementDimensionArray
+    attributeDimensions: MetadataRecordArray<'attribute'>
+    programIndicatorDimensions: MetadataRecordArray<'programIndicator'>
+    categoryDimensions: MetadataRecordArray<'category'>
+    categoryOptionGroupSetDimensions: MetadataRecordArray<'categoryOptionGroupSet'>
+    organisationUnitGroupSetDimensions: MetadataRecordArray<'organisationUnitGroupSet'>
+    dataElementGroupSetDimensions: MetadataRecordArray<'dataElementGroupSet'>
+    columns: DimensionArray
+    rows: DimensionArray
+    filters: DimensionArray
+    program: ProgramRecord
+    programStage: ProgramStageRecord
+    programDimensions: ProgramDimensionArray
+    legend: {
+        set: { id: string; displayName: string }
+        strategy: LegendDisplayStrategy
+        style: LegendDisplayStyle
+        showKey: boolean
+    }
+    trackedEntityType: IdNameRecord
+}
+
+type CurrentVisualization = Partial<SavedVisualization>
+
+export type EventVisualization = CurrentVisualization | SavedVisualization

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ import type { ResponseErrorReport } from '@api/parse-engine-error'
  * for generated types here, as we have done for `SystemSettings` */
 /* eslint-disable import/export */
 export type * from './dhis2-openapi-schemas'
+export type { EventVisualization } from './event-visualization'
 export type { SystemSettings } from './system-settings'
 export type { MetadataItem } from './metadata-item'
 /* eslint-enable import/export */


### PR DESCRIPTION
Part of [DHIS2-19821](https://dhis2.atlassian.net/browse/DHIS2-19821)

### Description

Adds the Interpretations and details toggler button to the toolbar.
The toggler is connected to the store using the same key in the `ui` slice as in LL app.
The toggler changes both `showDetailsPanel` and `showAccessoryPanel` to keep the same behaviour as in the current LL app.

Note: both the details panel and the accessory panel are not implemented yet.
Cypress tests will be added once those are available.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A
- [x] Tester approved (@HendrikThePendric )

---


### Screenshots

Note: the button will show in the correct place to the far right of the toolbar once the MenuBar component is added.
<img width="1040" height="160" alt="Screenshot 2025-08-22 at 15 59 12" src="https://github.com/user-attachments/assets/20c7f73d-4e23-4d0a-b7f3-ef727676be49" />



[DHIS2-19821]: https://dhis2.atlassian.net/browse/DHIS2-19821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ