### PR TITLE
feat: add landing page DHIS2-20123

### DIFF
--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -2,8 +2,8 @@ describe('bootstrapped app', () => {
     beforeEach(() => {
         cy.visit('/')
     })
-    it('shows the expected welcome text', () => {
-        cy.contains('Welcome to DHIS2 with TypeScript!').should('be.visible')
+    it('shows the landing page', () => {
+        cy.contains('Getting started').should('be.visible')
     })
     it('can open the profile menu', () => {
         cy.getByDataTest('headerbar-profile').should('exist').click()

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,11 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2025-09-17T07:41:56.513Z\n"
-"PO-Revision-Date: 2025-09-17T07:41:56.514Z\n"
-
-msgid "Welcome to DHIS2 with TypeScript!"
-msgstr "Welcome to DHIS2 with TypeScript!"
+"POT-Creation-Date: 2025-09-19T12:59:51.497Z\n"
+"PO-Revision-Date: 2025-09-19T12:59:51.498Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -188,6 +185,25 @@ msgstr "Completed"
 
 msgid "Scheduled"
 msgstr "Scheduled"
+
+msgid "Getting started"
+msgstr "Getting started"
+
+msgid ""
+"All dimensions that you can use to build visualizations are shown in the "
+"sections in the left sidebar."
+msgstr ""
+"All dimensions that you can use to build visualizations are shown in the "
+"sections in the left sidebar."
+
+msgid "Add dimensions to the layout above."
+msgstr "Add dimensions to the layout above."
+
+msgid "Click a dimension to add or remove conditions."
+msgstr "Click a dimension to add or remove conditions."
+
+msgid "Your most viewed event visualizations"
+msgstr "Your most viewed event visualizations"
 
 msgid "Download"
 msgstr "Download"

--- a/src/api/data-statistics-api.ts
+++ b/src/api/data-statistics-api.ts
@@ -1,0 +1,84 @@
+import { api } from '@api/api'
+import type { BaseQueryApiWithExtraArg } from '@api/custom-base-query'
+import { parseEngineError } from '@api/parse-engine-error'
+import type {
+    EventVisualizationType,
+    FavoriteStatistics,
+    SavedVisualization,
+} from '@types'
+
+type EventVisualizationRecord = Partial<SavedVisualization> &
+    Required<Pick<SavedVisualization, 'id' | 'type'>>
+type FavoriteRecord = FavoriteStatistics &
+    Required<Pick<FavoriteStatistics, 'id' | 'name'>>
+type MostViewedRecord = FavoriteRecord & {
+    type: EventVisualizationType
+}
+
+export const dataStatisticsApi = api.injectEndpoints({
+    endpoints: (builder) => ({
+        getMostViewed: builder.query<MostViewedRecord[], void>({
+            async queryFn(_args, apiArg: BaseQueryApiWithExtraArg) {
+                const { appCachedData, engine } = apiArg.extra
+
+                const username = appCachedData.currentUser.username
+
+                try {
+                    const mostViewedData: MostViewedRecord[] = []
+
+                    const favoritesResponse = await engine.query({
+                        favorites: {
+                            resource: 'dataStatistics/favorites',
+                            params: {
+                                eventType: 'EVENT_VISUALIZATION_VIEW',
+                                pageSize: 6,
+                                ...(username ? { username } : {}),
+                            },
+                        },
+                    })
+
+                    const favorites =
+                        favoritesResponse.favorites as FavoriteRecord[]
+
+                    if (favorites.length > 0) {
+                        const { eventVisualizations } = await engine.query({
+                            eventVisualizations: {
+                                resource: 'eventVisualizations',
+                                params: {
+                                    fields: 'id,type',
+                                    filter: `id:in:[${favorites.map(
+                                        ({ id }) => id
+                                    )}]`,
+                                },
+                            },
+                        })
+
+                        const visualizations = (
+                            eventVisualizations as {
+                                eventVisualizations: EventVisualizationRecord[]
+                            }
+                        ).eventVisualizations as EventVisualizationRecord[]
+
+                        for (const favorite of favorites) {
+                            const type = visualizations.find(
+                                (vis) => vis.id === favorite.id
+                            )?.type
+
+                            if (type) {
+                                mostViewedData.push({
+                                    id: favorite.id,
+                                    name: favorite.name,
+                                    type,
+                                })
+                            }
+                        }
+                    }
+
+                    return { data: mostViewedData }
+                } catch (error) {
+                    return { error: parseEngineError(error) }
+                }
+            },
+        }),
+    }),
+})

--- a/src/api/event-visualizations-api.ts
+++ b/src/api/event-visualizations-api.ts
@@ -74,6 +74,17 @@ export const eventVisualizationsApi = api.injectEndpoints({
 
                     metadataStore.addMetadata(visualization.metaData)
 
+                    // update most viewed statistics
+                    await engine.mutate({
+                        resource: 'dataStatistics',
+                        type: 'create',
+                        params: {
+                            eventType: 'EVENT_VISUALIZATION_VIEW',
+                            favorite: id,
+                        },
+                        data: {},
+                    })
+
                     return { data: visualization }
                 } catch (error) {
                     return { error: parseEngineError(error) }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -1,4 +1,3 @@
-import i18n from '@dhis2/d2-i18n'
 import { CssVariables } from '@dhis2/ui'
 import cx from 'classnames'
 import type { FC } from 'react'
@@ -13,8 +12,10 @@ import {
     GridTopRow,
 } from '@components/grid'
 import { PluginWrapper } from '@components/plugin-wrapper/plugin-wrapper'
+import { StartScreen } from '@components/start-screen/start-screen'
 import { Toolbar } from '@components/toolbar/toolbar'
 import { useAppSelector, useCurrentUser } from '@hooks'
+import { isVisualizationEmpty } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
 import {
     getUiDetailsPanelVisible,
@@ -46,10 +47,9 @@ const EventVisualizer: FC = () => {
             </GridCenterColumnTop>
             <GridCenterColumnBottom>
                 <div style={{ padding: 8 }}>
-                    <h1>Visualization Canvas</h1>
-                    <h3>{i18n.t('Welcome to DHIS2 with TypeScript!')}</h3>
-                    {/* TODO: use a type guard and implement the landing screen DHIS2-20123 */}
-                    {currentVis && (
+                    {isVisualizationEmpty(currentVis) ? (
+                        <StartScreen />
+                    ) : (
                         <PluginWrapper
                             visualization={currentVis}
                             displayProperty={

--- a/src/components/start-screen/start-screen.tsx
+++ b/src/components/start-screen/start-screen.tsx
@@ -1,0 +1,77 @@
+import i18n from '@dhis2/d2-i18n'
+import { colors } from '@dhis2/ui'
+import type { FC } from 'react'
+import classes from './styles/start-screen.module.css'
+import { dataStatisticsApi } from '@api/data-statistics-api'
+import { VisTypeIcon } from '@dhis2/analytics'
+import { useAppDispatch } from '@hooks'
+import { setNavigationState } from '@store/navigation-slice.js'
+
+export const StartScreen: FC = () => {
+    const dispatch = useAppDispatch()
+
+    const { data } = dataStatisticsApi.useGetMostViewedQuery()
+
+    return (
+        <div className={classes.outer}>
+            <div className={classes.inner}>
+                <div>
+                    <div className={classes.section}>
+                        <h3 className={classes.title}>
+                            {i18n.t('Getting started')}
+                        </h3>
+                        <ul className={classes.guide}>
+                            <li className={classes.guideItem}>
+                                {i18n.t(
+                                    'All dimensions that you can use to build visualizations are shown in the sections in the left sidebar.'
+                                )}
+                            </li>
+                            <li className={classes.guideItem}>
+                                {i18n.t('Add dimensions to the layout above.')}
+                            </li>
+                            <li className={classes.guideItem}>
+                                {i18n.t(
+                                    'Click a dimension to add or remove conditions.'
+                                )}
+                            </li>
+                        </ul>
+                    </div>
+                    {data && (
+                        <div className={classes.section}>
+                            <h3 className={classes.title}>
+                                {i18n.t(
+                                    'Your most viewed event visualizations'
+                                )}
+                            </h3>
+                            {data.map((vis) => (
+                                <p
+                                    key={vis.id}
+                                    className={classes.visualization}
+                                    onClick={() =>
+                                        dispatch(
+                                            setNavigationState({
+                                                visualizationId: vis.id,
+                                            })
+                                        )
+                                    }
+                                    data-test={
+                                        'start-screen-most-viewed-list-item'
+                                    }
+                                >
+                                    <span className={classes.visIcon}>
+                                        <VisTypeIcon
+                                            type={vis.type}
+                                            useSmall
+                                            color={colors.grey600}
+                                        />
+                                    </span>
+                                    <span>{vis.name}</span>
+                                </p>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}

--- a/src/components/start-screen/styles/start-screen.module.css
+++ b/src/components/start-screen/styles/start-screen.module.css
@@ -1,0 +1,69 @@
+.outer {
+    display: flex;
+    justify-content: center;
+    block-size: 100%;
+    flex-grow: 1;
+}
+.inner {
+    padding: var(--spacers-dp16) var(--spacers-dp24);
+    max-inline-size: 600px;
+    box-sizing: border-box;
+    color: var(--colors-grey900);
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+.title {
+    font-weight: 500;
+    font-size: 17px;
+    margin-block-start: 0;
+    line-height: 22px;
+    color: var(--colors-grey800);
+}
+.section {
+    text-align: start;
+    background: var(--colors-white);
+    padding: var(--spacers-dp16);
+    margin-block-end: var(--spacers-dp24);
+    border-radius: 5px;
+    border: 1px solid var(--colors-grey400);
+}
+.guide {
+    line-height: 18px;
+    letter-spacing: 0.1px;
+    list-style: circle;
+    list-style-position: outside;
+    margin: 0 0 0 var(--spacers-dp12);
+    padding: 0 0 0 var(--spacers-dp12);
+}
+.guideItem {
+    font-size: 14px;
+    line-height: 18px;
+    letter-spacing: 0.1px;
+    margin-block-end: var(--spacers-dp12);
+}
+.visualization {
+    display: flex;
+    align-items: center;
+    margin: 0 0 var(--spacers-dp4) 0;
+    padding: var(--spacers-dp4) 0 var(--spacers-dp4) var(--spacers-dp12);
+    letter-spacing: 0.1px;
+    line-height: 16px;
+    cursor: pointer;
+    font-size: 14px;
+    border-radius: 3px;
+}
+.visualization:hover {
+    text-decoration: underline;
+    background-color: var(--colors-grey100);
+}
+.visIcon {
+    block-size: 16px;
+    display: flex;
+    align-items: center;
+}
+.visIcon svg {
+    block-size: 16px;
+    inline-size: 16px;
+    margin-inline-end: var(--spacers-dp8);
+}

--- a/src/types/analytics/index.d.ts
+++ b/src/types/analytics/index.d.ts
@@ -13,6 +13,7 @@ import type { PivotTable } from './pivot-table'
 import type { Toolbar } from './toolbar'
 import type { ToolbarSidebar } from './toolbar-sidebar'
 import type { UpdateButton } from './update-button'
+import type { VisTypeIcon } from './vis-type-icon'
 import type {
     CurrentVisualization,
     DimensionArray,
@@ -39,6 +40,7 @@ declare module '@dhis2/analytics' {
     export const Toolbar: Toolbar
     export const ToolbarSidebar: ToolbarSidebar
     export const UpdateButton: UpdateButton
+    export const VisTypeIcon: VisTypeIcon
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     export const transformEventAggregateResponse: (any) => any
     export const visTypeDisplayNames: Array<

--- a/src/types/analytics/vis-type-icon.ts
+++ b/src/types/analytics/vis-type-icon.ts
@@ -1,0 +1,9 @@
+import type { FC } from 'react'
+
+type VisTypeIconProps = {
+    color?: string
+    type?: string
+    useSmall?: boolean
+}
+
+export type VisTypeIcon = FC<VisTypeIconProps>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,7 @@ import type { ResponseErrorReport } from '@api/parse-engine-error'
  * this list should not contain the types we override. */
 export type {
     EventVisualizationType,
+    FavoriteStatistics,
     GridHeader,
     LegendSet,
     MeDto,


### PR DESCRIPTION
Implements [DHIS2-20123](https://dhis2.atlassian.net/browse/DHIS2-20123)

### Description

When starting the app or clicking on File -> New, a landing page is shown.
It contains a list of hints on how to get started with a new visualization.
If statistic data about the visualizations is available, a list of the 6 most viewed event visualizations is shown.
Each item in the list is a link which acts as a shortcut to open the visualization.

When a saved visualization is opened, the most viewed statistics are updated.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A
- [ ] Tester approved (@HendrikThePendric )

---

### Known issues

- when switching to the landing page via File -> New, the list of most viewed visualizations is not refetched

---

### Screenshots
<img width="1388" height="628" alt="Screenshot 2025-09-19 at 15 55 32" src="https://github.com/user-attachments/assets/f516e044-9dfa-4cca-91c5-0370f512d2c3" />


