### PR TITLE
chore: ensure toolbar save acts as save-as for new visualizations

### DIFF
--- a/src/components/toolbar/actions-bar/actions-bar.tsx
+++ b/src/components/toolbar/actions-bar/actions-bar.tsx
@@ -13,6 +13,7 @@ import {
 import { SharingDialog } from '@dhis2/ui'
 import { useAppSelector, useCurrentUser } from '@hooks'
 import { isVisualizationPersistable } from '@modules/validation'
+import { isCurrentVisualizationPersisted } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
 import { getSavedVis } from '@store/saved-vis-slice'
 import type { SavedVisualization } from '@types'
@@ -140,14 +141,19 @@ export const ActionsBar: FC = () => {
     const [currentDialog, setCurrentDialog] = useState<string | null>(null)
 
     const currentUser = useCurrentUser()
+    const currentVis = useAppSelector(getCurrentVis)
 
-    const onMenuItemClick = (dialogToOpen) => {
+    const onMenuItemClick = (dialogToOpen: string) => {
         setCurrentDialog(dialogToOpen)
     }
 
     const onDialogClose = () => setCurrentDialog(null)
 
-    const { onNew, onOpen } = useToolbarActions()
+    const { onNew, onOpen, onSave } = useToolbarActions()
+
+    const onSaveOrSaveAs = isCurrentVisualizationPersisted(currentVis)
+        ? onSave
+        : () => setCurrentDialog('saveas')
 
     return (
         <>
@@ -155,11 +161,14 @@ export const ActionsBar: FC = () => {
                 <div className={classes.actionButtons}>
                     <NewButton />
                     <OpenButton onClick={() => onMenuItemClick('open')} />
-                    <SaveButton />
+                    <SaveButton onClick={onSaveOrSaveAs} />
                     <ToolbarDivider />
                 </div>
                 <HoverMenuBar>
-                    <FileMenu onMenuItemClick={onMenuItemClick} />
+                    <FileMenu
+                        onMenuItemClick={onMenuItemClick}
+                        onSaveOrSaveAs={onSaveOrSaveAs}
+                    />
                     <ViewMenu />
                     <DownloadMenu />
                 </HoverMenuBar>

--- a/src/components/toolbar/actions-bar/file-menu.tsx
+++ b/src/components/toolbar/actions-bar/file-menu.tsx
@@ -32,14 +32,17 @@ const iconInactiveColor = colors.grey500
 
 type FileMenuProps = {
     onMenuItemClick: (dialogName: string) => void
+    onSaveOrSaveAs: () => void
 }
 
-export const FileMenu: FC<FileMenuProps> = ({ onMenuItemClick }) => {
+export const FileMenu: FC<FileMenuProps> = ({
+    onMenuItemClick,
+    onSaveOrSaveAs,
+}) => {
     const currentVis = useAppSelector(getCurrentVis)
     const savedVis = useAppSelector(getSavedVis)
 
-    const { isSaveEnabled, isSaveAsEnabled, onNew, onSave } =
-        useToolbarActions()
+    const { isSaveEnabled, isSaveAsEnabled, onNew } = useToolbarActions()
 
     const hasVisualizationDeleteAccess: boolean = useMemo(
         () =>
@@ -94,11 +97,7 @@ export const FileMenu: FC<FileMenuProps> = ({ onMenuItemClick }) => {
                         />
                     }
                     disabled={!isSaveEnabled}
-                    onClick={
-                        isCurrentVisualizationPersisted(currentVis)
-                            ? onSave
-                            : () => onMenuItemClick('saveas')
-                    }
+                    onClick={onSaveOrSaveAs}
                     dataTest="file-menu-save"
                 />
                 <HoverMenuListItem

--- a/src/components/toolbar/actions-bar/save-button.tsx
+++ b/src/components/toolbar/actions-bar/save-button.tsx
@@ -1,27 +1,34 @@
 import i18n from '@dhis2/d2-i18n'
 import { Button, IconSave16 } from '@dhis2/ui'
 import { useAppSelector } from '@hooks'
-import { getSavedVis } from '@store/saved-vis-slice'
+import { isCurrentVisualizationPersisted } from '@modules/visualization'
+import { getCurrentVis } from '@store/current-vis-slice'
 import { type FC } from 'react'
 import classes from './styles/button.module.css'
 import { useToolbarActions } from './use-toolbar-actions'
 
-export const SaveButton: FC = () => {
-    const savedVis = useAppSelector(getSavedVis)
+type SaveButtonProps = {
+    onClick: () => void
+}
 
-    const { isSaveEnabled, onSave } = useToolbarActions()
+export const SaveButton: FC<SaveButtonProps> = ({ onClick }) => {
+    const currentVis = useAppSelector(getCurrentVis)
+
+    const { isSaveEnabled } = useToolbarActions()
 
     return (
         <Button
             icon={<IconSave16 color="#6C7787 " />}
-            onClick={onSave}
+            onClick={onClick}
             dataTest="save-button"
             className={classes.button}
             small
             disabled={!isSaveEnabled}
         >
             <span className={classes.label}>
-                {savedVis.id ? i18n.t('Save') : i18n.t('Save…')}
+                {isCurrentVisualizationPersisted(currentVis)
+                    ? i18n.t('Save')
+                    : i18n.t('Save…')}
             </span>
         </Button>
     )


### PR DESCRIPTION
Implements [DHIS2-21468](https://dhis2.atlassian.net/browse/DHIS2-21468)


[DHIS2-21468]: https://dhis2.atlassian.net/browse/DHIS2-21468?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ