### PR TITLE
refactor: simplify pagination

### DIFF
--- a/src/components/line-list/__tests__/line-list.spec.tsx
+++ b/src/components/line-list/__tests__/line-list.spec.tsx
@@ -163,7 +163,7 @@ describe('LineList', () => {
             ).getByText('50')
             await user.click(option50)
 
-            expect(onPaginate).toHaveBeenCalledWith({ pageSize: 50 })
+            expect(onPaginate).toHaveBeenCalledWith({ page: 1, pageSize: 50 })
         })
 
         it('displays pagination information correctly', async () => {

--- a/src/components/line-list/sticky-pagination.tsx
+++ b/src/components/line-list/sticky-pagination.tsx
@@ -40,7 +40,7 @@ const StickyPagination = ({
     )
     const onPageSizeChange = useCallback(
         (pageSize: number) => {
-            onPaginate({ pageSize })
+            onPaginate({ page: 1, pageSize })
         },
         [onPaginate]
     )

--- a/src/components/line-list/types.ts
+++ b/src/components/line-list/types.ts
@@ -52,10 +52,6 @@ export type DataSortPayload = {
     dimension: string
     direction?: SortDirection
 }
-export type PaginatePayload = {
-    page?: number
-    pageSize?: number
-}
 export type DataSortFn = (payload: DataSortPayload) => void
-export type PaginateFn = (payload: PaginatePayload) => void
+export type PaginateFn = (payload: { page: number; pageSize?: number }) => void
 export type ColumnHeaderClickFn = (cleanedHeaderName: string) => void

--- a/src/components/plugin-wrapper/line-list-plugin.tsx
+++ b/src/components/plugin-wrapper/line-list-plugin.tsx
@@ -4,7 +4,11 @@ import { useLineListAnalyticsData } from './hooks/use-line-list-analytics-data'
 import type { MetadataInput } from '@components/app-wrapper/metadata-helpers'
 import { LineList } from '@components/line-list'
 import type { LineListAnalyticsData } from '@components/line-list'
-import type { DataSortFn, DataSortPayload } from '@components/line-list/types'
+import type {
+    DataSortFn,
+    DataSortPayload,
+    PaginateFn,
+} from '@components/line-list/types'
 import { transformVisualization } from '@modules/visualization'
 import type { CurrentUser, CurrentVisualization, SortDirection } from '@types'
 
@@ -62,15 +66,11 @@ export const LineListPlugin: FC<LineListPluginProps> = ({
         ? visualization.sorting[0]
         : { dimension: undefined, direction: undefined }
 
-    const onPaginate = useCallback(({ page, pageSize }) => {
+    const onPaginate: PaginateFn = useCallback(({ page, pageSize }) => {
         if (pageSize) {
-            setPagination({ page: pageSize ? FIRST_PAGE : page, pageSize })
-        } else if (page) {
-            setPagination({ page })
+            setPagination({ page, pageSize })
         } else {
-            throw new Error(
-                'onPaginate was called with neither a page nor pageSize. At least one is expected'
-            )
+            setPagination({ page })
         }
     }, [])
 

--- a/src/components/plugin-wrapper/line-list-plugin.tsx
+++ b/src/components/plugin-wrapper/line-list-plugin.tsx
@@ -23,9 +23,6 @@ type LineListPluginProps = {
     onResponseReceived?: (metadata: MetadataInput) => void
 }
 
-const FIRST_PAGE: number = 1
-const PAGE_SIZE: number = 100
-
 export const LineListPlugin: FC<LineListPluginProps> = ({
     displayProperty,
     visualization: originalVisualization,
@@ -56,8 +53,8 @@ export const LineListPlugin: FC<LineListPluginProps> = ({
             ...newPagination,
         }),
         {
-            page: FIRST_PAGE,
-            pageSize: PAGE_SIZE,
+            page: 1,
+            pageSize: 100,
         }
     )
 
@@ -66,7 +63,7 @@ export const LineListPlugin: FC<LineListPluginProps> = ({
         ? visualization.sorting[0]
         : { dimension: undefined, direction: undefined }
 
-    const onPaginate: PaginateFn = useCallback(({ page, pageSize }) => {
+    const onPaginate = useCallback<PaginateFn>(({ page, pageSize }) => {
         if (pageSize) {
             setPagination({ page, pageSize })
         } else {


### PR DESCRIPTION
N/A

### Description

I've done the following:
- `page` is now required in the function signature of the `PaginateFn`
- The `onPaginate` function in the `LineListPlugin` now also implements that type.
- The `StickyNavigation` component now passes a `page` with value `1` when the `pageSize` changes.

The result of this is that:
1. The line-list-plugin doesn't have to handle resetting to page 1 when the `pageSize` changes
2. It also doesn't have to throw any errors, because the TS compiler won't allow the error case to happen anymore

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A
- [x] Tester approved (@edoardo)

---