### PR TITLE
chore: some PR suggestions

### DIFF
--- a/src/components/visualization-layout/__tests__/chip.cy.tsx
+++ b/src/components/visualization-layout/__tests__/chip.cy.tsx
@@ -197,7 +197,7 @@ describe('<Chip />', () => {
 
         cy.get('[data-test="layout-dimension-chip"]').should('not.contain', ',')
 
-        cy.getByDataTest('chip-items').should('not.exist')
+        cy.getByDataTest('chip-items').should('not.be.visible')
 
         cy.getByDataTest('chip-menu-button').should('be.visible')
 

--- a/src/components/visualization-layout/chip-base.tsx
+++ b/src/components/visualization-layout/chip-base.tsx
@@ -5,7 +5,7 @@ import classes from './styles/chip-base.module.css'
 import { DimensionTypeIcon } from '@components/dimension-item/dimension-type-icon'
 import type { SupportedAxis } from '@constants/axis-types'
 import type { SupportedInputType } from '@constants/input-types'
-import { getChipItems } from '@modules/get-chip-items'
+import { getChipItemsText } from '@modules/get-chip-items-text'
 
 // Presentational component used by dnd - do not add redux or dnd functionality
 
@@ -23,37 +23,29 @@ export const ChipBase: React.FC<ChipBaseProps> = ({
     itemsLength,
     inputType,
     axisId,
-}) => {
-    const name = dimension.name
-    const dimensionType = dimension.dimensionType
-    const suffix = dimension.suffix
-
-    const chipItems = getChipItems({
-        dimension,
-        conditionsLength,
-        itemsLength,
-        inputType,
-        axisId,
-    })
-
-    return (
-        <div className={cx(classes.chipBase)}>
-            {dimensionType && (
-                <div className={classes.leftIcon}>
-                    <DimensionTypeIcon dimensionType={dimensionType} />
-                </div>
-            )}
-            <span className={classes.label}>
-                <span className={classes.primary}>
-                    {suffix ? `${name},` : `${name}`}
-                </span>
-                {suffix && <span className={classes.secondary}>{suffix}</span>}
+}) => (
+    <div className={cx(classes.chipBase)}>
+        {dimension.dimensionType && (
+            <div className={classes.leftIcon}>
+                <DimensionTypeIcon dimensionType={dimension.dimensionType} />
+            </div>
+        )}
+        <span className={classes.label}>
+            <span className={classes.primary}>
+                {dimension.suffix ? `${dimension.name},` : `${dimension.name}`}
             </span>
-            {chipItems && (
-                <span className={classes.items} data-test="chip-items">
-                    {chipItems}
-                </span>
+            {dimension.suffix && (
+                <span className={classes.secondary}>{dimension.suffix}</span>
             )}
-        </div>
-    )
-}
+        </span>
+        <span className={classes.items} data-test="chip-items">
+            {getChipItemsText({
+                dimension,
+                conditionsLength,
+                itemsLength,
+                inputType,
+                axisId,
+            })}
+        </span>
+    </div>
+)

--- a/src/components/visualization-layout/styles/chip-base.module.css
+++ b/src/components/visualization-layout/styles/chip-base.module.css
@@ -48,6 +48,10 @@
     padding: 2px 2px 1px 2px;
 }
 
+.items:empty {
+    display: none;
+}
+
 .leftIcon {
     margin-inline-end: 4px;
     line-height: 0;

--- a/src/modules/__tests__/get-chip-items.spec.ts
+++ b/src/modules/__tests__/get-chip-items.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { getChipItemsText } from '../get-chip-items-text'
 
-describe('getChipItems', () => {
+describe('getChipItemsText', () => {
     describe('when axisId is "columns"', () => {
         it('returns empty string for organization unit dimension with no items (non-tracked entity)', () => {
             expect(

--- a/src/modules/__tests__/get-chip-items.spec.ts
+++ b/src/modules/__tests__/get-chip-items.spec.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { getChipItems } from '../get-chip-items'
+import { getChipItemsText } from '../get-chip-items-text'
 
 describe('getChipItems', () => {
     describe('when axisId is "columns"', () => {
         it('returns empty string for organization unit dimension with no items (non-tracked entity)', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'ou', dimensionType: 'ORGANISATION_UNIT' },
                     conditionsLength: undefined,
                     itemsLength: undefined,
@@ -17,7 +17,7 @@ describe('getChipItems', () => {
 
         it('returns empty string for period dimension with no items', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'pe', dimensionType: 'PERIOD' },
                     conditionsLength: undefined,
                     itemsLength: undefined,
@@ -29,7 +29,7 @@ describe('getChipItems', () => {
 
         it('returns "all" when no conditions or items', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'dx', dimensionType: 'DATA_ELEMENT' },
                     conditionsLength: undefined,
                     itemsLength: undefined,
@@ -41,7 +41,7 @@ describe('getChipItems', () => {
 
         it('returns "all" for TRUE_ONLY value type with 1 condition', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'de1', valueType: 'TRUE_ONLY' },
                     conditionsLength: 1,
                     itemsLength: undefined,
@@ -53,7 +53,7 @@ describe('getChipItems', () => {
 
         it('returns "all" for BOOLEAN value type with 2 conditions', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'de2', valueType: 'BOOLEAN' },
                     conditionsLength: 2,
                     itemsLength: undefined,
@@ -65,7 +65,7 @@ describe('getChipItems', () => {
 
         it('returns items length for dimension with option set', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'de3', optionSet: 'optionSet1' },
                     conditionsLength: undefined,
                     itemsLength: 3,
@@ -77,7 +77,7 @@ describe('getChipItems', () => {
 
         it('returns items length for dimension with items but no option set', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'de4' },
                     conditionsLength: undefined,
                     itemsLength: 5,
@@ -89,7 +89,7 @@ describe('getChipItems', () => {
 
         it('returns conditions length for dimension with only conditions', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'de5' },
                     conditionsLength: 2,
                     itemsLength: undefined,
@@ -101,7 +101,7 @@ describe('getChipItems', () => {
 
         it('returns items length for organization unit with TRACKED_ENTITY_INSTANCE', () => {
             expect(
-                getChipItems({
+                getChipItemsText({
                     dimension: { id: 'ou', dimensionType: 'ORGANISATION_UNIT' },
                     conditionsLength: undefined,
                     itemsLength: 4,
@@ -114,7 +114,7 @@ describe('getChipItems', () => {
 
     describe('when axisId is "filters"', () => {
         it('returns empty string when no conditions or items', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension' },
                 conditionsLength: undefined,
                 itemsLength: undefined,
@@ -126,7 +126,7 @@ describe('getChipItems', () => {
         })
 
         it('returns condition count for TRUE_ONLY valueType with 1 condition', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension', valueType: 'TRUE_ONLY' },
                 conditionsLength: 1,
                 itemsLength: undefined,
@@ -138,7 +138,7 @@ describe('getChipItems', () => {
         })
 
         it('returns condition count for BOOLEAN valueType with 2 conditions', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension', valueType: 'BOOLEAN' },
                 conditionsLength: 2,
                 itemsLength: undefined,
@@ -150,7 +150,7 @@ describe('getChipItems', () => {
         })
 
         it('returns itemsLength when dimension has optionSet and items', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension', optionSet: 'testOptionSet' },
                 conditionsLength: undefined,
                 itemsLength: 3,
@@ -162,7 +162,7 @@ describe('getChipItems', () => {
         })
 
         it('returns empty string for dimension with option set and no items', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'de3', optionSet: 'optionSet1' },
                 conditionsLength: undefined,
                 itemsLength: 0,
@@ -174,7 +174,7 @@ describe('getChipItems', () => {
         })
 
         it('returns conditionsLength when no optionSet or itemsLength', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension' },
                 conditionsLength: 5,
                 itemsLength: undefined,
@@ -186,7 +186,7 @@ describe('getChipItems', () => {
         })
 
         it('returns empty string for organization units with no itemsLength (same as other axes)', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'ou' },
                 conditionsLength: undefined,
                 itemsLength: undefined,
@@ -198,7 +198,7 @@ describe('getChipItems', () => {
         })
 
         it('returns empty string for period dimensions with no itemsLength (same as other axes)', () => {
-            const result = getChipItems({
+            const result = getChipItemsText({
                 dimension: { id: 'testDimension', dimensionType: 'PERIOD' },
                 conditionsLength: undefined,
                 itemsLength: undefined,

--- a/src/modules/get-chip-items-text.ts
+++ b/src/modules/get-chip-items-text.ts
@@ -10,7 +10,7 @@ type ChipDimension = Pick<
     'id' | 'dimensionType' | 'optionSet' | 'valueType'
 >
 
-interface GetChipItemsParams {
+interface GetChipItemsTextParams {
     dimension: ChipDimension
     conditionsLength: number | undefined
     itemsLength: number | undefined
@@ -18,13 +18,13 @@ interface GetChipItemsParams {
     axisId: SupportedAxis
 }
 
-export const getChipItems = ({
+export const getChipItemsText = ({
     dimension,
     conditionsLength,
     itemsLength,
     inputType,
     axisId,
-}: GetChipItemsParams): string => {
+}: GetChipItemsTextParams): string => {
     const { id, dimensionType, optionSet, valueType } = dimension
 
     if (


### PR DESCRIPTION
You can either close or merge this. What I tried here was:
1. Rename `getChipItems` to `getChipItemsText`
2. Remove the conditional rendering based on `chipItems` and use a CSS rule with `:empty` instead for hiding the element
3. Make the `ChipBase` do an implicit return, which is possible because it now only calls `getChipItemsText` once and everything else is just props

It also meant I had to update a few tests