### PR TITLE
fix: stay on UID url when refreshing [DHIS2-20177]

### DIFF
--- a/scripts/generate-types.sh
+++ b/scripts/generate-types.sh
@@ -3,7 +3,7 @@ set -e
 
 
 # Configuration
-API_URL="https://test.e2e.dhis2.org/anly-dev/api/openapi.yaml"
+API_URL="https://test.e2e.dhis2.org/anly-dev/api/openapi.yaml?expandedRefs=true"
 TYPES_DIR="./src/types/dhis2-openapi-schemas"
 TEMP_DIR="./temp-openapi"
 AUTH_HEADER="Authorization: Basic $(echo -n "admin:district" | base64)"

--- a/src/api/custom-base-query.ts
+++ b/src/api/custom-base-query.ts
@@ -14,7 +14,7 @@ import type {
 // cater for both queries and mutations
 export type EngineArgs = Query | Mutation | SingleQuery
 type EngineResult = QueryResult | MutationResult | unknown
-type ThunkExtraArg = {
+export type ThunkExtraArg = {
     engine: DataEngine
     metadataStore: MetadataStore
     appCachedData: AppCachedData

--- a/src/components/app-wrapper/store-to-location-syncer.tsx
+++ b/src/components/app-wrapper/store-to-location-syncer.tsx
@@ -2,7 +2,7 @@ import type { Location } from 'history'
 import queryString from 'query-string'
 import { useEffect, useRef } from 'react'
 import { useAppDispatch, useAppSelector, useAppStore } from '@hooks'
-import { history } from '@modules/history'
+import { getNavigationStateFromLocation, history } from '@modules/history'
 import { setNavigationState } from '@store/navigation-slice'
 
 export const StoreToLocationSyncer = () => {
@@ -36,27 +36,17 @@ export const StoreToLocationSyncer = () => {
             })
             dispatchEvent(popStateEvent)
 
-            // APP RELATED CODE:
-            const pathVisualizationId = location.pathname.slice(1) // remove leading "/"
-            const newVisualizationId = pathVisualizationId || 'new'
-            const queryParams = queryString.parse(location.search)
-            const newInterpretationId =
-                // Ignore interpretationId in query param when on new path
-                newVisualizationId === 'new' ||
-                typeof queryParams.interpretationId !== 'string'
-                    ? null
-                    : queryParams.interpretationId
-
-            const { navigation } = store.getState()
+            const locationState = getNavigationStateFromLocation()
+            const { navigation: storeState } = store.getState()
             const hasChanges =
-                newVisualizationId !== navigation.visualizationId ||
-                newInterpretationId !== navigation.interpretationId
+                locationState.visualizationId !== storeState.visualizationId ||
+                locationState.interpretationId !== storeState.interpretationId
 
             if (hasChanges) {
                 dispatch(
                     setNavigationState({
-                        visualizationId: newVisualizationId,
-                        interpretationId: newInterpretationId,
+                        visualizationId: locationState.visualizationId,
+                        interpretationId: locationState.interpretationId,
                     })
                 )
             }

--- a/src/components/app/app.tsx
+++ b/src/components/app/app.tsx
@@ -2,6 +2,7 @@ import { CssVariables } from '@dhis2/ui'
 import cx from 'classnames'
 import { useCallback, type FC } from 'react'
 import classes from './app.module.css'
+import { useLoadVisualizationOnMount } from './use-load-visualization-on-mount'
 import { AppWrapper } from '@components/app-wrapper'
 import {
     GridCenterColumnBottom,
@@ -24,6 +25,7 @@ import {
 import type { CurrentVisualization, Sorting } from '@types'
 
 const EventVisualizer: FC = () => {
+    useLoadVisualizationOnMount()
     const dispatch = useAppDispatch()
     const currentUser = useCurrentUser()
     const currentVis = useAppSelector(getCurrentVis)

--- a/src/components/app/use-load-visualization-on-mount.ts
+++ b/src/components/app/use-load-visualization-on-mount.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react'
+import { useAppDispatch, useAppStore } from '@hooks'
+import { tLoadSavedVisualization } from '@store/thunks'
+
+export const useLoadVisualizationOnMount = () => {
+    const store = useAppStore()
+    const dispatch = useAppDispatch()
+
+    useEffect(() => {
+        const { navigation } = store.getState()
+
+        if (navigation.visualizationId !== 'new') {
+            dispatch(tLoadSavedVisualization(navigation.visualizationId))
+        }
+    }, [dispatch, store])
+}

--- a/src/components/toolbar/menu-bar/menu-bar.tsx
+++ b/src/components/toolbar/menu-bar/menu-bar.tsx
@@ -9,7 +9,7 @@ import { isVisualizationSaved } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
 import { setNavigationState } from '@store/navigation-slice'
 import { getSavedVis } from '@store/saved-vis-slice'
-import { tLoadSavedVisualization } from '@store/thunks'
+import { tResetCurrentVisualizationFromSaved } from '@store/thunks'
 
 export const MenuBar: FC = () => {
     const dispatch = useAppDispatch()
@@ -33,7 +33,7 @@ export const MenuBar: FC = () => {
     const onOpen = useCallback(
         (id: string) => {
             if (isVisualizationSaved(currentVis) && currentVis.id === id) {
-                dispatch(tLoadSavedVisualization(id))
+                dispatch(tResetCurrentVisualizationFromSaved())
             } else {
                 dispatch(setNavigationState({ visualizationId: id }))
             }

--- a/src/components/toolbar/menu-bar/menu-bar.tsx
+++ b/src/components/toolbar/menu-bar/menu-bar.tsx
@@ -5,9 +5,11 @@ import { ViewMenu } from './view-menu'
 import { VISUALIZATION_TYPES } from '@constants/visualization-types'
 import { FileMenu, HoverMenuBar } from '@dhis2/analytics'
 import { useAppDispatch, useAppSelector, useCurrentUser } from '@hooks'
+import { isVisualizationSaved } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
 import { setNavigationState } from '@store/navigation-slice'
 import { getSavedVis } from '@store/saved-vis-slice'
+import { tLoadSavedVisualization } from '@store/thunks'
 
 export const MenuBar: FC = () => {
     const dispatch = useAppDispatch()
@@ -30,9 +32,13 @@ export const MenuBar: FC = () => {
 
     const onOpen = useCallback(
         (id: string) => {
-            dispatch(setNavigationState({ visualizationId: id }))
+            if (isVisualizationSaved(currentVis) && currentVis.id === id) {
+                dispatch(tLoadSavedVisualization(id))
+            } else {
+                dispatch(setNavigationState({ visualizationId: id }))
+            }
         },
-        [dispatch]
+        [dispatch, currentVis]
     )
 
     return (

--- a/src/components/toolbar/menu-bar/menu-bar.tsx
+++ b/src/components/toolbar/menu-bar/menu-bar.tsx
@@ -9,7 +9,7 @@ import { isVisualizationSaved } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
 import { setNavigationState } from '@store/navigation-slice'
 import { getSavedVis } from '@store/saved-vis-slice'
-import { tResetCurrentVisualizationFromSaved } from '@store/thunks'
+import { tLoadSavedVisualization } from '@store/thunks'
 
 export const MenuBar: FC = () => {
     const dispatch = useAppDispatch()
@@ -33,7 +33,7 @@ export const MenuBar: FC = () => {
     const onOpen = useCallback(
         (id: string) => {
             if (isVisualizationSaved(currentVis) && currentVis.id === id) {
-                dispatch(tResetCurrentVisualizationFromSaved())
+                dispatch(tLoadSavedVisualization(id))
             } else {
                 dispatch(setNavigationState({ visualizationId: id }))
             }

--- a/src/modules/__tests__/history.spec.ts
+++ b/src/modules/__tests__/history.spec.ts
@@ -1,0 +1,71 @@
+import type { Location } from 'history'
+import { describe, expect, it } from 'vitest'
+import { getNavigationStateFromLocation } from '../history'
+
+describe('getNavigationStateFromLocation', () => {
+    it('should return "new" when pathname is empty', () => {
+        const location = {
+            pathname: '/',
+            search: '',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('new')
+        expect(result.interpretationId).toBeNull()
+    })
+
+    it('should extract visualizationId from pathname', () => {
+        const location = {
+            pathname: '/abc123',
+            search: '',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('abc123')
+        expect(result.interpretationId).toBeNull()
+    })
+
+    it('should ignore interpretationId when on "new" path', () => {
+        const location = {
+            pathname: '/',
+            search: '?interpretationId=test123',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('new')
+        expect(result.interpretationId).toBeNull()
+    })
+
+    it('should return interpretationId when valid string and not on new path', () => {
+        const location = {
+            pathname: '/vis123',
+            search: '?interpretationId=interp456',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('vis123')
+        expect(result.interpretationId).toBe('interp456')
+    })
+
+    it('should return null when interpretationId is empty string', () => {
+        const location = {
+            pathname: '/vis123',
+            search: '?interpretationId=',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('vis123')
+        expect(result.interpretationId).toBeNull()
+    })
+
+    it('should handle multiple query params', () => {
+        const location = {
+            pathname: '/vis123',
+            search: '?foo=bar&interpretationId=interp789&baz=qux',
+        } as Location
+        const result = getNavigationStateFromLocation(location)
+
+        expect(result.visualizationId).toBe('vis123')
+        expect(result.interpretationId).toBe('interp789')
+    })
+})

--- a/src/modules/history.ts
+++ b/src/modules/history.ts
@@ -1,3 +1,23 @@
 import { createHashHistory } from 'history'
+import type { Location } from 'history'
+import queryString from 'query-string'
+import type { NavigationState } from '@store/navigation-slice'
 
 export const history = createHashHistory()
+
+export const getNavigationStateFromLocation = (
+    location: Location = history.location
+): NavigationState => {
+    const pathVisualizationId = location.pathname.slice(1) // remove leading "/"
+    const visualizationId = pathVisualizationId || 'new'
+    const queryParams = queryString.parse(location.search)
+    const interpretationId =
+        // Ignore interpretationId in query param when on new path
+        visualizationId === 'new' ||
+        typeof queryParams.interpretationId !== 'string' ||
+        queryParams.interpretationId.length === 0
+            ? null
+            : queryParams.interpretationId
+
+    return { visualizationId, interpretationId }
+}

--- a/src/store/navigation-slice.ts
+++ b/src/store/navigation-slice.ts
@@ -32,17 +32,15 @@ export const { setNavigationState } = navigationSlice.actions
 
 startAppListening({
     actionCreator: setNavigationState,
-    effect: async (action, listenerApi) => {
-        const dispatch = listenerApi.dispatch
-        const currentState = listenerApi.getState().navigation
-
-        const currentVisualizationId = currentState.visualizationId
+    effect: async (action, { dispatch, getOriginalState }) => {
+        const originalState = getOriginalState()
+        const originalVisualizationId = originalState.navigation.visualizationId
         const newVisualizationId = action.payload.visualizationId
 
         /* Since the InterpretationsModal loads its own visualization
          * we are only interested in visualizationId changes in this
          * listener middleware */
-        if (currentVisualizationId !== newVisualizationId) {
+        if (originalVisualizationId !== newVisualizationId) {
             if (newVisualizationId === 'new') {
                 dispatch(tClearVisualization())
             } else {

--- a/src/store/navigation-slice.ts
+++ b/src/store/navigation-slice.ts
@@ -30,35 +30,24 @@ export const navigationSlice = createSlice({
 
 export const { setNavigationState } = navigationSlice.actions
 
-// listen to changes in navigation.visualizationId
-// "new" (FileMenu -> New): clean the store
-// "id" (FileMenu -> Open): fetch the visualization only if the id changes
 startAppListening({
-    predicate: (_, currentState, previousState) =>
-        currentState.navigation.visualizationId !==
-        previousState.navigation.visualizationId,
-    effect: async (_, listenerApi) => {
+    actionCreator: setNavigationState,
+    effect: async (action, listenerApi) => {
         const dispatch = listenerApi.dispatch
+        const currentState = listenerApi.getState().navigation
 
-        const visualizationId =
-            listenerApi.getState().navigation.visualizationId
+        const currentVisualizationId = currentState.visualizationId
+        const newVisualizationId = action.payload.visualizationId
 
-        if (visualizationId === 'new') {
-            dispatch(tClearVisualization())
-        } else {
-            dispatch(tLoadSavedVisualization(visualizationId))
+        /* Since the InterpretationsModal loads its own visualization
+         * we are only interested in visualizationId changes in this
+         * listener middleware */
+        if (currentVisualizationId !== newVisualizationId) {
+            if (newVisualizationId === 'new') {
+                dispatch(tClearVisualization())
+            } else {
+                dispatch(tLoadSavedVisualization(newVisualizationId))
+            }
         }
-    },
-})
-
-// listen to changes in navigation.interpretationId
-startAppListening({
-    predicate: (_, currentState, previousState) =>
-        currentState.navigation.interpretationId !==
-        previousState.navigation.interpretationId,
-    effect: () => {
-        console.log(
-            'interpretationId changed - add the logic in place of this message'
-        )
     },
 })

--- a/src/store/navigation-slice.ts
+++ b/src/store/navigation-slice.ts
@@ -1,12 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import { clearCurrentVis, setCurrentVis } from './current-vis-slice'
 import { startAppListening } from './middleware-listener'
-import { clearSavedVis, setSavedVis } from './saved-vis-slice'
-import { clearUi } from './ui-slice'
-import { setVisUiConfig } from './vis-ui-config-slice'
-import { eventVisualizationsApi } from '@api/event-visualizations-api'
-import { getVisualizationUiConfig } from '@modules/get-visualization-ui-config'
+import { tClearVisualization, tLoadSavedVisualization } from './thunks'
 import { getNavigationStateFromLocation } from '@modules/history'
 
 export interface NavigationState {
@@ -49,23 +44,9 @@ startAppListening({
             listenerApi.getState().navigation.visualizationId
 
         if (visualizationId === 'new') {
-            dispatch(clearUi())
-            dispatch(clearSavedVis())
-            dispatch(clearCurrentVis())
+            dispatch(tClearVisualization())
         } else {
-            const { data, error } = await dispatch(
-                eventVisualizationsApi.endpoints.getVisualization.initiate(
-                    visualizationId
-                )
-            )
-
-            if (data) {
-                dispatch(setSavedVis(data))
-                dispatch(setVisUiConfig(getVisualizationUiConfig(data)))
-                dispatch(setCurrentVis(data))
-            } else if (error) {
-                console.error(error)
-            }
+            dispatch(tLoadSavedVisualization(visualizationId))
         }
     },
 })

--- a/src/store/navigation-slice.ts
+++ b/src/store/navigation-slice.ts
@@ -7,16 +7,14 @@ import { clearUi } from './ui-slice'
 import { setVisUiConfig } from './vis-ui-config-slice'
 import { eventVisualizationsApi } from '@api/event-visualizations-api'
 import { getVisualizationUiConfig } from '@modules/get-visualization-ui-config'
+import { getNavigationStateFromLocation } from '@modules/history'
 
 export interface NavigationState {
     visualizationId: string | 'new'
     interpretationId: string | null
 }
 
-export const initialState: NavigationState = {
-    visualizationId: 'new',
-    interpretationId: null,
-}
+export const initialState: NavigationState = getNavigationStateFromLocation()
 
 export const navigationSlice = createSlice({
     name: 'navigation',

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -25,6 +25,13 @@ export const tClearVisualization = () => (dispatch: AppDispatch) => {
     dispatch(clearCurrentVis())
 }
 
+export const tResetCurrentVisualizationFromSaved =
+    () => (dispatch: AppDispatch, getState: () => RootState) => {
+        const { savedVis } = getState()
+        dispatch(setVisUiConfig(getVisualizationUiConfig(savedVis)))
+        dispatch(setCurrentVis(savedVis))
+    }
+
 export const tLoadSavedVisualization = createAsyncThunk<
     void,
     string,

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -1,0 +1,45 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { clearCurrentVis, setCurrentVis } from './current-vis-slice'
+import { clearSavedVis, setSavedVis } from './saved-vis-slice'
+import type { RootState } from './store'
+import { clearUi } from './ui-slice'
+import { setVisUiConfig } from './vis-ui-config-slice'
+import type { ThunkExtraArg } from '@api/custom-base-query'
+import { eventVisualizationsApi } from '@api/event-visualizations-api'
+import { getVisualizationUiConfig } from '@modules/get-visualization-ui-config'
+import type { AppDispatch } from '@types'
+
+type AppAsyncThunkConfig = {
+    state: RootState
+    dispatch: AppDispatch
+    extra: ThunkExtraArg
+    rejectValue?: unknown
+    serializedErrorType?: unknown
+    fulfillMeta?: unknown
+    rejectMeta?: unknown
+}
+
+export const tClearVisualization = () => (dispatch: AppDispatch) => {
+    dispatch(clearUi())
+    dispatch(clearSavedVis())
+    dispatch(clearCurrentVis())
+}
+
+export const tLoadSavedVisualization = createAsyncThunk<
+    void,
+    string,
+    AppAsyncThunkConfig
+>('visualization/load', async (visualizationId: string, { dispatch }) => {
+    const { data, error } = await dispatch(
+        eventVisualizationsApi.endpoints.getVisualization.initiate(
+            visualizationId
+        )
+    )
+    if (data) {
+        dispatch(setSavedVis(data))
+        dispatch(setVisUiConfig(getVisualizationUiConfig(data)))
+        dispatch(setCurrentVis(data))
+    } else if (error) {
+        console.error(error)
+    }
+})

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -25,22 +25,16 @@ export const tClearVisualization = () => (dispatch: AppDispatch) => {
     dispatch(clearCurrentVis())
 }
 
-export const tResetCurrentVisualizationFromSaved =
-    () => (dispatch: AppDispatch, getState: () => RootState) => {
-        const { savedVis } = getState()
-        dispatch(setVisUiConfig(getVisualizationUiConfig(savedVis)))
-        dispatch(setCurrentVis(savedVis))
-    }
-
 export const tLoadSavedVisualization = createAsyncThunk<
     void,
     string,
     AppAsyncThunkConfig
->('visualization/load', async (visualizationId: string, { dispatch }) => {
+>('visualization/load', async (id: string, { dispatch }) => {
     const { data, error } = await dispatch(
-        eventVisualizationsApi.endpoints.getVisualization.initiate(
-            visualizationId
-        )
+        eventVisualizationsApi.endpoints.getVisualization.initiate(id, {
+            // This is consistent with other analytics apps
+            forceRefetch: true,
+        })
     )
     if (data) {
         dispatch(setSavedVis(data))


### PR DESCRIPTION
Implements [DHIS2-20177](https://dhis2.atlassian.net/browse/DHIS2-20177)

### Description

While fixing the initial issue, I ended up breaking something else: after a refresh the URL would now remain correct but nothing would load. I fixed things as follows:
1. The `navigation` state is now being initialised from the `history.location`. This means the listener middleware does not detect a state change and will not load anything. This is a small downside, but initialising the state from the URL is intrinsically correct.
2. The listener middleware has been simplified. Instead of using a predicate, which gets a bit messy with types, it now uses `actionCreator: setNavigationState`. This also means it will only run when the `setNavigationState` action is called. To detect changes in the `visualizationId` in the `effect` callback, we use `useOriginalState` which is the "state before the action updated it".
3. The code that loads or clears a visualisation has been extracted into two thunks: `tClearVisualization` and `tLoadSavedVisualization`. This makes it easy to do the same thing from different places in the codebase. 
4. I've added a hooks that checks if a visualisation needs to be loaded when the app mounts. It then dispatches the `tLoadSavedVisualization` thunk. There will be other places where we need to do the same in the future, like the "open file with same ID scenario"

#### Unrelated change

I had a call with Jan Bernitt today. He advised me to add the `expandedRefs=true` query param when I fetch the OpenAPI specs. This will give us better type information reg. nested objects.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A
- [x] Tester approved (@edoardo )

---


[DHIS2-20177]: https://dhis2.atlassian.net/browse/DHIS2-20177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ