### PR TITLE
fix: adjust analytics requests logic for LL

### DIFF
--- a/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
+++ b/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
@@ -287,7 +287,6 @@ describe('MetadataStore', () => {
               "dimensionType": "USER",
               "id": "createdBy",
               "name": "Created by",
-              "valueType": "USERNAME",
             },
             "createdDate": {
               "dimensionId": "createdDate",
@@ -398,7 +397,6 @@ describe('MetadataStore', () => {
               "dimensionType": "USER",
               "id": "lastUpdatedBy",
               "name": "Last updated by",
-              "valueType": "USERNAME",
             },
             "lastUpdatedOn": {
               "dimensionId": "lastUpdatedOn",

--- a/src/components/line-list/use-transformed-line-list-data.ts
+++ b/src/components/line-list/use-transformed-line-list-data.ts
@@ -66,7 +66,7 @@ const getHeaderDimensionId = (
     })
     const idMatch =
         Object.keys(headersMap).find(
-            (key) => headersMap[key] === dimensionId
+            (key) => headersMap[key] === header.name
             // TODO: find a better solution
             // https://dhis2.atlassian.net/browse/DHIS2-20136
         ) ?? ''
@@ -93,7 +93,7 @@ const getHeaderDimensionId = (
             (programId || outputType !== 'TRACKED_ENTITY_INSTANCE')) ||
         ['programStatus', 'eventStatus'].includes(idMatch)
         // org unit only if there's a programId or not tracked entity: this prevents pid.ou from being mixed up with just ou in TE
-        // program status + event status in all cases
+        // program status + event status in all cases XXX: these 2 are not in defaultMetadata ...
     ) {
         defaultMetadata[formattedDimensionId] = getProgramDimensions(
             // TODO: remove initialisation to '' and fix args order in function
@@ -130,18 +130,16 @@ const DATE_VALUE_TYPES: ValueType[] = ['DATE', 'DATETIME']
 
 const getFormattedCellValue = ({
     value,
-    dimensionId,
     header,
     visualization,
 }: {
     value: string
-    dimensionId: string
     header: LineListAnalyticsDataHeader
     visualization: CurrentVisualization
 }) => {
     if (
         header.name &&
-        [headersMap.eventStatus, headersMap.programStatus].includes(dimensionId)
+        [headersMap.eventStatus, headersMap.programStatus].includes(header.name)
     ) {
         return getStatusNames()[value] ?? value
     }
@@ -156,7 +154,7 @@ const getFormattedCellValue = ({
                 headersMap.enrollmentDate,
                 headersMap.incidentDate,
                 headersMap.scheduledDate,
-            ].includes(dimensionId)
+            ].includes(header.name)
         ) {
             // override valueType for time dimensions to format the value as date (DHIS2-17855)
             valueType = 'DATE'
@@ -221,7 +219,6 @@ export const transformLineListData = (
         row.map((value, columnIndex) => ({
             formattedValue: getFormattedCellValue({
                 value,
-                dimensionId: headers[columnIndex].dimensionId,
                 header: data.headers[columnIndex],
                 visualization,
             }),

--- a/src/components/main-sidebar/cards-program-with-registration/__tests__/card-enrollment.spec.tsx
+++ b/src/components/main-sidebar/cards-program-with-registration/__tests__/card-enrollment.spec.tsx
@@ -115,7 +115,7 @@ describe('CardEnrollment', () => {
         expect(fixedDimensions).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
-                    id: 'prog1.ou',
+                    id: 'prog1.enrollmentOu',
                     dimensionType: 'ORGANISATION_UNIT',
                 }),
                 expect.objectContaining({
@@ -147,7 +147,7 @@ describe('CardEnrollment', () => {
             fixedDimensions: Array<{ id: string; name: string }>
         }
         const ouDimension = call.fixedDimensions.find(
-            (d) => d.id === 'prog1.ou'
+            (d) => d.id === 'prog1.enrollmentOu'
         )
         expect(ouDimension?.name).toBe('Facility')
     })

--- a/src/components/main-sidebar/cards-program-with-registration/card-enrollment.tsx
+++ b/src/components/main-sidebar/cards-program-with-registration/card-enrollment.tsx
@@ -24,8 +24,8 @@ const getFixedDimensions = (
 ): DimensionMetadataItem[] => {
     return [
         {
-            id: `${program.id}.ou`,
-            dimensionId: 'ou',
+            id: `${program.id}.enrollmentOu`,
+            dimensionId: 'enrollmentOu',
             dimensionType: 'ORGANISATION_UNIT',
             name: program.displayOrgUnitLabel ?? i18n.t('Enrollment org. unit'),
             valueType: 'ORGANISATION_UNIT',

--- a/src/components/main-sidebar/dimension-card/card-metadata.tsx
+++ b/src/components/main-sidebar/dimension-card/card-metadata.tsx
@@ -24,7 +24,6 @@ const getFixedDimensions = (): DimensionMetadataItem[] => [
         dimensionId: 'lastUpdatedBy',
         name: i18n.t('Last updated by'),
         dimensionType: 'USER',
-        valueType: 'USERNAME',
     },
     {
         id: 'created',
@@ -38,7 +37,6 @@ const getFixedDimensions = (): DimensionMetadataItem[] => [
         dimensionId: 'createdBy',
         name: i18n.t('Created by'),
         dimensionType: 'USER',
-        valueType: 'USERNAME',
     },
     {
         id: 'completed',

--- a/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
@@ -1,4 +1,4 @@
-import { getFullDimensionId, isTimeDimensionId } from '@modules/dimension'
+import { getFullDimensionId } from '@modules/dimension'
 import { getHeadersMap } from '@modules/visualization'
 import type {
     Axis,
@@ -9,6 +9,9 @@ import type {
 import { getRequestOptions } from './query-tools-common'
 import type { ParameterRecord } from './query-tools-common'
 
+const convertToScreamingSnakeCase = (input: string) =>
+    input.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()
+
 const adaptDimensions = (
     dimensions: DimensionArray,
     parameters: ParameterRecord,
@@ -16,35 +19,65 @@ const adaptDimensions = (
 ) => {
     const adaptedDimensions: DimensionArray = []
 
+    // This function should accommodate the various dimension cases and exceptions detailed in the Analytics apis spreadsheet
+
     dimensions.forEach((dimensionObj) => {
         const dimensionId = dimensionObj.dimension
 
-        if (
-            isTimeDimensionId(dimensionId) ||
-            dimensionId === 'eventStatus' ||
-            dimensionId === 'programStatus' ||
-            dimensionId === 'created' ||
-            (dimensionId === 'ou' && outputType === 'TRACKED_ENTITY_INSTANCE')
+        console.log('adapt dim', dimensionId)
+
+        // these are always passed without any prefix
+        if (['completed', 'created', 'lastUpdated'].includes(dimensionId)) {
+            adaptedDimensions.push({
+                ...dimensionObj,
+                dimension: convertToScreamingSnakeCase(dimensionId),
+                program: undefined,
+                programStage: undefined,
+            })
+            // eventDate, eventStatus and sheduledDate have a program or stage id prefixed
+        } else if (
+            ['eventDate', 'eventStatus', 'scheduledDate'].includes(dimensionId)
         ) {
-            if (dimensionObj.items?.length) {
-                const items = dimensionObj.items?.map((item) => item.id)
-                if (
-                    (dimensionId === 'programStatus' ||
-                        isTimeDimensionId(dimensionId)) &&
-                    Array.isArray(parameters[dimensionId])
-                ) {
-                    parameters[dimensionId].push(...items)
-                } else if (dimensionId === 'ou') {
-                    adaptedDimensions.push(dimensionObj)
-                } else {
-                    parameters[dimensionId] = items
-                }
+            adaptedDimensions.push({
+                ...dimensionObj,
+                dimension: convertToScreamingSnakeCase(dimensionId),
+            })
+        } else if (
+            dimensionId === 'programStatus' ||
+            dimensionId === 'enrollmentDate' ||
+            dimensionId === 'incidentDate'
+        ) {
+            const dimension = convertToScreamingSnakeCase(dimensionId)
+
+            if (outputType === 'TRACKED_ENTITY_INSTANCE') {
+                adaptedDimensions.push({
+                    ...dimensionObj,
+                    dimension,
+                })
+            } else {
+                // remove program/programStage for these dimensions for event/enrollment
+                adaptedDimensions.push({
+                    ...dimensionObj,
+                    dimension,
+                    program: undefined,
+                    programStage: undefined,
+                })
             }
+        } else if (dimensionId === 'enrollmentOu') {
+            // enrollmentOu must be passed as ou for ENROLLMENT
+            adaptedDimensions.push({
+                ...dimensionObj,
+                dimension: outputType === 'ENROLLMENT' ? 'ou' : 'ENROLLMENT_OU',
+                program:
+                    outputType === 'TRACKED_ENTITY_INSTANCE'
+                        ? dimensionObj.program
+                        : undefined,
+                programStage: undefined,
+            })
         } else if (
             // "dy" dimension can be present in PT visualizations
-            !['created', 'createdBy', 'lastUpdatedBy', 'dy'].includes(
-                dimensionId
-            )
+            // everything else is a normal dimension id with program/programStage prefix
+            !['createdBy', 'lastUpdatedBy', 'dy'].includes(dimensionId)
         ) {
             adaptedDimensions.push(dimensionObj)
         }
@@ -74,9 +107,18 @@ export const getAdaptedVisualization = (
     const adaptedRows = adaptDimensions(rows, parameters, outputType)
     const adaptedFilters = adaptDimensions(filters, parameters, outputType)
 
-    const dimensionHeadersMap = getHeadersMap(visualization)
+    const baseHeadersMap = getHeadersMap(visualization)
+    const dimensionHeadersMap: Record<string, string> = {
+        ...baseHeadersMap,
+        ...Object.fromEntries(
+            Object.entries(baseHeadersMap).map(([key, value]) => [
+                convertToScreamingSnakeCase(key),
+                value,
+            ])
+        ),
+    }
 
-    const headers = [...columns, ...rows].map(
+    const headers = [...adaptedColumns, ...adaptedRows].map(
         ({ dimension, program, programStage, repetition }) => {
             const programStageId = programStage?.id
 
@@ -103,9 +145,9 @@ export const getAdaptedVisualization = (
 
     return {
         adaptedVisualization: {
-            columns: adaptedColumns,
-            rows: adaptedRows,
-            filters: adaptedFilters,
+            columns: adaptedColumns.filter(({ items }) => items?.length),
+            rows: adaptedRows.filter(({ items }) => items?.length),
+            filters: adaptedFilters.filter(({ items }) => items?.length),
             outputType: outputType,
         },
         headers,

--- a/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
@@ -7,14 +7,12 @@ import type {
     OutputType,
 } from '@types'
 import { getRequestOptions } from './query-tools-common'
-import type { ParameterRecord } from './query-tools-common'
 
 const convertToScreamingSnakeCase = (input: string) =>
-    input.replace(/[A-Z]/g, (c) => `_${c}`).toUpperCase()
+    input.replaceAll(/[A-Z]/g, (c) => `_${c}`).toUpperCase()
 
 const adaptDimensions = (
     dimensions: DimensionArray,
-    parameters: ParameterRecord,
     outputType: OutputType
 ) => {
     const adaptedDimensions: DimensionArray = []
@@ -65,6 +63,7 @@ const adaptDimensions = (
             }
         } else if (dimensionId === 'enrollmentOu') {
             // enrollmentOu must be passed as ou for ENROLLMENT
+            // program prefix must be removed for EVENT/ENROLLMENT
             adaptedDimensions.push({
                 ...dimensionObj,
                 dimension: outputType === 'ENROLLMENT' ? 'ou' : 'ENROLLMENT_OU',
@@ -77,7 +76,7 @@ const adaptDimensions = (
         } else if (
             // "dy" dimension can be present in PT visualizations
             // everything else is a normal dimension id with program/programStage prefix
-            !['createdBy', 'lastUpdatedBy', 'dy'].includes(dimensionId)
+            !['dy'].includes(dimensionId)
         ) {
             adaptedDimensions.push(dimensionObj)
         }
@@ -103,9 +102,9 @@ export const getAdaptedVisualization = (
     const rows = visualization.rows ?? []
     const filters = visualization.filters ?? []
 
-    const adaptedColumns = adaptDimensions(columns, parameters, outputType)
-    const adaptedRows = adaptDimensions(rows, parameters, outputType)
-    const adaptedFilters = adaptDimensions(filters, parameters, outputType)
+    const adaptedColumns = adaptDimensions(columns, outputType)
+    const adaptedRows = adaptDimensions(rows, outputType)
+    const adaptedFilters = adaptDimensions(filters, outputType)
 
     const baseHeadersMap = getHeadersMap(visualization)
     const dimensionHeadersMap: Record<string, string> = {
@@ -145,6 +144,7 @@ export const getAdaptedVisualization = (
 
     return {
         adaptedVisualization: {
+            // only pass dimensions with conditions
             columns: adaptedColumns.filter(({ items }) => items?.length),
             rows: adaptedRows.filter(({ items }) => items?.length),
             filters: adaptedFilters.filter(({ items }) => items?.length),

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -83,9 +83,11 @@ const fetchAnalyticsDataForLL = async ({
     sortField,
     sortDirection,
     displayProperty,
-}) => {
+}: FetchAnalyticsDataForLLParams) => {
     const { adaptedVisualization, headers, parameters } =
         getAdaptedVisualization(visualization)
+
+    console.log('adaptedVisualization', adaptedVisualization)
 
     let req = new analyticsEngine.request()
         .fromVisualization(adaptedVisualization)
@@ -97,24 +99,37 @@ const fetchAnalyticsDataForLL = async ({
                 : {}),
             ...parameters,
         })
-        .withDisplayProperty(displayProperty.toUpperCase())
         .withPageSize(pageSize)
         .withPage(page)
         .withIncludeMetadataDetails()
 
+    if (displayProperty) {
+        req = req.withDisplayProperty(displayProperty.toUpperCase())
+    }
+
     // trackedEntity request can use multiple programs
     if (visualization.outputType !== 'TRACKED_ENTITY_INSTANCE') {
-        req = req
-            .withProgram(visualization.program.id)
-            .withOutputType(visualization.outputType)
+        // TODO: replace with getSingleProgramFromVisualization fn
+        const programId = visualization.programDimensions?.at(0)?.id
+
+        req = req.withOutputType(visualization.outputType)
+
+        if (programId) {
+            req = req.withProgram(programId)
+        }
     }
 
     if (visualization.outputType === 'EVENT') {
+        // TODO: replace with getSingleProgramStageFromVisualization fn
         req = req.withStage(visualization.programStage?.id)
     }
 
     if (visualization.outputType === 'TRACKED_ENTITY_INSTANCE') {
-        req = req.withTrackedEntityType(visualization.trackedEntityType.id)
+        const trackedEntityTypeId = visualization.trackedEntityType?.id
+
+        if (trackedEntityTypeId) {
+            req = req.withTrackedEntityType(trackedEntityTypeId)
+        }
     }
 
     if (relativePeriodDate && isVisualizationWithTimeDimension(visualization)) {
@@ -334,6 +349,17 @@ export type OnAnalyticsResponseReceivedCb = (
     headers: Array<LineListAnalyticsDataHeader>
 ) => void
 
+type FetchAnalyticsDataForLLParams = {
+    analyticsEngine: ReturnType<typeof Analytics.getAnalytics>
+    visualization: CurrentVisualization
+    pageSize: number
+    page: number
+    relativePeriodDate: unknown
+    sortField: string | undefined
+    sortDirection: 'ASC' | 'DESC' | undefined
+    displayProperty: CurrentUser['settings']['displayProperty']
+}
+
 type FetchAnalyticsDataParams = {
     visualization: CurrentVisualization
     filters?: Record<string, unknown>
@@ -383,6 +409,7 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
                     : { dimension: undefined, direction: undefined }
 
             try {
+                console.log('in fetch analytics data try')
                 const analyticsResponse = await fetchAnalyticsDataForLL({
                     analyticsEngine,
                     page,
@@ -460,6 +487,7 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
 
                 onResponseReceived(analyticsResponse.metaData.items, headers)
             } catch (error) {
+                console.log('fetch LL data error', error)
                 setState({
                     data: null,
                     error,

--- a/src/components/plugin-wrapper/line-list-plugin.tsx
+++ b/src/components/plugin-wrapper/line-list-plugin.tsx
@@ -95,6 +95,7 @@ export const LineListPlugin: FC<LineListPluginProps> = ({
     )
 
     useEffect(() => {
+        console.log('fetch analytics data')
         fetchAnalyticsData({
             visualization: transformVisualization(eventVisualization),
             filters,

--- a/src/constants/dimensions.ts
+++ b/src/constants/dimensions.ts
@@ -15,11 +15,13 @@ export const YOUR_DIMENSION_TYPES = asStringLiteralSubsetArray<DimensionType>()(
 )
 
 export const DIMENSION_IDS = [
+    'completed',
     'completedDate',
     'created',
     'createdBy',
     'createdDate',
     'enrollmentDate',
+    'enrollmentOu',
     'eventDate',
     'eventStatus',
     'incidentDate',
@@ -34,8 +36,8 @@ export const DIMENSION_IDS = [
 export const DIMENSION_ID_ORGUNIT: DimensionId = 'ou'
 
 export const TIME_DIMENSION_IDS = [
-    'completedDate',
-    'createdDate',
+    'completedDate', // XXX: is this a thing? or should it be completed
+    'createdDate', // XXX: same for this one
     'enrollmentDate',
     'eventDate',
     'incidentDate',

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -159,13 +159,29 @@ export const getFullDimensionId = ({
     programStageId,
     outputType,
 }: GetFullDimensionIdParams): string => {
-    return [
-        outputType === 'TRACKED_ENTITY_INSTANCE' ? programId : undefined,
-        programStageId,
-        dimensionId,
-    ]
-        .filter(Boolean)
-        .join('.')
+    if (dimensionId === 'created') {
+        return dimensionId
+    } else if (
+        outputType !== 'TRACKED_ENTITY_INSTANCE' &&
+        [
+            'completed',
+            'enrollmentdate',
+            'enrollmentouname',
+            'incidenddate',
+            'lastupdated',
+            'programstatus',
+        ].includes(dimensionId)
+    ) {
+        return dimensionId
+    } else {
+        return [
+            outputType === 'TRACKED_ENTITY_INSTANCE' ? programId : undefined,
+            programStageId,
+            dimensionId,
+        ]
+            .filter(Boolean)
+            .join('.')
+    }
 }
 
 type DimensionRecordObject = Partial<Record<DimensionId, DimensionMetadataItem>>

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -219,14 +219,12 @@ export const getMainDimensions = (
         dimensionId: 'createdBy',
         dimensionType: 'USER',
         name: i18n.t('Created by'),
-        valueType: 'USERNAME',
     },
     lastUpdatedBy: {
         id: 'lastUpdatedBy',
         dimensionId: 'lastUpdatedBy',
         dimensionType: 'USER',
         name: i18n.t('Last updated by'),
-        valueType: 'USERNAME',
     },
 })
 

--- a/src/modules/layout.ts
+++ b/src/modules/layout.ts
@@ -3,7 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import { getDimensionIdParts } from '@modules/dimension'
 import { parseUiRepetitions } from '@modules/repetitions'
 import type { VisUiConfigState } from '@store/vis-ui-config-slice'
-import type { Axis, Layout } from '@types'
+import type { Axis, Layout, MetadataStore, Program } from '@types'
 
 export const getAxisName = (axisId: Axis): string => getAxisNames()[axisId]
 
@@ -70,3 +70,25 @@ export const formatLayoutForVisualization = (visUiConfig: VisUiConfigState) =>
         }),
         {}
     )
+
+export const formatProgramDimensionsForVisualization = (
+    visUiConfig: VisUiConfigState,
+    metadataStore: MetadataStore
+) =>
+    Object.values(visUiConfig.layout)
+        .flat()
+        .reduce<Program[]>((programDimensions, dimensionId) => {
+            const programId =
+                metadataStore.getDimensionMetadataItem(dimensionId)?.programId
+
+            if (programId) {
+                const programMetadata =
+                    metadataStore.getProgramMetadataItem(programId)
+
+                if (programMetadata) {
+                    programDimensions.push(programMetadata)
+                }
+            }
+
+            return programDimensions
+        }, [])

--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -7,7 +7,7 @@ import {
 import i18n from '@dhis2/d2-i18n'
 import { initialState as currentVisDefaultValue } from '@store/current-vis-slice'
 import { initialState as savedVisDefaultValue } from '@store/saved-vis-slice'
-import type { LastActiveButton } from '@store/vis-ui-config-slice'
+import { type LastActiveButton } from '@store/vis-ui-config-slice'
 import type {
     DimensionArray,
     CurrentVisualization,
@@ -42,6 +42,7 @@ export const headersMap: Record<DimensionId, string> = {
     ou: 'ouname',
     programStatus: 'programstatus',
     eventStatus: 'eventstatus',
+    completed: 'completed',
     completedDate: 'completeddate',
     created: 'created',
     createdBy: 'createdbydisplayname',
@@ -50,20 +51,25 @@ export const headersMap: Record<DimensionId, string> = {
     lastUpdatedOn: 'lastupdatedon', // XXX: needed here? is this used also in LL?
     eventDate: 'eventdate',
     enrollmentDate: 'enrollmentdate',
+    enrollmentOu: 'enrollmentouname',
     incidentDate: 'incidentdate',
     scheduledDate: 'scheduleddate',
     lastUpdated: 'lastupdated',
 }
 
-export const getHeadersMap = ({
-    showHierarchy,
-}: {
-    showHierarchy?: boolean
-}): Record<DimensionId, string> => {
+export const getHeadersMap = (
+    visualization: CurrentVisualization
+): Record<DimensionId, string> => {
+    const { outputType, showHierarchy } = visualization
+
     const map = Object.assign({}, headersMap)
 
     if (showHierarchy) {
         map['ou'] = 'ounamehierarchy'
+    }
+
+    if (outputType === 'ENROLLMENT') {
+        map['enrollmentOu'] = 'ouname'
     }
 
     return map

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -1,7 +1,10 @@
 import type { ThunkExtraArg } from '@api/custom-base-query'
 import { eventVisualizationsApi } from '@api/event-visualizations-api'
 import { extractDataSourceIdFromVisualization } from '@modules/data-source'
-import { formatLayoutForVisualization } from '@modules/layout'
+import {
+    formatLayoutForVisualization,
+    formatProgramDimensionsForVisualization,
+} from '@modules/layout'
 import { getDisabledOptions } from '@modules/options'
 import {
     getVisualizationUiConfig,
@@ -99,7 +102,7 @@ export const tLoadSavedVisualization = createAsyncThunk<
 )
 
 export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
-    () => (dispatch, getState) => {
+    () => (dispatch, getState, extra) => {
         const { currentVis, visUiConfig } = getState()
 
         const mergedVis = deepmerge(
@@ -118,6 +121,8 @@ export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
             ...mergedVis,
             // visualization type
             type: visUiConfig.visualizationType,
+            // output type
+            outputType: visUiConfig.outputType,
             // custom value and aggregation
             ...(visUiConfig.customValue && {
                 value: {
@@ -127,6 +132,11 @@ export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
             }),
             // columns/rows/filters from visUiConfig.layout
             ...formatLayoutForVisualization(visUiConfig),
+            // programDimensions from visUiConfig.layout + metadataStore
+            programDimensions: formatProgramDimensionsForVisualization(
+                visUiConfig,
+                extra.metadataStore
+            ),
         }
 
         dispatch(setCurrentVis(updatedCurrentVis))


### PR DESCRIPTION
Implements [DHIS2-XXXX](https://dhis2.atlassian.net/browse/DHIS2-XXXX)

### Description

The way the analytics request is constructed is different in EVER compared to LL.
The PR addresses the differences and new things according to the spreadsheet.

The main difference is that all dimensions with no conditions are not added as `dimension` parameters or "standalone" parameters. For those situations only `headers` is passed in the request.
For dimensions with conditions applied, `dimension` parameters are added for all dimensions (before some dimensions where passed as "standalone" parameters).

This PR has fixes also for the aggregate (PT) requests.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [ ] Dashboard tested
- [ ] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

<img width="844" height="347" alt="Screenshot 2026-04-20 at 13 49 12" src="https://github.com/user-attachments/assets/0350a1c2-4d9f-4a5a-bbe2-63a57b42fa8d" />

