### PR TITLE
chore: switch to analytics backend for open api specs

### DIFF
--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -3,7 +3,7 @@ set -e
 
 
 # Configuration
-API_URL="https://play.im.dhis2.org/dev/api/openapi.yaml"
+API_URL="https://test.e2e.dhis2.org/anly-dev/api/openapi.yaml"
 TYPES_DIR="./src/types/dhis2-openapi-schemas"
 TEMP_DIR="./temp-openapi"
 AUTH_HEADER="Authorization: Basic $(echo -n "admin:district" | base64)"


### PR DESCRIPTION
We used to fetch the OpenAPI specs from here:
```
API_URL="https://play.im.dhis2.org/dev/api/openapi.yaml"
```
But when play is down stuff will break. It makes sense to use our "own" backend:
```
API_URL="https://test.e2e.dhis2.org/anly-dev/api/openapi.yaml"
```