### PR TITLE
chore: fail linting when there are stylelint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
             "prettier --check"
         ],
         "*.{css,scss,tsx}": [
-            "stylelint"
+            "stylelint --max-warnings=0"
         ],
         "*.{css,scss,json,md,MD,yml,YML,yaml,YAML}": [
             "prettier --check"

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -19,7 +19,7 @@ echo ""
 
 # Stylelint fix
 echo "🔧 Running Stylelint --fix..."
-if ! npx stylelint "**/*.{css,scss,tsx}" --fix; then
+if ! npx stylelint "**/*.{css,scss,tsx}" --fix  --max-warnings=0; then
     echo "❌ Stylelint formatting failed"
     EXIT_CODE=1
 else

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -25,7 +25,7 @@ echo ""
 
 # Stylelint check
 echo "🔍 Checking Stylelint..."
-if ! npx stylelint "**/*.{css,scss,tsx}"; then
+if ! npx stylelint "**/*.{css,scss,tsx}" --max-warnings=0; then
     echo "❌ Stylelint check failed"
     EXIT_CODE=1
 else


### PR DESCRIPTION
I noticed yesterday that I ended up pushing some bad CSS to my branch, I used `width` (or maybe `height`) instead of a logical property. After a bit of investigation this turned out to be "by design": the D2 Style stylelint config throws warnings for this instead of errors. Since this is a new app, we should just write good CSS from the start, so I added `--max-warnings=0` in all relevant places so the stylelint process exits with an error code when violations at the warning level are encountered. 