### PR TITLE
chore: add additional workflow trigger

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,35 +1,22 @@
-name: 'Dependabot Auto-Merge on Approval'
+name: 'Enable auto-merge for Dependabot PRs'
 
 on:
-    pull_request_review:
-        types:
-            - submitted
     pull_request:
-        types: [synchronize]
+        types: [opened, reopened, synchronize]
 
 permissions:
     pull-requests: write
     contents: write
 
 jobs:
-    automerge:
+    enable-automerge:
         runs-on: ubuntu-latest
 
-        # Run only when the PR’s author is Dependabot
+        # Only run on Dependabot PRs
         if: github.event.pull_request.user.login == 'dependabot[bot]'
 
         steps:
-            - name: Check if the review is an approval
-              id: approval
-              run: |
-                  if [ "${{ github.event.review.state }}" = "approved" ]; then
-                    echo "approved=true" >> $GITHUB_OUTPUT
-                  else
-                    echo "approved=false" >> $GITHUB_OUTPUT
-                  fi
-
             - name: Enable auto-merge (squash)
-              if: steps.approval.outputs.approved == 'true'
               uses: peter-evans/enable-pull-request-automerge@v3
               with:
                   pull-request-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
I noticed yesterday that this workflow wasn't working very well for typical workflows where we need to approve several dependabot PRs and then update the other branches. I tried to initially solve this by adding more triggers (when the workflow runs), but this started to make things quite complicated because we would then need to read the same things (PR ID) from different event payloads. Later on I reached a critical realisation: this workflow does not actually merge the PR, it just programatically "checks the enabale-automerge option on the PR". And when this option is enabled the merge does not happen until all conditions are met, so the PR:
- is up-to-date with master 
- has received an approval (and this approval has not been invalidated by a new commit)
- all checks have passed

So the workflow should just enable auto-merge for all dependabot PRs and only run on triggers that invalidate the "enabled auto-merge". It should not check any conditions, because that's built into the auto-merge feature itself.

As such I believe the cvurrent version of the workflow is more simple and more correct.

However, trying to merge a bunch of dependabot PRs can still feel a bit sluggish for the following reason:
- PR A gets merged and now PR B is out-of-date with master
- PR B cannot be merged because it is out-of-date, so you need to update PR B which happens via a commit
- Because there has been a new commit, the PR needs re-approval

This means that in practice, when you have multiple dependabot PRs, you will have to keep going back to the various PRs and click update and then approve. This can't really be solved via a workflow since it is a consequence of our branch protection rules.

So in practice, the only thing this rule adds is to avoid clicking the the "enable auto-merge" button yourself.