### PR TITLE
fix: pass a stable function to `useDebounceCallback`

### DIFF
--- a/src/components/main-sidebar/use-resizable-sidebar.ts
+++ b/src/components/main-sidebar/use-resizable-sidebar.ts
@@ -25,10 +25,14 @@ export const useResizableSidebar = () => {
     const containerRef = useRef<HTMLDivElement>(null)
     const startEdgePosRef = useRef(0)
 
-    const syncToStore = useDebounceCallback((value: number) => {
-        setMainSidebarWidthToLocalStorage(value)
-        dispatch(setUiMainSidebarWidth(value))
-    }, MAIN_SIDEBAR_DEBOUNCE_DELAY)
+    const onSync = useCallback(
+        (value: number) => {
+            setMainSidebarWidthToLocalStorage(value)
+            dispatch(setUiMainSidebarWidth(value))
+        },
+        [dispatch]
+    )
+    const syncToStore = useDebounceCallback(onSync, MAIN_SIDEBAR_DEBOUNCE_DELAY)
 
     // Re-clamp on window resize (handles monitor switches, window resizing)
     const onWindowResize = useDebounceCallback(() => {


### PR DESCRIPTION
Implements: No JIRA ticket available

### Description

The callback passed to useDebounceCallback was an inline function, so usehooks-ts rebuilt a fresh lodash.debounce instance on every render. So old pending timeouts never got cancelled. Also syncToStore's identity changing every render caused the useEffect([width, syncToStore]) to re-fire on unrelated re-renders

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---
