### PR TITLE
chore: enable inspection of the metadata store in development mode

### DIFF
--- a/src/components/app-wrapper/metadata-provider.tsx
+++ b/src/components/app-wrapper/metadata-provider.tsx
@@ -22,6 +22,13 @@ import {
 } from './metadata-helpers'
 import { getInitialMetadata } from './metadata-helpers/initial-metadata'
 
+declare global {
+    interface Window {
+        getMetadaStore: () => Record<string, MetadataStoreItem>
+        getMetadaStoreItem: (key: string) => MetadataStoreItem | undefined
+    }
+}
+
 class MetadataStore {
     private map = new Map<string, MetadataStoreItem>()
     private subscribers = new Map<string, Set<Subscriber>>()
@@ -34,6 +41,11 @@ class MetadataStore {
                 this.map.set(key, normalizeMetadataInputItem(item))
                 this.initialMetadataKeys.add(key)
             })
+        }
+        if (process.env.NODE_ENV === 'development') {
+            window.getMetadaStore = () => Object.fromEntries(this.map)
+            window.getMetadaStoreItem = (key: string) =>
+                this.getMetadataItem(key)
         }
     }
 


### PR DESCRIPTION
No issue number available, just a quick chore....
- `getMetadaStore()` returns the entire store as an object
- `getMetadaStoreItem('key')` returns the specified item or undefined