### PR TITLE
fix: other dimensions should not have a compound ID

### DIFF
--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -683,6 +683,37 @@ describe('toAppLocalDimensions', () => {
         expect(result[0].dimension).toBe('enrollmentDate')
         expect(result[1].dimension).toBe('eventDate')
     })
+
+    it('strips program and programStage from ORGANISATION_UNIT_GROUP_SET dimensions (legacy backend noise)', () => {
+        const dims: DimensionArray = [
+            {
+                dimension: 'area',
+                dimensionType: 'ORGANISATION_UNIT_GROUP_SET',
+                items: [],
+                program: { id: 'prog1' },
+                programStage: { id: 'stage1' },
+            },
+        ]
+        const result = toAppLocalDimensions(dims)
+        expect(result[0].dimension).toBe('area')
+        expect(result[0].program).toBeUndefined()
+        expect(result[0].programStage).toBeUndefined()
+    })
+
+    it('preserves other fields on a stripped contextless dimension', () => {
+        const dims: DimensionArray = [
+            {
+                dimension: 'area',
+                dimensionType: 'ORGANISATION_UNIT_GROUP_SET',
+                items: [{ id: 'urban' }, { id: 'rural' }],
+                program: { id: 'prog1' },
+                programStage: { id: 'stage1' },
+            },
+        ]
+        const result = toAppLocalDimensions(dims)
+        expect(result[0].items).toEqual([{ id: 'urban' }, { id: 'rural' }])
+        expect(result[0].dimensionType).toBe('ORGANISATION_UNIT_GROUP_SET')
+    })
 })
 
 describe('toApiDimensionId', () => {
@@ -896,5 +927,20 @@ describe('getCompoundDimensionId', () => {
         expect(
             getCompoundDimensionId({ dimension: 'someField', items: [] })
         ).toBe('someField')
+    })
+
+    it('returns plain ID for ORGANISATION_UNIT_GROUP_SET after toAppLocalDimensions stripping', () => {
+        // Contextless dimensions have program/programStage stripped at the
+        // boundary; the helper then naturally falls through to plain ID.
+        expect(
+            getCompoundDimensionId(
+                {
+                    dimension: 'area',
+                    dimensionType: 'ORGANISATION_UNIT_GROUP_SET',
+                    items: [],
+                },
+                'EVENT'
+            )
+        ).toBe('area')
     })
 })

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -419,9 +419,27 @@ export const combineAllDimensionsFromVisualization = (
 // boundary.
 // ---------------------------------------------------------------------------
 
+// Dimension types that are not bound to any program or stage. The backend
+// may still populate program/programStage on these in legacy visualizations;
+// drop those fields at the API → app-local boundary so that downstream code
+// (compound ID, save round-trip) treats them as the contextless dimensions
+// they actually are.
+const CONTEXTLESS_DIMENSION_TYPES: ReadonlySet<string> = new Set([
+    'ORGANISATION_UNIT_GROUP_SET',
+])
+
 /** Forward: API → app-local dimension IDs on a DimensionArray. */
 export const toAppLocalDimensions = (dims: DimensionArray): DimensionArray =>
     dims.map((dim) => {
+        if (
+            dim.dimensionType &&
+            CONTEXTLESS_DIMENSION_TYPES.has(dim.dimensionType)
+        ) {
+            const stripped = { ...dim }
+            delete stripped.program
+            delete stripped.programStage
+            return stripped
+        }
         if (dim.dimension === 'ou' && dim.program && !dim.programStage) {
             return { ...dim, dimension: 'enrollmentOu' }
         }


### PR DESCRIPTION
Fix that ensures the "other" dimensions don't end up with stage ID prefix, they need a plain ID, not a compound ID.