### PR TITLE
chore: allow submitting by hitting enter

### DIFF
--- a/src/components/options/options-modal.tsx
+++ b/src/components/options/options-modal.tsx
@@ -21,6 +21,8 @@ type OptionsModalProps = {
     visType: VisualizationType
 }
 
+const FORM_ID = 'options-modal-form'
+
 export const OptionsModal: FC<OptionsModalProps> = ({
     activeSectionKey,
     setActiveSectionKey,
@@ -54,10 +56,12 @@ export const OptionsModal: FC<OptionsModalProps> = ({
                         </Tab>
                     ))}
                 </TabBar>
-                <OptionsSectionContent
-                    sectionKey={activeSectionKey}
-                    visType={visType}
-                />
+                <form onSubmit={updateVisualizationAndClose} id={FORM_ID}>
+                    <OptionsSectionContent
+                        sectionKey={activeSectionKey}
+                        visType={visType}
+                    />
+                </form>
             </ModalContent>
             <ModalActions dataTest={'options-modal-actions'}>
                 <ButtonStrip>
@@ -70,9 +74,9 @@ export const OptionsModal: FC<OptionsModalProps> = ({
                         {i18n.t('Hide')}
                     </Button>
                     <Button
-                        onClick={updateVisualizationAndClose}
                         dataTest={'options-modal-action-confirm'}
-                        type="button"
+                        form={FORM_ID}
+                        type="submit"
                         primary
                     >
                         {i18n.t('Update')}


### PR DESCRIPTION
Implements [DHIS2-20515](https://dhis2.atlassian.net/browse/DHIS2-20515)

### Description

I tried various things to improve keyboard support, but ended up just going with this very simple change. All it does is allow the form to be submitted using the enter key as well as by hitting the submit button. Making this form fully usable by keyboard would require a lot of work in the UI library.

There are a lot fo issues there:
- The `TabBar` will select the first tab when you simply try to "tab over it".
- The select fields do not allow item selection for the options

So I just tried to keep things as simple as possible while adding a little bit of convience
---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---


[DHIS2-20515]: https://dhis2.atlassian.net/browse/DHIS2-20515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ