### PR TITLE
fix: make metadata store fn returned from hooks stable

### DIFF
--- a/src/components/app-wrapper/__tests__/metadata-provider.spec.tsx
+++ b/src/components/app-wrapper/__tests__/metadata-provider.spec.tsx
@@ -539,4 +539,43 @@ describe('MetadataProvider API and return value types', () => {
         expect(typeof result.current.getMetadataItems).toBe('function')
         expect(typeof result.current.addMetadata).toBe('function')
     })
+
+    it('hooks return stable functions', () => {
+        const { result, rerender } = renderHook(
+            () => ({
+                useAddMetadataResult: useAddMetadata(),
+                useMetadataStoreResult: useMetadataStore(),
+            }),
+            {
+                wrapper: ProviderWithComponents,
+            }
+        )
+
+        const initialFunctions = {
+            useAddMetadata: result.current.useAddMetadataResult,
+            useMetadataStoreAddMetadata:
+                result.current.useMetadataStoreResult.addMetadata,
+            useMetadataStoreGetMetadataItem:
+                result.current.useMetadataStoreResult.getMetadataItem,
+            useMetadataStoreGetMetadataItems:
+                result.current.useMetadataStoreResult.getMetadataItems,
+        }
+
+        act(() => {
+            rerender()
+        })
+
+        expect(result.current.useAddMetadataResult).toEqual(
+            initialFunctions.useAddMetadata
+        )
+        expect(result.current.useMetadataStoreResult.addMetadata).toEqual(
+            initialFunctions.useMetadataStoreAddMetadata
+        )
+        expect(result.current.useMetadataStoreResult.getMetadataItem).toEqual(
+            initialFunctions.useMetadataStoreGetMetadataItem
+        )
+        expect(result.current.useMetadataStoreResult.getMetadataItems).toEqual(
+            initialFunctions.useMetadataStoreGetMetadataItems
+        )
+    })
 })

--- a/src/components/app-wrapper/metadata-provider.tsx
+++ b/src/components/app-wrapper/metadata-provider.tsx
@@ -234,7 +234,12 @@ export const useMetadataItems = (
 
 export const useAddMetadata = (): MetadataStore['addMetadata'] => {
     const metadataStore = useContext(MetadataContext)!
-    return metadataStore.addMetadata.bind(metadataStore)
+
+    const [addMetadata] = useState(() =>
+        metadataStore.addMetadata.bind(metadataStore)
+    )
+
+    return addMetadata
 }
 
 export type UseMetadataStoreReturnValue = Pick<


### PR DESCRIPTION
### Description

I found out that the`useAddMetadata` hook was returning a new function every time thus making callbacks that use it in their dependencies "unstable".
The reason is that `bind` returns a new function every time.
The fix is wrapping the function in `useMemo` as the `metadataStore` dependency is stable.

The issue I was investigating was an unwanted and unexpected refetch of the analytics data in the LL plugin.
In the chain of components, the reference to `onResponseReceivedCb` in `PluginWrapper` was changing every time.
This callback is defined in `app.tsx` and has `addMetadata` returned by the `useAddMetadata` hook in the `useCallback` dependencies.
`PluginWrapper` is defining its own `onResponseReceived` for setting the `hasAnalyticsData` internal state and call the `onResponseReceivedCb` passed from `app.tsx`.
This `onResponseReceived` is in the dependency list of the `useEffect` that triggers the analytics fetch.
This ultimately was the cause of the re-fetch in the LL plugin when sidebars were toggled.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A
