### PR TITLE
chore: add workflow that approves dependabot PRs on approval

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,34 @@
+name: 'Dependabot Auto-Merge on Approval'
+
+on:
+    pull_request_review:
+        types:
+            - submitted
+
+permissions:
+    pull-requests: write
+    contents: write
+
+jobs:
+    automerge:
+        runs-on: ubuntu-latest
+
+        # Run only when the PR’s author is Dependabot
+        if: github.event.pull_request.user.login == 'dependabot[bot]'
+
+        steps:
+            - name: Check if the review is an approval
+              id: approval
+              run: |
+                  if [ "${{ github.event.review.state }}" = "approved" ]; then
+                    echo "approved=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "approved=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Enable auto-merge (squash)
+              if: steps.approval.outputs.approved == 'true'
+              uses: peter-evans/enable-pull-request-automerge@v3
+              with:
+                  pull-request-number: ${{ github.event.pull_request.number }}
+                  merge-method: squash


### PR DESCRIPTION
Just a quick PR to enable auto-merge for dependabot PRs. Note that the way I implemented this now is quite limited/restrictive in terms of the actions that trigger this workflow: it will only run when a review is submitted. This means that this thing is only going to work when the PR is green and then you approve, and not if you approve first and then changes are added to the PR. But I actually think this is probably what we want anyway and since we have this setting that requires us to re-review after any changes, I think it will basically cover 100% of cases.