### PR TITLE
chore: read tet id via org unit dimension

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -502,18 +502,18 @@ dates, statuses). They are built by shared helpers in `src/modules/dimension.ts`
 (`getStageFixedDimensions`, `getEnrollmentFixedDimensions`, `getTrackedEntityTypeFixedDimensions`)
 and consumed by both the sidebar cards and the metadata provider.
 
-| Scope      | Dimension ID     | Compound ID notation          | Display name source                                          | Sidebar card |
-| ---------- | ---------------- | ----------------------------- | ------------------------------------------------------------ | ------------ |
-| Stage      | `ou`             | `stageId.ou`                  | `program.displayOrgUnitLabel` or "Event org. unit"           | Stage        |
-| Stage      | `eventDate`      | `stageId.eventDate`           | `stage.displayExecutionDateLabel` or "Event date"            | Stage        |
-| Stage      | `scheduledDate`  | `stageId.scheduledDate`       | `stage.displayDueDateLabel` or "Scheduled date"              | Stage        |
-| Stage      | `eventStatus`    | `stageId.eventStatus`         | "Event status"                                               | Stage        |
-| Enrollment | `ou`             | `programId.ou`                | `program.displayOrgUnitLabel` or "Enrollment org. unit"      | Enrollment   |
-| Enrollment | `enrollmentDate` | `programId.enrollmentDate`    | `program.displayEnrollmentDateLabel` or "Date of enrollment" | Enrollment   |
-| Enrollment | `incidentDate`   | `programId.incidentDate`      | `program.displayIncidentDateLabel` or "Incident date"        | Enrollment   |
-| Enrollment | `programStatus`  | `programId.programStatus`     | "Enrollment status"                                          | Enrollment   |
-| TEI        | `ou`             | `trackedEntityTypeId.ou`      | "Registration org. unit"                                     | Registration |
-| TEI        | `created`        | `trackedEntityTypeId.created` | "Registration date"                                          | Registration |
+| Scope      | Dimension ID     | Compound ID notation               | Display name source                                          | Sidebar card |
+| ---------- | ---------------- | ---------------------------------- | ------------------------------------------------------------ | ------------ |
+| Stage      | `ou`             | `stageId.ou`                       | `program.displayOrgUnitLabel` or "Event org. unit"           | Stage        |
+| Stage      | `eventDate`      | `stageId.eventDate`                | `stage.displayExecutionDateLabel` or "Event date"            | Stage        |
+| Stage      | `scheduledDate`  | `stageId.scheduledDate`            | `stage.displayDueDateLabel` or "Scheduled date"              | Stage        |
+| Stage      | `eventStatus`    | `stageId.eventStatus`              | "Event status"                                               | Stage        |
+| Enrollment | `ou`             | `programId.ou`                     | `program.displayOrgUnitLabel` or "Enrollment org. unit"      | Enrollment   |
+| Enrollment | `enrollmentDate` | `programId.enrollmentDate`         | `program.displayEnrollmentDateLabel` or "Date of enrollment" | Enrollment   |
+| Enrollment | `incidentDate`   | `programId.incidentDate`           | `program.displayIncidentDateLabel` or "Incident date"        | Enrollment   |
+| Enrollment | `programStatus`  | `programId.programStatus`          | "Enrollment status"                                          | Enrollment   |
+| TEI        | `enrollmentOu`   | `trackedEntityTypeId.enrollmentOu` | "Registration org. unit"                                     | Registration |
+| TEI        | `created`        | `trackedEntityTypeId.created`      | "Registration date"                                          | Registration |
 
 Non-fixed dimensions use compound or plain IDs depending on their type:
 
@@ -541,26 +541,35 @@ compound ID from a `DimensionRecord`. It applies these rules in order:
   `toAppLocalDimensions` renames API `ou` (with program, no programStage) to `enrollmentOu`
   at the API → app-local boundary. `toApiDimensionId` does the inverse on save — but only
   in some outputType/visType combinations (see table below).
-- **Registration org unit**: `ou` with `trackedEntityType` → compound `tetId.ou`
+- **Registration org unit**: `enrollmentOu` with `trackedEntityType` (no program/stage) →
+  compound `tetId.enrollmentOu`. The TEI registration OU shares the `enrollmentOu` dimension
+  ID with the program-scope enrollment OU; the prefix (programId vs trackedEntityTypeId)
+  distinguishes them.
 
-**`enrollmentOu` POST translation by outputType/visType**: the eventVisualizations POST
-endpoint accepts `enrollmentOu` verbatim for some combinations and requires plain `ou` for
-others. `toApiDimensionId` applies this mapping on save:
+**`enrollmentOu` POST translation by outputType/visType/scope**: the eventVisualizations
+POST endpoint accepts `enrollmentOu` verbatim only when the dim carries a program qualifier
+AND the visualization is in EVENT/TEI LINE_LIST mode. Other combinations — including the
+TEI registration OU, which has no program qualifier — must be sent as bare `ou`.
+`toEventVisualizationDimensionId` applies this mapping on save:
 
-| outputType                | visType       | POST dimension | Rewrite `enrollmentOu` → `ou`? |
-| ------------------------- | ------------- | -------------- | ------------------------------ |
-| `EVENT`                   | `LINE_LIST`   | `enrollmentOu` | no                             |
-| `ENROLLMENT`              | `LINE_LIST`   | `ou`           | yes                            |
-| `TRACKED_ENTITY_INSTANCE` | `LINE_LIST`   | `enrollmentOu` | no                             |
-| `EVENT`                   | `PIVOT_TABLE` | `ou`           | yes                            |
-| `ENROLLMENT`              | `PIVOT_TABLE` | `ou`           | yes                            |
+| outputType                | visType       | dim has `programId`? | POST dimension | Rewrite `enrollmentOu` → `ou`? |
+| ------------------------- | ------------- | -------------------- | -------------- | ------------------------------ |
+| `EVENT`                   | `LINE_LIST`   | yes                  | `enrollmentOu` | no                             |
+| `ENROLLMENT`              | `LINE_LIST`   | yes                  | `ou`           | yes                            |
+| `TRACKED_ENTITY_INSTANCE` | `LINE_LIST`   | yes (program-scope)  | `enrollmentOu` | no                             |
+| `TRACKED_ENTITY_INSTANCE` | `LINE_LIST`   | no (registration)    | `ou`           | yes                            |
+| `EVENT`                   | `PIVOT_TABLE` | yes                  | `ou`           | yes                            |
+| `ENROLLMENT`              | `PIVOT_TABLE` | yes                  | `ou`           | yes                            |
 
-Rule: rewrite to `ou` when `outputType === 'ENROLLMENT'` OR `visType === 'PIVOT_TABLE'`.
-Keep as `enrollmentOu` otherwise (i.e. `LINE_LIST` with `EVENT` or `TRACKED_ENTITY_INSTANCE`).
+Rule: rewrite to `ou` when the dim has no `programId` (i.e. TEI registration scope)
+OR `outputType === 'ENROLLMENT'` OR `visType === 'PIVOT_TABLE'`. Keep as `enrollmentOu`
+only for program-scope dims in `EVENT`/`TRACKED_ENTITY_INSTANCE` `LINE_LIST`.
 
-The reverse (load) direction does not need the same conditional — `toAppLocalDimensions`
-keys purely on the shape `dim.dimension === 'ou' && dim.program && !dim.programStage`, which
-catches the three `ou`-cases and leaves the two `enrollmentOu`-cases untouched.
+The reverse (load) direction is shape-based — `toAppLocalDimensions` rewrites
+`dim.dimension === 'ou' && !dim.programStage` to `enrollmentOu`. This catches both
+program-scope (`{dimension: 'ou', program: {id}}`) and TEI registration
+(`{dimension: 'ou'}`, no program/stage) and leaves stage event OU
+(`{dimension: 'ou', programStage: {id}}`) untouched.
 
 ### Save/load translation at the visualization API boundary
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,13 @@ This is a DHIS2 Event Visualizer application built with React, TypeScript, Vite,
 - **Linting/Formatting**: ESLint, Prettier, Stylelint via `@dhis2/cli-style`
 - **i18n**: DHIS2 i18n utilities for internationalization
 
+### Project Stage
+
+This is an unreleased app under active development. Some defaults that suit stable codebases are loosened:
+
+- **Refactor freely when it improves clarity or reduces tech debt**, even outside the strict scope of the current task. Scope creep is fine here.
+- **Keep README and other documentation in sync with code changes**: when you change behavior, structure, or setup steps, update the relevant docs in the same change rather than waiting for an explicit ask.
+
 ## DHIS2 App Shell Structure
 
 This is a DHIS2 "App Shell App" with a special build structure:
@@ -153,6 +160,9 @@ pnpm generate-types # Regenerate DHIS2 API types from OpenAPI specs
 - **CSS Modules**: kebab-case (e.g., `event-chart.module.css`)
 
 ### Testing Guidelines
+
+- **Test behavior, not implementation details**: assert on what callers observe, not on private state, internal call sequences, or how a result was produced.
+- **Cover new functionality**: when adding or changing logic, add tests in the same change — including edge cases and error conditions, not just the happy path.
 
 #### Unit Tests (Vitest)
 
@@ -596,296 +606,26 @@ reference them.
 
 ## Testing & Linting Workflow for AI Agents
 
-**Golden Rule**: When building a solution, test and lint **specific files only**. When finishing, always run **full project validation** with `pnpm test` and `pnpm lint`.
+**Golden rule**: during development, lint/test only the files you touched. Before finishing, always run `pnpm test` and `pnpm lint`.
 
-### During Development (File-Specific Commands)
+### Per-file commands (during development)
 
-Use these commands when actively working on code to get fast feedback:
+- **Vitest**: `pnpm exec vitest run <file-path>`
+- **ESLint**: `pnpm exec eslint <file-path>` (add `--fix` to auto-fix)
+- **Stylelint**: `pnpm exec stylelint <file-path> --max-warnings=0` (add `--fix` to auto-fix)
+- **Prettier**: `pnpm exec prettier --write <file-path>`
 
-#### Testing Individual Files
+ESLint, Stylelint, and Prettier run automatically via PostToolUse hooks after Edit/Write. Files modified via Bash are **not** auto-formatted — run Prettier manually after.
 
-```bash
-pnpm exec vitest run <file-path>
-# Example: pnpm exec vitest run src/hooks/useEventData.spec.ts
-```
+### TypeScript
 
-#### Linting Individual Files
+File-specific `tsc` is not possible (path aliases, project references). Use the `typescript-lsp` plugin for diagnostics, or run `./scripts/check-typescript.sh` (covers both `tsconfig.json` and `cypress/tsconfig.json`).
 
-**TypeScript Checking**
-
-**Primary: LSP Plugin** — The `typescript-lsp` plugin provides automatic TypeScript diagnostics after every file edit, with full project context (path aliases, multiple tsconfig files). This is the fastest and most accurate method. See [Claude Code Setup](#claude-code-setup) for installation.
-
-**Fallback: Project-wide CLI** — If the LSP plugin is not installed, use:
+### Before finishing
 
 ```bash
-./scripts/check-typescript.sh
-# Or directly:
-pnpm exec tsc --project tsconfig.json --noEmit --skipLibCheck
-pnpm exec tsc --project cypress/tsconfig.json --noEmit --skipLibCheck
+pnpm test     # all unit tests
+pnpm lint     # ESLint, Stylelint, Prettier, TypeScript, ls-lint
 ```
 
-File-specific `tsc` checking is **not possible** due to path aliases and project references.
-
-**ESLint, Stylelint, and Prettier**
-
-These are handled **automatically by PostToolUse hooks** (configured in `.claude/settings.json`). After every Edit/Write, the hook runs Prettier auto-fix and the relevant linter for the file type. Always check the hook output for errors. Note that the hook only runs after Edit/Write tool calls — files modified via Bash are **not** auto-formatted. If you use Bash to write or modify a file, you must run `pnpm exec prettier --write <file>` manually afterward.
-
-If you need to run them manually (e.g., for debugging):
-
-```bash
-pnpm exec eslint <file-path>                    # Check only
-pnpm exec eslint <file-path> --fix              # Fix automatically
-```
-
-**Secondary: LSP Diagnostics** - NeoVim LSP may show ESLint errors, but OpenCode's LSP integration may filter them. CLI commands are more reliable.
-
-**Rationale**: CLI commands are more reliable and complete than LSP for ESLint.
-
-**Stylelint Checking**
-
-**Primary: File-specific CLI** - Always use CLI commands:
-
-```bash
-pnpm exec stylelint <file-path> --max-warnings=0         # Check only
-pnpm exec stylelint <file-path> --fix --max-warnings=0   # Fix automatically
-```
-
-**Rationale**: CLI commands ensure consistent and complete Stylelint checking.
-
-**Prettier Formatting**
-
-**Primary: File-specific CLI**:
-
-```bash
-pnpm exec prettier --check <file-path>          # Check formatting
-pnpm exec prettier --write <file-path>          # Format automatically
-```
-
-**Rationale**: CLI commands ensure consistent formatting.
-
-**File Type Specific Instructions**:
-
-**TypeScript/TSX files** (`.ts`, `.tsx`):
-
-- **TypeScript**: LSP diagnostics (automatic when reading/editing)
-- **ESLint**: Use file-specific CLI commands
-- **Prettier**: Use file-specific CLI commands
-
-**CSS/SCSS files** (`.css`):
-
-- **Stylelint**: Use file-specific CLI commands
-- **Prettier**: Use file-specific CLI commands
-
-**Other formats** (`.json`, `.md`, `.yml`, `.yaml`):
-
-- **Prettier**: Use file-specific CLI commands
-
-### After Completing Work (Project-Wide Commands)
-
-**Always run these before finishing, regardless of how small the change was** (even for non-code files like `.md`, `.json`, `.yml`):
-
-```bash
-pnpm test          # Run all unit tests (vitest)
-pnpm lint          # Run all linters (ESLint, Stylelint, Prettier, TypeScript, ls-lint)
-```
-
-If there are failures, many can be fixed automatically using `pnpm format`:
-
-```bash
-pnpm format        # Auto-fix formatting and auto-fixable lint issues
-```
-
-After running `pnpm format`, run `pnpm lint` again to verify all issues are resolved. Note that `pnpm format` can resolve:
-
-- Prettier formatting issues (indentation, spacing, quotes, etc.)
-- Auto-fixable ESLint issues (marked with wrench 🔧 icon in ESLint output)
-- Auto-fixable Stylelint issues
-
-Some errors require manual fixes (e.g., type errors, logic issues, certain lint violations).
-
-**Note on TypeScript**: The project has two TypeScript configurations:
-
-- `tsconfig.json` - Main configuration for src files with path aliases
-- `cypress/tsconfig.json` - Configuration for Cypress tests
-
-The `pnpm lint` command checks both configurations. Individual file TypeScript checking via `pnpm exec tsc` is not recommended as it lacks the full project context (path aliases, project references). Use `./scripts/check-typescript.sh` or LSP diagnostics instead.
-
-### Decision Tree
-
-**While working on a solution**:
-
-- Modified 1-3 files → Use file-specific `pnpm exec` commands for each file
-- Need to fix formatting → Use `pnpm exec prettier --write <file-path>` or `pnpm exec eslint <file-path> --fix`
-- Modified many files → Use `pnpm lint` and `pnpm test`
-
-**When finishing a task**:
-
-- Always run `pnpm test` (ensures all tests pass)
-- Always run `pnpm lint` (ensures code quality across project)
-- If lint fails with formatting issues → Run `pnpm format` then `pnpm lint` again
-
-### Common Pitfalls to Avoid
-
-- ❌ **Don't** run `pnpm test` and `pnpm lint` after every small change (wastes time)
-- ❌ **Don't** use `pnpm exec eslint .` when you only changed one file
-- ❌ **Don't** forget to run full `pnpm test` and `pnpm lint` when finishing
-- ✅ **Do** prefer LSP diagnostics for TypeScript checking (fastest with full context)
-- ✅ **Do** use file-specific CLI commands for ESLint and Stylelint (more reliable than LSP)
-- ✅ **Do** run project-wide commands as final validation
-- ✅ **Do** use `pnpm exec prettier --write` to quickly fix formatting issues
-
----
-
-# General Guidelines
-
-## General Principles
-
-### Code Quality
-
-- Write clean, readable, and maintainable code
-- Follow established patterns and conventions for each language/framework
-- Prefer simplicity over complexity
-- Use meaningful and descriptive names for variables, functions, and files
-- Write self-documenting code when possible
-
-### Project Structure
-
-- Organize code logically by feature or domain
-- Keep related files close together
-- Separate concerns appropriately
-- Maintain a consistent directory structure within the project
-- Use clear separation between source code, tests, configuration, and build artifacts
-
-### Code Organization
-
-- Keep functions and methods focused on a single responsibility
-- Limit file size to improve readability
-- Group related functionality together
-- Minimize dependencies between modules
-- Use appropriate abstraction levels
-
-## Testing & Quality Assurance
-
-### Testing Principles
-
-- Write tests for new functionality
-- Prefer unit tests for isolated logic
-- Write integration tests for component interactions
-- Write end-to-end tests for critical user journeys
-- Test edge cases and error conditions
-- Avoid testing implementation details
-- Mock external dependencies appropriately
-
-### Quality Practices
-
-- Run tests before committing changes
-- Maintain test coverage for critical paths
-- Use static analysis tools where available
-- Perform code reviews for significant changes
-- Refactor code to improve clarity and maintainability
-
-## Version Control
-
-### Git Best Practices
-
-- Write clear, descriptive commit messages
-- Follow conventional commits when possible
-- Keep commits focused and atomic
-- Use feature branches for new work
-- Regularly sync with remote repositories
-- Use meaningful branch names
-- Review changes before committing
-
-### Collaboration
-
-- Use pull requests for code review
-- Provide context in PR descriptions
-- Request reviews from appropriate team members
-- Address review feedback promptly
-- Keep PRs manageable in size
-
-## Security
-
-### General Security
-
-- Never commit secrets, API keys, or credentials
-- Use environment variables for configuration
-- Validate and sanitize all user input
-- Follow the principle of least privilege
-- Keep dependencies updated to address security vulnerabilities
-- Use secure communication protocols (HTTPS, TLS)
-
-### Data Protection
-
-- Handle sensitive data with care
-- Implement proper authentication and authorization
-- Log security-relevant events appropriately
-- Follow data protection regulations and best practices
-
-## Performance
-
-### Code Performance
-
-- Write efficient algorithms and data structures
-- Avoid unnecessary computations
-- Use appropriate caching strategies
-- Optimize critical paths
-- Profile code to identify bottlenecks
-
-### System Performance
-
-- Minimize resource usage (CPU, memory, disk, network)
-- Implement lazy loading for heavy resources
-- Optimize bundle sizes where applicable
-- Monitor and optimize network requests
-- Use appropriate compression techniques
-
-## Documentation
-
-### Code Documentation
-
-- Document public APIs and complex logic
-- Keep documentation up to date with code changes
-- Use appropriate documentation tools for the language/framework
-- Include examples for complex functionality
-- Document architectural decisions and trade-offs
-
-### Project Documentation
-
-- Maintain current README files
-- Document setup and development procedures
-- Keep architecture diagrams updated
-- Document deployment and operations procedures
-- Maintain changelogs for significant releases
-
-## Development Workflow
-
-### Local Development
-
-- Use consistent development environments
-- Follow project-specific setup instructions
-- Use local development servers where appropriate
-- Test changes thoroughly before committing
-
-### Code Review Process
-
-- Review your own code before submitting
-- Check for common issues and improvements
-- Ensure tests pass and new tests are added
-- Verify compliance with project guidelines
-
-## Maintenance & Operations
-
-### Code Maintenance
-
-- Regularly update dependencies
-- Refactor code to reduce technical debt
-- Remove unused code and dependencies
-- Update documentation alongside code changes
-
-### Operational Considerations
-
-- Design for observability (logging, monitoring, tracing)
-- Implement proper error handling and recovery
-- Consider scalability and performance implications
-- Plan for maintenance and future enhancements
+If lint fails on formatting/auto-fixable issues, run `pnpm format` then re-run `pnpm lint`. Type errors and logic issues require manual fixes.

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-04-20T12:25:49.079Z\n"
-"PO-Revision-Date: 2026-04-20T12:25:49.079Z\n"
+"POT-Creation-Date: 2026-05-05T09:31:10.642Z\n"
+"PO-Revision-Date: 2026-05-05T09:31:10.643Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -498,9 +498,6 @@ msgstr "Event data"
 
 msgid "Program indicators"
 msgstr "Program indicators"
-
-msgid "Registration org. unit"
-msgstr "Registration org. unit"
 
 msgid "{{name}} registration"
 msgstr "{{name}} registration"
@@ -1022,6 +1019,9 @@ msgstr "Date of enrollment"
 
 msgid "Enrollment status"
 msgstr "Enrollment status"
+
+msgid "Registration org. unit"
+msgstr "Registration org. unit"
 
 msgid "Columns"
 msgstr "Columns"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7997,11 +7997,12 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@8.1.1:

--- a/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
@@ -101,8 +101,8 @@ const metadata = {
         dimensionType: 'DATA_ELEMENT',
         valueType: 'DATE',
     },
-    'tei1.ou': {
-        id: 'tei1.ou',
+    'tei1.enrollmentOu': {
+        id: 'tei1.enrollmentOu',
         name: 'Registration org. unit',
         dimensionType: 'DATA_ELEMENT',
         valueType: 'ORGANISATION_UNIT',
@@ -298,7 +298,7 @@ describe('useActionButton for Event button', () => {
                 },
                 visUiConfig: {
                     layout: {
-                        columns: [metadata['tei1.ou'].id],
+                        columns: [metadata['tei1.enrollmentOu'].id],
                     },
                     visualizationType: 'LINE_LIST',
                 },
@@ -324,7 +324,7 @@ describe('useActionButton for Event button', () => {
                 visUiConfig: {
                     layout: {
                         columns: [
-                            metadata['tei1.ou'].id,
+                            metadata['tei1.enrollmentOu'].id,
                             metadata['tei1.created'].id,
                         ],
                     },
@@ -515,7 +515,7 @@ describe('useActionButton for Enrollment button', () => {
                 },
                 visUiConfig: {
                     layout: {
-                        columns: [metadata['tei1.ou'].id],
+                        columns: [metadata['tei1.enrollmentOu'].id],
                     },
                     visualizationType: 'LINE_LIST',
                 },
@@ -541,7 +541,7 @@ describe('useActionButton for Enrollment button', () => {
                 visUiConfig: {
                     layout: {
                         columns: [
-                            metadata['tei1.ou'].id,
+                            metadata['tei1.enrollmentOu'].id,
                             metadata['tei1.created'].id,
                         ],
                     },
@@ -1048,7 +1048,7 @@ describe('useActionButton for Custom value button', () => {
             createStoreWithPreloadedState({
                 visUiConfig: {
                     layout: {
-                        columns: [metadata['tei1.ou'].id],
+                        columns: [metadata['tei1.enrollmentOu'].id],
                     },
                     visualizationType: 'PIVOT_TABLE',
                 },

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -320,7 +320,7 @@ export const useActionButton = (
         if (isDataSourceProgramWithRegistration(dataSourceMetadata)) {
             const tetId = dataSourceMetadata.trackedEntityType.id
 
-            return isDimensionInLayout(layout, `${tetId}.ou`)
+            return isDimensionInLayout(layout, `${tetId}.enrollmentOu`)
         }
 
         return false

--- a/src/components/main-sidebar/cards-program-with-registration/card-tracked-entity-type.tsx
+++ b/src/components/main-sidebar/cards-program-with-registration/card-tracked-entity-type.tsx
@@ -12,13 +12,11 @@ import {
 } from '@components/main-sidebar/use-selected-dimension-count'
 import i18n from '@dhis2/d2-i18n'
 import { useCurrentUser } from '@hooks'
-import type {
-    DataSourceProgramWithRegistration,
-    DimensionMetadataItem,
-} from '@types'
+import { getTrackedEntityTypeFixedDimensions } from '@modules/dimension'
+import type { DataSourceProgramWithRegistration } from '@types'
 import { useCallback, useMemo, type FC } from 'react'
 
-export const transformProgramAttributes = (
+const transformProgramAttributes = (
     data: unknown,
     trackedEntityTypeId: string
 ): ReturnType<Transformer> => {
@@ -38,18 +36,6 @@ type CardTrackedEntityTypeProps = {
 
 const CARD_AND_LIST_KEY = 'program-tracked-entity-type'
 
-const getFixedDimensions = (
-    program: DataSourceProgramWithRegistration
-): DimensionMetadataItem[] => [
-    {
-        id: `${program.trackedEntityType.id}.ou`,
-        dimensionId: 'ou',
-        dimensionType: 'ORGANISATION_UNIT',
-        name: i18n.t('Registration org. unit'),
-        valueType: 'ORGANISATION_UNIT',
-    },
-]
-
 export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
     program,
 }) => {
@@ -62,8 +48,11 @@ export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
             program.trackedEntityType.name,
     })
     const fixedDimensions = useMemo(
-        () => getFixedDimensions(program),
-        [program]
+        () =>
+            getTrackedEntityTypeFixedDimensions(
+                program.trackedEntityType
+            ).filter((dimension) => dimension.dimensionId === 'enrollmentOu'),
+        [program.trackedEntityType]
     )
     const baseQuery = useMemo(
         () =>
@@ -87,7 +76,10 @@ export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
     })
     const isSelectedMatchFn: UseSelectedDimensionCountMatchFn = useCallback(
         (selectedDimension) => {
-            if (selectedDimension.id === `${program.trackedEntityType.id}.ou`) {
+            if (
+                selectedDimension.id ===
+                `${program.trackedEntityType.id}.enrollmentOu`
+            ) {
                 return true
             }
             if (selectedDimension.dimensionType === 'PROGRAM_ATTRIBUTE') {

--- a/src/components/main-sidebar/cards-tracked-entity-type/__tests__/card-tracked-entity-type.spec.tsx
+++ b/src/components/main-sidebar/cards-tracked-entity-type/__tests__/card-tracked-entity-type.spec.tsx
@@ -2,10 +2,7 @@ import type { UseDimensionListResult } from '@components/main-sidebar/use-dimens
 import { render, screen } from '@testing-library/react'
 import type { MetadataItem } from '@types'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import {
-    CardTrackedEntityType,
-    getFixedDimensions,
-} from '../card-tracked-entity-type'
+import { CardTrackedEntityType } from '../card-tracked-entity-type'
 
 const mockUseDimensionList = vi.fn()
 const mockUseSelectedDimensionCount = vi.fn()
@@ -136,34 +133,5 @@ describe('CardTrackedEntityType', () => {
             'data-count',
             '4'
         )
-    })
-})
-
-describe('getFixedDimensions', () => {
-    it('returns org unit and registration date dimensions', () => {
-        const tet = createTrackedEntityType()
-        const fixedDimensions = getFixedDimensions(tet)
-
-        expect(fixedDimensions).toHaveLength(2)
-        expect(fixedDimensions).toEqual([
-            expect.objectContaining({
-                id: 'tet1.ou',
-                dimensionId: 'ou',
-                dimensionType: 'ORGANISATION_UNIT',
-            }),
-            expect.objectContaining({
-                id: 'tet1.created',
-                dimensionId: 'created',
-                dimensionType: 'PERIOD',
-            }),
-        ])
-    })
-
-    it('uses the tracked entity type id in compound IDs', () => {
-        const tet = createTrackedEntityType({ id: 'custom-tet' })
-        const fixedDimensions = getFixedDimensions(tet)
-
-        expect(fixedDimensions[0].id).toBe('custom-tet.ou')
-        expect(fixedDimensions[1].id).toBe('custom-tet.created')
     })
 })

--- a/src/components/main-sidebar/cards-tracked-entity-type/card-tracked-entity-type.tsx
+++ b/src/components/main-sidebar/cards-tracked-entity-type/card-tracked-entity-type.tsx
@@ -53,7 +53,7 @@ const transformItem = (
     }
 }
 
-export const transformTrackedEntityTypeAttributes = (
+const transformTrackedEntityTypeAttributes = (
     data: unknown,
     trackedEntityTypeId: string
 ): ReturnType<Transformer> => {
@@ -71,8 +71,6 @@ export const transformTrackedEntityTypeAttributes = (
     }
 }
 
-export const getFixedDimensions = getTrackedEntityTypeFixedDimensions
-
 export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
     trackedEntityType,
 }) => {
@@ -80,17 +78,12 @@ export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
         name: trackedEntityType.name,
     })
     const fixedDimensions = useMemo(
-        () => getFixedDimensions(trackedEntityType),
+        () => getTrackedEntityTypeFixedDimensions(trackedEntityType),
         [trackedEntityType]
     )
     const fixedDimensionIdLookup = useMemo(
-        () =>
-            new Set(
-                getFixedDimensions(trackedEntityType).map(
-                    (dimension) => dimension.id
-                )
-            ),
-        [trackedEntityType]
+        () => new Set(fixedDimensions.map((dimension) => dimension.id)),
+        [fixedDimensions]
     )
     const baseQuery = useMemo<SingleQuery>(
         () => ({

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -17,8 +17,9 @@ import {
     getTimeDimensions,
     getTimeDimensionName,
     toAppLocalDimensions,
-    toApiDimensionId,
+    toEventVisualizationDimensionId,
     getCompoundDimensionId,
+    getTrackedEntityTypeFixedDimensions,
 } from '../dimension'
 
 const outputType = 'EVENT'
@@ -655,7 +656,7 @@ describe('toAppLocalDimensions', () => {
         expect(result[0].dimension).toBe('ou')
     })
 
-    it('keeps ou unchanged when dimension has no program (TEI registration ou)', () => {
+    it('renames ou to enrollmentOu when dimension has no program/stage (TEI registration ou)', () => {
         const dims: DimensionArray = [
             {
                 dimension: 'ou',
@@ -663,7 +664,7 @@ describe('toAppLocalDimensions', () => {
             },
         ]
         const result = toAppLocalDimensions(dims)
-        expect(result[0].dimension).toBe('ou')
+        expect(result[0].dimension).toBe('enrollmentOu')
     })
 
     it('does not modify non-ou dimensions', () => {
@@ -685,62 +686,99 @@ describe('toAppLocalDimensions', () => {
     })
 })
 
-describe('toApiDimensionId', () => {
+describe('toEventVisualizationDimensionId', () => {
     describe('enrollmentOu', () => {
-        it('keeps enrollmentOu for EVENT + LINE_LIST', () => {
+        it('keeps enrollmentOu for program-scope + EVENT + LINE_LIST', () => {
             expect(
-                toApiDimensionId('enrollmentOu', {
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    programId: 'prog1',
                     outputType: 'EVENT',
-                    visType: 'LINE_LIST',
+                    visualizationType: 'LINE_LIST',
                 })
             ).toBe('enrollmentOu')
         })
 
-        it('rewrites to ou for ENROLLMENT + LINE_LIST', () => {
+        it('rewrites to ou for program-scope + ENROLLMENT + LINE_LIST', () => {
             expect(
-                toApiDimensionId('enrollmentOu', {
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    programId: 'prog1',
                     outputType: 'ENROLLMENT',
-                    visType: 'LINE_LIST',
+                    visualizationType: 'LINE_LIST',
                 })
             ).toBe('ou')
         })
 
-        it('keeps enrollmentOu for TRACKED_ENTITY_INSTANCE + LINE_LIST', () => {
+        it('keeps enrollmentOu for program-scope + TRACKED_ENTITY_INSTANCE + LINE_LIST', () => {
             expect(
-                toApiDimensionId('enrollmentOu', {
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    programId: 'prog1',
                     outputType: 'TRACKED_ENTITY_INSTANCE',
-                    visType: 'LINE_LIST',
+                    visualizationType: 'LINE_LIST',
                 })
             ).toBe('enrollmentOu')
         })
 
-        it('rewrites to ou for EVENT + PIVOT_TABLE', () => {
+        it('rewrites to ou for program-scope + EVENT + PIVOT_TABLE', () => {
             expect(
-                toApiDimensionId('enrollmentOu', {
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    programId: 'prog1',
                     outputType: 'EVENT',
-                    visType: 'PIVOT_TABLE',
+                    visualizationType: 'PIVOT_TABLE',
                 })
             ).toBe('ou')
         })
 
-        it('rewrites to ou for ENROLLMENT + PIVOT_TABLE', () => {
+        it('rewrites to ou for program-scope + ENROLLMENT + PIVOT_TABLE', () => {
             expect(
-                toApiDimensionId('enrollmentOu', {
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    programId: 'prog1',
                     outputType: 'ENROLLMENT',
-                    visType: 'PIVOT_TABLE',
+                    visualizationType: 'PIVOT_TABLE',
+                })
+            ).toBe('ou')
+        })
+
+        it('rewrites to ou for TEI registration scope (no programId) + LINE_LIST', () => {
+            expect(
+                toEventVisualizationDimensionId({
+                    dimensionId: 'enrollmentOu',
+                    outputType: 'TRACKED_ENTITY_INSTANCE',
+                    visualizationType: 'LINE_LIST',
                 })
             ).toBe('ou')
         })
     })
 
     it('passes through other dimension IDs unchanged', () => {
-        const ctx = {
-            outputType: 'ENROLLMENT' as const,
-            visType: 'PIVOT_TABLE' as const,
-        }
-        expect(toApiDimensionId('eventDate', ctx)).toBe('eventDate')
-        expect(toApiDimensionId('ou', ctx)).toBe('ou')
-        expect(toApiDimensionId('enrollmentDate', ctx)).toBe('enrollmentDate')
+        expect(
+            toEventVisualizationDimensionId({
+                dimensionId: 'eventDate',
+                programId: 'prog1',
+                outputType: 'ENROLLMENT',
+                visualizationType: 'PIVOT_TABLE',
+            })
+        ).toBe('eventDate')
+        expect(
+            toEventVisualizationDimensionId({
+                dimensionId: 'ou',
+                programId: 'prog1',
+                outputType: 'ENROLLMENT',
+                visualizationType: 'PIVOT_TABLE',
+            })
+        ).toBe('ou')
+        expect(
+            toEventVisualizationDimensionId({
+                dimensionId: 'enrollmentDate',
+                programId: 'prog1',
+                outputType: 'ENROLLMENT',
+                visualizationType: 'PIVOT_TABLE',
+            })
+        ).toBe('enrollmentDate')
     })
 })
 
@@ -867,11 +905,11 @@ describe('getCompoundDimensionId', () => {
     it('uses trackedEntityTypeId prefix for TEI registration dimensions', () => {
         expect(
             getCompoundDimensionId(
-                { dimension: 'ou', items: [] },
+                { dimension: 'enrollmentOu', items: [] },
                 'TRACKED_ENTITY_INSTANCE',
                 'tet1'
             )
-        ).toBe('tet1.ou')
+        ).toBe('tet1.enrollmentOu')
 
         expect(
             getCompoundDimensionId(
@@ -896,5 +934,38 @@ describe('getCompoundDimensionId', () => {
         expect(
             getCompoundDimensionId({ dimension: 'someField', items: [] })
         ).toBe('someField')
+    })
+})
+
+describe('getTrackedEntityTypeFixedDimensions', () => {
+    it('returns registration org unit and registration date dimensions', () => {
+        const fixedDimensions = getTrackedEntityTypeFixedDimensions({
+            id: 'tet1',
+        })
+
+        expect(fixedDimensions).toHaveLength(2)
+        expect(fixedDimensions).toEqual([
+            expect.objectContaining({
+                id: 'tet1.enrollmentOu',
+                dimensionId: 'enrollmentOu',
+                dimensionType: 'ORGANISATION_UNIT',
+                trackedEntityTypeId: 'tet1',
+            }),
+            expect.objectContaining({
+                id: 'tet1.created',
+                dimensionId: 'created',
+                dimensionType: 'PERIOD',
+                trackedEntityTypeId: 'tet1',
+            }),
+        ])
+    })
+
+    it('uses the tracked entity type id in compound IDs', () => {
+        const fixedDimensions = getTrackedEntityTypeFixedDimensions({
+            id: 'custom-tet',
+        })
+
+        expect(fixedDimensions[0].id).toBe('custom-tet.enrollmentOu')
+        expect(fixedDimensions[1].id).toBe('custom-tet.created')
     })
 })

--- a/src/modules/__tests__/layout.spec.ts
+++ b/src/modules/__tests__/layout.spec.ts
@@ -372,41 +372,78 @@ const baseState = (
     }) as unknown as VisUiConfigState
 
 describe('resolveTeiFields', () => {
-    const progWithRegDataSource = {
+    const trackerProgram = {
         id: 'progA',
         name: 'Child program',
         programType: 'WITH_REGISTRATION',
         trackedEntityType: { id: 'tetA', name: 'Person' },
-    } as unknown as MetadataItem
+    } as unknown as Program
+    const eventProgram = {
+        id: 'progB',
+        name: 'Event program',
+        programType: 'WITHOUT_REGISTRATION',
+    } as unknown as Program
 
-    const tetDataSource = {
-        id: 'tetA',
-        name: 'Person',
-    } as unknown as MetadataItem
+    const tetOuDim: DimensionMetadataItem = {
+        id: 'tetA.enrollmentOu',
+        dimensionId: 'enrollmentOu',
+        name: 'Registration org. unit',
+        dimensionType: 'ORGANISATION_UNIT',
+        trackedEntityTypeId: 'tetA',
+    } as DimensionMetadataItem
+    const enrollmentOuDim: DimensionMetadataItem = {
+        id: 'progA.enrollmentOu',
+        dimensionId: 'enrollmentOu',
+        name: 'Enrollment org. unit',
+        dimensionType: 'ORGANISATION_UNIT',
+        programId: 'progA',
+    } as DimensionMetadataItem
+    const stageOuDim: DimensionMetadataItem = {
+        id: 'stage1.ou',
+        dimensionId: 'ou',
+        name: 'Event org. unit',
+        dimensionType: 'ORGANISATION_UNIT',
+        programId: 'progA',
+        programStageId: 'stage1',
+    } as DimensionMetadataItem
+    const eventProgramOuDim: DimensionMetadataItem = {
+        id: 'evtStage.ou',
+        dimensionId: 'ou',
+        name: 'Event org. unit',
+        dimensionType: 'ORGANISATION_UNIT',
+        programId: 'progB',
+        programStageId: 'evtStage',
+    } as DimensionMetadataItem
 
-    it('TEI viz with program-with-registration data source → TET resolved from data source', () => {
-        const state = baseState('TRACKED_ENTITY_INSTANCE', ['tea1', 'tea2'])
+    const tea1Dim: DimensionMetadataItem = {
+        id: 'tea1',
+        dimensionId: 'tea1',
+        name: 'First name',
+        dimensionType: 'PROGRAM_ATTRIBUTE',
+    } as DimensionMetadataItem
+    const tea2Dim: DimensionMetadataItem = {
+        id: 'tea2',
+        dimensionId: 'tea2',
+        name: 'Last name',
+        dimensionType: 'PROGRAM_ATTRIBUTE',
+    } as DimensionMetadataItem
+
+    it('TEI viz with TET registration ou → TET resolved from ouDim.trackedEntityTypeId', () => {
+        const state = baseState('TRACKED_ENTITY_INSTANCE', [
+            'tetA.enrollmentOu',
+            'tea1',
+            'tea2',
+        ])
         const store = makeStore({
             dims: {
-                tea1: {
-                    id: 'tea1',
-                    dimensionId: 'tea1',
-                    name: 'First name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                    trackedEntityTypeId: 'tetA',
-                },
-                tea2: {
-                    id: 'tea2',
-                    dimensionId: 'tea2',
-                    name: 'Last name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                    trackedEntityTypeId: 'tetA',
-                },
+                'tetA.enrollmentOu': tetOuDim,
+                tea1: tea1Dim,
+                tea2: tea2Dim,
             },
             metadata: { tetA: { id: 'tetA', name: 'Person' } },
         })
 
-        expect(resolveTeiFields(state, store, progWithRegDataSource)).toEqual({
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: { id: 'tetA', name: 'Person' },
             attributeDimensions: [
                 { attribute: { id: 'tea1', name: 'First name' } },
@@ -415,42 +452,72 @@ describe('resolveTeiFields', () => {
         })
     })
 
-    it('TEI viz with tracked-entity-type data source → TET resolved from data source', () => {
-        const state = baseState('TRACKED_ENTITY_INSTANCE', ['de1'])
+    it('TEI viz with stage ou → walks programId → program.trackedEntityType', () => {
+        const state = baseState('TRACKED_ENTITY_INSTANCE', ['stage1.ou'])
         const store = makeStore({
-            dims: {
-                de1: {
-                    id: 'de1',
-                    dimensionId: 'de1',
-                    name: 'Weight',
-                    dimensionType: 'DATA_ELEMENT',
-                },
-            },
+            dims: { 'stage1.ou': stageOuDim },
             metadata: { tetA: { id: 'tetA', name: 'Person' } },
+            programs: { progA: trackerProgram },
         })
 
-        expect(resolveTeiFields(state, store, tetDataSource)).toEqual({
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: { id: 'tetA', name: 'Person' },
             attributeDimensions: undefined,
         })
     })
 
-    it('TEI viz ignores layout-dim trackedEntityTypeId in favour of data source', () => {
+    it('TEI viz with enrollment ou → walks programId → program.trackedEntityType', () => {
+        const state = baseState('TRACKED_ENTITY_INSTANCE', [
+            'progA.enrollmentOu',
+        ])
+        const store = makeStore({
+            dims: { 'progA.enrollmentOu': enrollmentOuDim },
+            metadata: { tetA: { id: 'tetA', name: 'Person' } },
+            programs: { progA: trackerProgram },
+        })
+
+        expect(resolveTeiFields(state, store)).toEqual({
+            trackedEntityType: { id: 'tetA', name: 'Person' },
+            attributeDimensions: undefined,
+        })
+    })
+
+    it('TEI viz with no ou dim in layout → throws', () => {
         const state = baseState('TRACKED_ENTITY_INSTANCE', ['tea1'])
         const store = makeStore({
-            dims: {
-                tea1: {
-                    id: 'tea1',
-                    dimensionId: 'tea1',
-                    name: 'First name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                    trackedEntityTypeId: 'tetGhost',
-                },
-            },
+            dims: { tea1: tea1Dim },
             metadata: { tetA: { id: 'tetA', name: 'Person' } },
         })
 
-        expect(resolveTeiFields(state, store, progWithRegDataSource)).toEqual({
+        expect(() => resolveTeiFields(state, store)).toThrow(
+            'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the layout has no organisation unit dimension carrying TET context'
+        )
+    })
+
+    it('TEI viz with event-program stage ou → throws (program has no TET)', () => {
+        const state = baseState('TRACKED_ENTITY_INSTANCE', ['evtStage.ou'])
+        const store = makeStore({
+            dims: { 'evtStage.ou': eventProgramOuDim },
+            programs: { progB: eventProgram },
+        })
+
+        expect(() => resolveTeiFields(state, store)).toThrow(
+            'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the layout has no organisation unit dimension carrying TET context'
+        )
+    })
+
+    it('ENROLLMENT viz with enrollment ou and TEAs → TET + attributeDimensions both emitted', () => {
+        const state = baseState('ENROLLMENT', ['progA.enrollmentOu', 'tea1'])
+        const store = makeStore({
+            dims: {
+                'progA.enrollmentOu': enrollmentOuDim,
+                tea1: tea1Dim,
+            },
+            metadata: { tetA: { id: 'tetA', name: 'Person' } },
+            programs: { progA: trackerProgram },
+        })
+
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: { id: 'tetA', name: 'Person' },
             attributeDimensions: [
                 { attribute: { id: 'tea1', name: 'First name' } },
@@ -458,123 +525,41 @@ describe('resolveTeiFields', () => {
         })
     })
 
-    it('TEI viz with no data source → throws', () => {
-        const state = baseState('TRACKED_ENTITY_INSTANCE', ['de1'])
+    it('ENROLLMENT viz with enrollment ou, no TEAs → TET emitted (program is tracker)', () => {
+        const state = baseState('ENROLLMENT', ['progA.enrollmentOu'])
         const store = makeStore({
-            dims: {
-                de1: {
-                    id: 'de1',
-                    dimensionId: 'de1',
-                    name: 'Weight',
-                    dimensionType: 'DATA_ELEMENT',
-                },
-            },
-        })
-
-        expect(() => resolveTeiFields(state, store, undefined)).toThrow(
-            'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the data source does not provide a trackedEntityTypeId'
-        )
-    })
-
-    it('TEI viz with event-program data source (no TET) → throws', () => {
-        const state = baseState('TRACKED_ENTITY_INSTANCE', ['de1'])
-        const store = makeStore({
-            dims: {
-                de1: {
-                    id: 'de1',
-                    dimensionId: 'de1',
-                    name: 'Weight',
-                    dimensionType: 'DATA_ELEMENT',
-                },
-            },
-        })
-        const eventProgramDataSource = {
-            id: 'progB',
-            name: 'Event program',
-            programType: 'WITHOUT_REGISTRATION',
-        } as unknown as MetadataItem
-
-        expect(() =>
-            resolveTeiFields(state, store, eventProgramDataSource)
-        ).toThrow(
-            'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the data source does not provide a trackedEntityTypeId'
-        )
-    })
-
-    it('ENROLLMENT viz with TEA → TET resolved from layout dim (data source ignored)', () => {
-        const state = baseState('ENROLLMENT', ['tea1'])
-        const store = makeStore({
-            dims: {
-                tea1: {
-                    id: 'tea1',
-                    dimensionId: 'tea1',
-                    name: 'First name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                    trackedEntityTypeId: 'tetA',
-                },
-            },
+            dims: { 'progA.enrollmentOu': enrollmentOuDim },
             metadata: { tetA: { id: 'tetA', name: 'Person' } },
+            programs: { progA: trackerProgram },
         })
 
-        expect(resolveTeiFields(state, store, undefined)).toEqual({
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: { id: 'tetA', name: 'Person' },
-            attributeDimensions: [
-                { attribute: { id: 'tea1', name: 'First name' } },
-            ],
+            attributeDimensions: undefined,
         })
     })
 
-    it('ENROLLMENT viz with TEA that lacks trackedEntityTypeId → throws', () => {
-        const state = baseState('ENROLLMENT', ['tea1'])
+    it('EVENT viz with event-program stage ou → no TET, no attributeDimensions', () => {
+        const state = baseState('EVENT', ['evtStage.ou'])
         const store = makeStore({
-            dims: {
-                tea1: {
-                    id: 'tea1',
-                    dimensionId: 'tea1',
-                    name: 'First name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                },
-            },
+            dims: { 'evtStage.ou': eventProgramOuDim },
+            programs: { progB: eventProgram },
         })
 
-        expect(() => resolveTeiFields(state, store, undefined)).toThrow(
-            'Cannot resolve trackedEntityType for outputType=ENROLLMENT: no layout dimension carries a trackedEntityTypeId'
-        )
-    })
-
-    it('ENROLLMENT viz without TEA → neither field emitted', () => {
-        const state = baseState('ENROLLMENT', ['de1'])
-        const store = makeStore({
-            dims: {
-                de1: {
-                    id: 'de1',
-                    dimensionId: 'de1',
-                    name: 'Weight',
-                    dimensionType: 'DATA_ELEMENT',
-                },
-            },
-        })
-
-        expect(resolveTeiFields(state, store, undefined)).toEqual({
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: undefined,
             attributeDimensions: undefined,
         })
     })
 
-    it('EVENT viz with TEA → trackedEntityType cleared, attributeDimensions populated', () => {
-        const state = baseState('EVENT', ['tea1'])
+    it('EVENT viz with event-program ou and TEA → attributeDimensions populated, no TET', () => {
+        const state = baseState('EVENT', ['evtStage.ou', 'tea1'])
         const store = makeStore({
-            dims: {
-                tea1: {
-                    id: 'tea1',
-                    dimensionId: 'tea1',
-                    name: 'First name',
-                    dimensionType: 'PROGRAM_ATTRIBUTE',
-                },
-            },
+            dims: { 'evtStage.ou': eventProgramOuDim, tea1: tea1Dim },
+            programs: { progB: eventProgram },
         })
 
-        expect(resolveTeiFields(state, store, undefined)).toEqual({
+        expect(resolveTeiFields(state, store)).toEqual({
             trackedEntityType: undefined,
             attributeDimensions: [
                 { attribute: { id: 'tea1', name: 'First name' } },
@@ -582,25 +567,16 @@ describe('resolveTeiFields', () => {
         })
     })
 
-    it('TEI viz with data-source tetId not in metadata store → throws', () => {
-        const state = baseState('TRACKED_ENTITY_INSTANCE', ['de1'])
+    it('resolved tetId missing from metadata store → throws', () => {
+        const state = baseState('TRACKED_ENTITY_INSTANCE', [
+            'tetA.enrollmentOu',
+        ])
         const store = makeStore({
-            dims: {
-                de1: {
-                    id: 'de1',
-                    dimensionId: 'de1',
-                    name: 'Weight',
-                    dimensionType: 'DATA_ELEMENT',
-                },
-            },
+            dims: { 'tetA.enrollmentOu': tetOuDim },
         })
-        const dataSource = {
-            id: 'tetGhost',
-            name: 'Ghost',
-        } as unknown as MetadataItem
 
-        expect(() => resolveTeiFields(state, store, dataSource)).toThrow(
-            'Tracked entity type "tetGhost" referenced but not found in the metadata store'
+        expect(() => resolveTeiFields(state, store)).toThrow(
+            'Tracked entity type "tetA" referenced but not found in the metadata store'
         )
     })
 
@@ -608,7 +584,7 @@ describe('resolveTeiFields', () => {
         const state = baseState('EVENT', ['ghost'])
         const store = makeStore({})
 
-        expect(() => resolveTeiFields(state, store, undefined)).toThrow(
+        expect(() => resolveTeiFields(state, store)).toThrow(
             'No metadata found for dimension "ghost" in the layout'
         )
     })

--- a/src/modules/__tests__/visualization.spec.ts
+++ b/src/modules/__tests__/visualization.spec.ts
@@ -89,7 +89,7 @@ const testCases = {
         },
         expected: {
             itemsByDimension: {
-                ou: ['USER_ORGUNIT'],
+                enrollmentOu: ['USER_ORGUNIT'],
                 bcgDoses: [],
                 lastName: [],
                 enrollmentDate: [],
@@ -111,7 +111,7 @@ const testCases = {
             visualizationType: 'LINE_LIST',
             layout: {
                 columns: [
-                    'ou',
+                    'enrollmentOu',
                     'bcgDoses',
                     'lastName',
                     'enrollmentDate',
@@ -174,7 +174,7 @@ const testCases = {
         },
         expected: {
             itemsByDimension: {
-                ou: ['USER_ORGUNIT'],
+                enrollmentOu: ['USER_ORGUNIT'],
                 enrollmentDate: [],
                 firstName: [],
                 bcgDoses: [],
@@ -189,7 +189,7 @@ const testCases = {
             visualizationType: 'LINE_LIST',
             layout: {
                 columns: [
-                    'ou',
+                    'enrollmentOu',
                     'enrollmentDate',
                     'firstName',
                     'bcgDoses',
@@ -282,7 +282,7 @@ const testCases = {
         },
         expected: {
             itemsByDimension: {
-                ou: ['USER_ORGUNIT'],
+                enrollmentOu: ['USER_ORGUNIT'],
                 focusName: [],
                 localFocusId: [],
                 area: [],
@@ -305,7 +305,7 @@ const testCases = {
             visualizationType: 'LINE_LIST',
             layout: {
                 columns: [
-                    'ou',
+                    'enrollmentOu',
                     'focusName',
                     'localFocusId',
                     'area',

--- a/src/modules/data-source.ts
+++ b/src/modules/data-source.ts
@@ -25,18 +25,6 @@ export const isDataSourceTrackedEntityType = (
 ): dataSource is MetadataItem =>
     !isProgramMetadataItem(dataSource) && isMetadataItem(dataSource)
 
-export const getTrackedEntityTypeIdFromDataSource = (
-    dataSource: unknown
-): string | null => {
-    if (isDataSourceProgramWithRegistration(dataSource)) {
-        return dataSource.trackedEntityType.id
-    }
-    if (isDataSourceTrackedEntityType(dataSource)) {
-        return dataSource.id
-    }
-    return null
-}
-
 export const extractDataSourceIdFromVisualization = (
     visualization: CurrentVisualization
 ): string => {

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -419,36 +419,50 @@ export const combineAllDimensionsFromVisualization = (
 // boundary.
 // ---------------------------------------------------------------------------
 
-/** Forward: API → app-local dimension IDs on a DimensionArray. */
+/**
+ * Forward: API → app-local dimension IDs on a DimensionArray.
+ *
+ * The eventVisualizations API uses bare `ou` for both enrollment-scope and
+ * TEI-registration-scope org units; these are distinguished only by the
+ * presence/absence of a `program` qualifier on the dim record. Stage event OU
+ * (with `programStage`) is a different concept and stays as `ou`.
+ */
 export const toAppLocalDimensions = (dims: DimensionArray): DimensionArray =>
     dims.map((dim) => {
-        if (dim.dimension === 'ou' && dim.program && !dim.programStage) {
+        if (dim.dimension === 'ou' && !dim.programStage) {
             return { ...dim, dimension: 'enrollmentOu' }
         }
         return dim
     })
 
 /**
- * Inverse: app-local → API dimension ID (single dimension).
+ * Inverse: app-local dim → eventVisualizations POST `dimension` ID.
  *
- * `enrollmentOu` is the app-local ID for the enrollment org unit. The
- * eventVisualizations POST endpoint accepts it verbatim in some
- * outputType/visType combinations and requires plain `ou` in others. See the
- * "Org unit scopes" table in CLAUDE.md for the authoritative mapping.
+ * `enrollmentOu` is the app-local ID for both program-scope enrollment OU
+ * and TEI-registration-scope OU. The POST endpoint accepts it verbatim only
+ * when it carries a program qualifier AND the visualization is in EVENT/TEI
+ * `LINE_LIST` mode; otherwise it must be sent as bare `ou`. See the "Org
+ * unit scopes" table in CLAUDE.md for the authoritative mapping.
  */
-export const toApiDimensionId = (
-    dimId: string,
-    {
-        outputType,
-        visType,
-    }: { outputType?: OutputType; visType?: VisualizationType } = {}
-): string => {
-    if (dimId !== 'enrollmentOu') {
-        return dimId
+export const toEventVisualizationDimensionId = ({
+    dimensionId,
+    programId,
+    outputType,
+    visualizationType,
+}: {
+    dimensionId: string
+    programId?: string
+    outputType: OutputType
+    visualizationType: VisualizationType
+}): string => {
+    if (dimensionId !== 'enrollmentOu') {
+        return dimensionId
     }
     const shouldRewriteToOu =
-        outputType === 'ENROLLMENT' || visType === 'PIVOT_TABLE'
-    return shouldRewriteToOu ? 'ou' : dimId
+        !programId ||
+        outputType === 'ENROLLMENT' ||
+        visualizationType === 'PIVOT_TABLE'
+    return shouldRewriteToOu ? 'ou' : 'enrollmentOu'
 }
 
 // Dimension types that use plain IDs (no compound prefix) even when
@@ -472,7 +486,7 @@ const ENROLLMENT_SCOPED_DIMENSION_IDS: ReadonlySet<string> = new Set([
 // trackedEntityTypeId when there is no program or stage context.
 // Must match what getTrackedEntityTypeFixedDimensions produces.
 const TEI_REGISTRATION_DIMENSION_IDS: ReadonlySet<string> = new Set([
-    'ou',
+    'enrollmentOu',
     'created',
 ])
 
@@ -608,8 +622,8 @@ export const getTrackedEntityTypeFixedDimensions = (trackedEntityType: {
     id: string
 }): DimensionMetadataItem[] => [
     {
-        id: `${trackedEntityType.id}.ou`,
-        dimensionId: 'ou',
+        id: `${trackedEntityType.id}.enrollmentOu`,
+        dimensionId: 'enrollmentOu',
         dimensionType: 'ORGANISATION_UNIT',
         name: i18n.t('Registration org. unit'),
         trackedEntityTypeId: trackedEntityType.id,

--- a/src/modules/layout.ts
+++ b/src/modules/layout.ts
@@ -1,7 +1,6 @@
 import { dimensionCreate } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import { getTrackedEntityTypeIdFromDataSource } from '@modules/data-source'
-import { toApiDimensionId } from '@modules/dimension'
+import { toEventVisualizationDimensionId } from '@modules/dimension'
 import { parseUiRepetitions } from '@modules/repetitions'
 import {
     selectLayoutAllDimensionIds,
@@ -13,7 +12,6 @@ import type {
     DimensionArray,
     DimensionMetadataItem,
     Layout,
-    MetadataItem,
     MetadataStore,
     Program,
 } from '@types'
@@ -47,7 +45,6 @@ export const buildAxis = (
                     `No metadata found for dimension "${id}" — cannot decompose compound ID for API`
                 )
             }
-            const dimensionId = dim.dimensionId ?? id
             const conditions = visUiConfig.conditionsByDimension[id]
             const repetitions = visUiConfig.repetitionsByDimension[id]
             const options: Record<string, unknown> = {}
@@ -69,9 +66,11 @@ export const buildAxis = (
                 options.programStage = { id: dim.programStageId }
             }
             return dimensionCreate(
-                toApiDimensionId(dimensionId, {
+                toEventVisualizationDimensionId({
+                    dimensionId: dim.dimensionId ?? id,
+                    programId: dim.programId,
                     outputType: visUiConfig.outputType,
-                    visType: visUiConfig.visualizationType,
+                    visualizationType: visUiConfig.visualizationType,
                 }),
                 visUiConfig.itemsByDimension[id],
                 options
@@ -122,8 +121,7 @@ type TeiFields = {
 
 export const resolveTeiFields = (
     visUiConfig: VisUiConfigState,
-    metadataStore: MetadataStore,
-    dataSource: MetadataItem | undefined
+    metadataStore: MetadataStore
 ): TeiFields => {
     const layoutDims = getLayoutDims(visUiConfig, metadataStore)
     const { outputType } = visUiConfig
@@ -138,28 +136,25 @@ export const resolveTeiFields = (
               }))
             : undefined
 
-    // TET is a first-class property of TEI visualizations (see the backend's
-    // EventVisualization.isMultiProgram), so the data source is authoritative.
-    // For ENROLLMENT+TEAs the TET is derived from the TEA's owning program via
-    // the layout.
-    let tetId: string | null = null
-    if (outputType === 'TRACKED_ENTITY_INSTANCE') {
-        tetId = getTrackedEntityTypeIdFromDataSource(dataSource)
-        if (!tetId) {
+    /* The layout's OU dim is the canonical source for TET context: TET-registration
+     * ou carries trackedEntityTypeId directly; enrollment/stage ou carry a programId
+     * whose program reference provides the TET (or none, for event programs). */
+    const ouDim = layoutDims.find(
+        (dim) => dim.dimensionType === 'ORGANISATION_UNIT'
+    )
+    const tetId =
+        ouDim?.trackedEntityTypeId ??
+        (ouDim?.programId &&
+            metadataStore.getProgramMetadataItem(ouDim.programId)
+                ?.trackedEntityType?.id) ??
+        null
+
+    if (!tetId) {
+        if (outputType === 'TRACKED_ENTITY_INSTANCE') {
             throw new Error(
-                'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the data source does not provide a trackedEntityTypeId'
+                'Cannot resolve trackedEntityType for outputType=TRACKED_ENTITY_INSTANCE: the layout has no organisation unit dimension carrying TET context'
             )
         }
-    } else if (outputType === 'ENROLLMENT' && teaDims.length > 0) {
-        tetId =
-            layoutDims.find((dim) => dim.trackedEntityTypeId)
-                ?.trackedEntityTypeId ?? null
-        if (!tetId) {
-            throw new Error(
-                'Cannot resolve trackedEntityType for outputType=ENROLLMENT: no layout dimension carries a trackedEntityTypeId'
-            )
-        }
-    } else {
         return { trackedEntityType: undefined, attributeDimensions }
     }
 

--- a/src/modules/layout.ts
+++ b/src/modules/layout.ts
@@ -1,4 +1,3 @@
-import { dimensionCreate } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
 import { toEventVisualizationDimensionId } from '@modules/dimension'
 import { parseUiRepetitions } from '@modules/repetitions'
@@ -11,6 +10,7 @@ import type {
     CurrentVisualization,
     DimensionArray,
     DimensionMetadataItem,
+    DimensionRecord,
     Layout,
     MetadataStore,
     Program,
@@ -37,46 +37,55 @@ export const buildAxis = (
     visUiConfig: VisUiConfigState,
     metadataStore: MetadataStore
 ): DimensionArray =>
-    dimensionIds
-        .map((id) => {
-            const dim = metadataStore.getDimensionMetadataItem(id)
-            if (!dim) {
-                throw new Error(
-                    `No metadata found for dimension "${id}" — cannot decompose compound ID for API`
-                )
-            }
-            const conditions = visUiConfig.conditionsByDimension[id]
-            const repetitions = visUiConfig.repetitionsByDimension[id]
-            const options: Record<string, unknown> = {}
-            if (conditions?.condition) {
-                options.filter = conditions.condition
-            }
-            if (conditions?.legendSet) {
-                options.legendSet = { id: conditions.legendSet }
-            }
-            if (repetitions) {
-                options.repetition = {
-                    indexes: parseUiRepetitions(repetitions),
-                }
-            }
-            if (dim.programId) {
-                options.program = { id: dim.programId }
-            }
-            if (dim.programStageId) {
-                options.programStage = { id: dim.programStageId }
-            }
-            return dimensionCreate(
-                toEventVisualizationDimensionId({
-                    dimensionId: dim.dimensionId ?? id,
-                    programId: dim.programId,
-                    outputType: visUiConfig.outputType,
-                    visualizationType: visUiConfig.visualizationType,
-                }),
-                visUiConfig.itemsByDimension[id],
-                options
+    dimensionIds.map((id) => {
+        const dim = metadataStore.getDimensionMetadataItem(id)
+        if (!dim) {
+            throw new Error(
+                `No metadata found for dimension "${id}" — cannot decompose compound ID for API`
             )
-        })
-        .filter((dim): dim is DimensionArray[number] => dim !== null)
+        }
+        const itemIds = visUiConfig.itemsByDimension[id]
+        const conditions = visUiConfig.conditionsByDimension[id]
+        const repetitions = visUiConfig.repetitionsByDimension[id]
+        const dimensionRecord: DimensionRecord = {
+            dimension: toEventVisualizationDimensionId({
+                dimensionId: dim.dimensionId ?? id,
+                programId: dim.programId,
+                outputType: visUiConfig.outputType,
+                visualizationType: visUiConfig.visualizationType,
+            }),
+        }
+        if (itemIds?.length) {
+            dimensionRecord.items = itemIds.map((itemId) => ({ id: itemId }))
+        }
+        if (conditions?.condition) {
+            dimensionRecord.filter = conditions.condition
+        }
+        if (conditions?.legendSet) {
+            dimensionRecord.legendSet = { id: conditions.legendSet }
+        }
+        if (repetitions) {
+            dimensionRecord.repetition = {
+                indexes: parseUiRepetitions(repetitions),
+            }
+        }
+        if (dim.programId) {
+            dimensionRecord.program = { id: dim.programId }
+        }
+        if (dim.programStageId) {
+            dimensionRecord.programStage = { id: dim.programStageId }
+        }
+        if (dim.dimensionType) {
+            dimensionRecord.dimensionType = dim.dimensionType
+        }
+        if (dim.optionSetId) {
+            dimensionRecord.optionSet = { id: dim.optionSetId }
+        }
+        if (dim.valueType) {
+            dimensionRecord.valueType = dim.valueType
+        }
+        return dimensionRecord
+    })
 
 const getLayoutDims = (
     visUiConfig: VisUiConfigState,

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -16,7 +16,7 @@ import {
 import { createAsyncThunk } from '@reduxjs/toolkit'
 import type { AppDispatch, CurrentVisualization } from '@types'
 import { clearCurrentVis, setCurrentVis } from './current-vis-slice'
-import { getDataSourceId, setDataSourceId } from './dimensions-selection-slice'
+import { setDataSourceId } from './dimensions-selection-slice'
 import { setIsVisualizationLoading, setLoadError } from './loader-slice'
 import { clearSavedVis, setSavedVis } from './saved-vis-slice'
 import type { RootState } from './store'
@@ -109,10 +109,6 @@ export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
         const { currentVis, visUiConfig } = state
         const { metadataStore } = extra
         const { customValue } = visUiConfig
-        const dataSourceId = getDataSourceId(state)
-        const dataSource = dataSourceId
-            ? metadataStore.getMetadataItem(dataSourceId)
-            : undefined
 
         // Build fresh from visUiConfig so stale currentVis fields can't leak
         // through. Carry over only id and sorting from the previous currentVis.
@@ -149,7 +145,7 @@ export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
                 customValue?.aggregationType ??
                 visUiConfig.options.aggregationType,
             ...getEnabledOptions(visUiConfig.options),
-            ...resolveTeiFields(visUiConfig, metadataStore, dataSource),
+            ...resolveTeiFields(visUiConfig, metadataStore),
         }
 
         dispatch(setCurrentVis(updatedCurrentVis))

--- a/src/store/vis-ui-config-slice.ts
+++ b/src/store/vis-ui-config-slice.ts
@@ -13,7 +13,7 @@ import type {
 import { setUiActiveDimensionModal } from './ui-slice'
 
 export type ConditionsObject = {
-    condition?: string | string[]
+    condition?: string
     legendSet?: string
 }
 

--- a/src/types/analytics/index.d.ts
+++ b/src/types/analytics/index.d.ts
@@ -105,12 +105,6 @@ declare module '@dhis2/analytics' {
         nextPage: number | null
     }
 
-    export const dimensionCreate: (
-        dimensionId: string,
-        itemIds: string[],
-        args: Record<string, unknown>
-    ) => DimensionRecord
-
     export const dimensionIsValid: (
         dimension: DimensionRecord,
         flags: { requireItems?: boolean }

--- a/src/types/visualization.ts
+++ b/src/types/visualization.ts
@@ -1,6 +1,5 @@
 import type {
     EventVisualization as EventVisualizationGenerated,
-    EventRepetition,
     ValueType,
     LegendDisplayStrategy,
     LegendDisplayStyle,
@@ -28,6 +27,11 @@ type MetadataRecordArray<T extends string> = Array<Record<T, IdNameRecord>>
  *
  * transformDimensions() converts PROGRAM_DATA_ELEMENT → DATA_ELEMENT where needed.
  */
+/* repetition: only `indexes` is meaningful on write — the backend's
+ * populateEventRepetitions() hydrates `dimension` and `parent` from the
+ * owning DimensionalObject and axis. The OpenAPI EventRepetition type
+ * marks those fields required, but in practice the frontend only sends
+ * indexes and the backend fills in the rest. */
 export type DimensionRecord = {
     dimension: string
     dimensionType?: DimensionType | 'PROGRAM_DATA_ELEMENT'
@@ -37,8 +41,14 @@ export type DimensionRecord = {
     optionSet?: IdRecord
     valueType?: ValueType
     legendSet?: IdRecord
-    repetition?: EventRepetition
-    items: Array<DimensionalItemObject>
+    repetition?: {
+        indexes: number[]
+        dimension?: string
+        parent?: 'COLUMN' | 'ROW' | 'FILTER'
+        program?: string
+        programStage?: string
+    }
+    items?: Array<DimensionalItemObject>
 }
 
 export type DimensionArray = Array<DimensionRecord>


### PR DESCRIPTION
Implements: N/A (it's a fixup)

### Description

Resolves the `trackedEntityType` ID for updating the `currentVis` from the `visUiConfig` by walking the layout's organisation unit dimension instead of consulting the data source / scanning layout dims for a TEA's `trackedEntityTypeId`. 

Also fixes several related issues that surfaced while doing so:
- In the sidebar we were using `ou` instead of the "app-local" `enrollmentOu` for "Registration org. unit" (in the TET card for tracker-programs and TET data sources). This was fixed, we're using `enrollmentOu` now.
- This change then required updating the logic in `toApiDimensionId` so this was fixed as well. As discussed this function was also renamed to `toEventVisualizationDimensionId` for clarity.
- We also needed some updates to the inverse dimension ID handling (when we extract dimensions from the visualization), so now `TEI_REGISTRATION_DIMENSION_IDS` is updated from `['ou', 'created']` to `['enrollmentOu', 'created']` so `getCompoundDimensionId` reconstructs `${tetId}.enrollmentOu` on saved-vis load. `toAppLocalDimensions` was also simplified to handle the unqualified `ou` form (TEI registration OU on load).
- Fixed a hard-coded `${tetId}.ou` reference in `use-action-button.ts` that would have silently broken otherwise.
- I also spotted a function that was renamed and exported in `cards-tracked-entity-type/card-tracked-entity-type.tsx`. It was also being tested in the wrong place. 
- The Claude instructions have been compacted because I got a warning about the file exceeding the max. recommended size. I also made some specific changes:
    - "Org unit scopes" were updated for the new `tetId.enrollmentOu` form. 
    - Translation table extended with a TEI registration row gated on `programId` presence.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---