### PR TITLE
chore: tweak the return type of `dataEngine.query`

### DIFF
--- a/src/api/data-statistics-api.ts
+++ b/src/api/data-statistics-api.ts
@@ -41,7 +41,9 @@ export const dataStatisticsApi = api.injectEndpoints({
                         favoritesResponse.favorites as FavoriteRecord[]
 
                     if (favorites.length > 0) {
-                        const { eventVisualizations } = await engine.query({
+                        const {
+                            eventVisualizations: { eventVisualizations },
+                        } = (await engine.query({
                             eventVisualizations: {
                                 resource: 'eventVisualizations',
                                 params: {
@@ -51,16 +53,14 @@ export const dataStatisticsApi = api.injectEndpoints({
                                     )}]`,
                                 },
                             },
-                        })
-
-                        const visualizations = (
-                            eventVisualizations as {
+                        })) as {
+                            eventVisualizations: {
                                 eventVisualizations: EventVisualizationRecord[]
                             }
-                        ).eventVisualizations as EventVisualizationRecord[]
+                        }
 
                         for (const favorite of favorites) {
-                            const type = visualizations.find(
+                            const type = eventVisualizations.find(
                                 (vis) => vis.id === favorite.id
                             )?.type
 

--- a/src/types/data-engine.ts
+++ b/src/types/data-engine.ts
@@ -1,0 +1,25 @@
+import type {
+    ContextType,
+    ExecuteOptions,
+    Query,
+} from '@dhis2/app-service-data'
+import type { ResponseErrorReport } from '@api/parse-engine-error'
+
+export type DataEngine = Omit<ContextType['engine'], 'query'> & {
+    query(
+        query: Query,
+        options?: ExecuteOptions
+    ): Promise<Record<keyof typeof query, unknown>>
+}
+export type QueryResult = Awaited<ReturnType<DataEngine['query']>>
+export type MutationResult = {
+    httpStatus: string
+    httpStatusCode: number
+    status: string
+    response: {
+        uid: string
+        klass: string
+        errorReports: Array<ResponseErrorReport>
+        responseType: string
+    }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,14 @@
 /* ONLY PLACE GENERAL TYPES HERE WHICH ARE USED THROUGHOUT THE APP
  * Types exported from here can be imported as follows:
  * `import type { MyType } from '@types'` */
-import type { ContextType } from '@dhis2/app-service-data'
 import type { TransformedAppCachedData } from '../components/app-wrapper/app-cached-data-query-provider'
-import type { ResponseErrorReport } from '@api/parse-engine-error'
 /* We have an ESLint rule in place to prevent imports from
  * `src/types/dhis2-openapi-schemas` anywhere else in the codebase.
  * The reason for this is so that we can apply manual overrides
  * for generated types here, as we have done for `SystemSettings`.
  * Anything that is needed from the generated types should be explicitly exported here;
  * this list should not contain the types we override. */
+export type { DataEngine, QueryResult, MutationResult } from './data-engine'
 export type {
     EventVisualizationType,
     FavoriteStatistics,
@@ -42,19 +41,6 @@ export type SingleQuery = {
         string,
         number | string | boolean | Array<number | string | boolean>
     >
-}
-export type DataEngine = ContextType['engine']
-export type QueryResult = Awaited<ReturnType<DataEngine['query']>>
-export type MutationResult = {
-    httpStatus: string
-    httpStatusCode: number
-    status: string
-    response: {
-        uid: string
-        klass: string
-        errorReports: Array<ResponseErrorReport>
-        responseType: string
-    }
 }
 export type { AppStore, AppDispatch, RootState } from '@store/store'
 export type { UseMetadataStoreReturnValue as MetadataStore } from '../components/app-wrapper/metadata-provider'


### PR DESCRIPTION
By changing the return type of `dataEngine.query` to this, we no longer have to deal with this inconvenient `JsonMap` type. This means we are no longer to "untype things", i.e. we can now do `as SomeType` instead of doing `as unknown as SomeType`