### PR TITLE
fix: use useDataQuery for fetching the visualization

### DIFF
--- a/src/dashboard-plugin.tsx
+++ b/src/dashboard-plugin.tsx
@@ -1,8 +1,9 @@
+// eslint-disable-next-line  no-restricted-imports
+import { useDataQuery } from '@dhis2/app-runtime'
 import type { FC } from 'react'
 import { getVisualizationQueryFields } from '@api/event-visualizations-api'
 import { PluginWrapper } from '@components/plugin-wrapper/plugin-wrapper'
 import { DashboardPluginWrapper } from '@dhis2/analytics'
-import { useRtkQuery } from '@hooks'
 import './locales/index.js'
 import type { CurrentUser, SavedVisualization } from '@types'
 
@@ -16,8 +17,8 @@ const DashboardPlugin: FC<DashboardPluginProps> = (props) => {
     console.log('DashboardPlugin props', props)
 
     // fetch the visualization
-    const { data, isLoading, isError, error } = useRtkQuery<SavedVisualization>(
-        {
+    const { data, loading, error } = useDataQuery({
+        eventVisualization: {
             resource: 'eventVisualizations',
             id: props.visualization.id, // TODO: this should be just passed as visualizationId
             params: {
@@ -29,19 +30,21 @@ const DashboardPlugin: FC<DashboardPluginProps> = (props) => {
                         : 'displayShortName'
                 ),
             },
-        }
-    )
+        },
+    })
 
-    if (isLoading) {
+    if (loading) {
         // Both `error` and `data` will be undefined here
         console.log(data, error)
         return <div>Loading event visualization...</div>
     }
-    if (isError) {
+    if (error) {
         // `error` will be of type EngineError and `data` will is possibly undefined
         console.log(data, error)
         return <div>Error loading event visualization: {error.message}</div>
     }
+
+    const eventVisualization = data?.eventVisualization as SavedVisualization
 
     return (
         <DashboardPluginWrapper {...props}>
@@ -52,7 +55,7 @@ const DashboardPlugin: FC<DashboardPluginProps> = (props) => {
                 <PluginWrapper
                     displayProperty={props.displayProperty}
                     filters={props.filters}
-                    visualization={data}
+                    visualization={eventVisualization}
                 />
             )}
         </DashboardPluginWrapper>


### PR DESCRIPTION
### Description

We are moving the visualization fetch from dashboard app to each individual plugin.
This is to avoid to have to sync the fields list between dashboard app and the other apps.
The only information needed from dashboard is the visualization id, which is already returned in the `dashboard` response.

Since the plugin cannot rely on the app's RTK store, `useDataQuery` needs to be used for the fetch.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [ ] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated N/A
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A
- [ ] Tester approved (@HendrikThePendric )

---

### Screenshots

LL visualization loaded in a dashboard using the new EVER plugin:
<img width="1309" height="621" alt="Screenshot 2025-10-06 at 12 11 39" src="https://github.com/user-attachments/assets/2e079bab-e8fc-412c-8a09-fb0309d5f3ac" />

