### PR TITLE
chore: clean up vitest output

### DIFF
--- a/src/api/__tests__/custom-base-query.spec.ts
+++ b/src/api/__tests__/custom-base-query.spec.ts
@@ -2,6 +2,7 @@ import type { Query, Mutation } from '@dhis2/app-service-data'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { customBaseQuery } from '../custom-base-query'
 import type { BaseQueryApiWithExtraArg } from '../custom-base-query'
+import { suppressConsoleError } from '@test-utils/supress-console-error'
 import type { DataEngine } from '@types'
 
 describe('customBaseQuery', () => {
@@ -58,30 +59,40 @@ describe('customBaseQuery', () => {
         expect(result).toEqual({ data: {} })
     })
 
-    it('returns error if query throws', async () => {
-        const errorMsg = 'Query failed'
-        const queryMock = engine.query as ReturnType<typeof vi.fn>
-        queryMock.mockRejectedValueOnce(new Error(errorMsg))
-        const api = { extra: { engine } } as unknown as BaseQueryApiWithExtraArg
-        const result = await customBaseQuery(queryArgs, api, {})
-        expect(result).toEqual({
-            error: {
-                type: 'runtime',
-                message: errorMsg,
-            },
+    it(
+        'returns error if query throws',
+        suppressConsoleError('Query failed', async () => {
+            const errorMsg = 'Query failed'
+            const queryMock = engine.query as ReturnType<typeof vi.fn>
+            queryMock.mockRejectedValueOnce(new Error(errorMsg))
+            const api = {
+                extra: { engine },
+            } as unknown as BaseQueryApiWithExtraArg
+            const result = await customBaseQuery(queryArgs, api, {})
+            expect(result).toEqual({
+                error: {
+                    type: 'runtime',
+                    message: errorMsg,
+                },
+            })
         })
-    })
+    )
 
-    it('returns error if mutation throws non-Error', async () => {
-        const mutateMock = engine.mutate as ReturnType<typeof vi.fn>
-        mutateMock.mockRejectedValueOnce('fail')
-        const api = { extra: { engine } } as unknown as BaseQueryApiWithExtraArg
-        const result = await customBaseQuery(mutationArgs, api, {})
-        expect(result).toEqual({
-            error: {
-                type: 'runtime',
-                message: 'An unexpected runtime error occurred',
-            },
+    it(
+        'returns error if mutation throws non-Error',
+        suppressConsoleError('fail', async () => {
+            const mutateMock = engine.mutate as ReturnType<typeof vi.fn>
+            mutateMock.mockRejectedValueOnce('fail')
+            const api = {
+                extra: { engine },
+            } as unknown as BaseQueryApiWithExtraArg
+            const result = await customBaseQuery(mutationArgs, api, {})
+            expect(result).toEqual({
+                error: {
+                    type: 'runtime',
+                    message: 'An unexpected runtime error occurred',
+                },
+            })
         })
-    })
+    )
 })

--- a/src/test-utils/supress-console-error.ts
+++ b/src/test-utils/supress-console-error.ts
@@ -1,0 +1,32 @@
+export const suppressConsoleError = (
+    messageToMatch: string,
+    fn: () => Promise<void>
+) => {
+    return async () => {
+        const originalConsoleError = console.error
+        console.error = (...args: unknown[]) => {
+            // Check if any argument contains our target message
+            const shouldSuppress = args.some((arg) => {
+                if (typeof arg === 'string') {
+                    return arg.includes(messageToMatch)
+                }
+                if (arg instanceof Error) {
+                    return arg.message.includes(messageToMatch)
+                }
+                return false
+            })
+
+            if (shouldSuppress) {
+                return // Suppress this specific error
+            }
+
+            originalConsoleError(...args) // Let original console.error do its thing
+        }
+
+        try {
+            await fn()
+        } finally {
+            console.error = originalConsoleError
+        }
+    }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,5 +23,11 @@ export default defineConfig({
         setupFiles: './vitest.setup.ts',
         environment: 'jsdom',
         exclude: [...configDefaults.exclude, '**/.d2/**'],
+        onConsoleLog(log, type) {
+            // Suppress Highcharts warnings
+            if (type === 'stderr' && log.includes('Highcharts warning')) {
+                return false
+            }
+        },
     },
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,12 @@ export default defineConfig({
         exclude: [...configDefaults.exclude, '**/.d2/**'],
         onConsoleLog(log, type) {
             // Suppress Highcharts warnings
-            if (type === 'stderr' && log.includes('Highcharts warning')) {
+            if (
+                type === 'stderr' &&
+                log.includes(
+                    'Highcharts warning #26: www.highcharts.com/errors/26/'
+                )
+            ) {
                 return false
             }
         },


### PR DESCRIPTION
N/A

### Description

Cleans up the Vitest output as follows:

- Adds a `suppressConsoleError` helper that allows you to silence known console.error messages that are going to be produced by a given test
- Use this helper and apply another small fix to remove output clutter
- Gloablly suppresses the Highcharts error

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [ ] Dashboard tested N/A
- [ ] Cypress and/or Jest tests added/updated
- [ ] Docs added N/A
- [ ] d2-ci dependency replaced N/A

---


