### PR TITLE
fix: pass the correct enrollmentOu dimension in analytics request

### DIFF
--- a/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
@@ -20,12 +20,13 @@ const adaptDimensions = (
 
     dimensions.forEach((dimensionObj) => {
         const dimensionId = dimensionObj.dimension
+        const dimension = convertToScreamingSnakeCase(dimensionId)
 
         // these are always passed without any prefix
         if (['completed', 'created', 'lastUpdated'].includes(dimensionId)) {
             adaptedDimensions.push({
                 ...dimensionObj,
-                dimension: convertToScreamingSnakeCase(dimensionId),
+                dimension,
                 program: undefined,
                 programStage: undefined,
             })
@@ -35,7 +36,7 @@ const adaptDimensions = (
         ) {
             adaptedDimensions.push({
                 ...dimensionObj,
-                dimension: convertToScreamingSnakeCase(dimensionId),
+                dimension,
                 program: undefined,
             })
         } else if (
@@ -43,8 +44,6 @@ const adaptDimensions = (
             dimensionId === 'enrollmentDate' ||
             dimensionId === 'incidentDate'
         ) {
-            const dimension = convertToScreamingSnakeCase(dimensionId)
-
             if (outputType === 'TRACKED_ENTITY_INSTANCE') {
                 // remove programStage for these dimensions for trackedEntity
                 adaptedDimensions.push({
@@ -64,6 +63,7 @@ const adaptDimensions = (
         } else if (dimensionId === 'enrollmentOu') {
             adaptedDimensions.push({
                 ...dimensionObj,
+                dimension,
                 program:
                     outputType === 'TRACKED_ENTITY_INSTANCE'
                         ? dimensionObj.program


### PR DESCRIPTION

### Description

A previous change to the analytics request logic introduced an issue with the `enrollmentOu` dimension, which was passed unchanged and instead it should be passed a `ENROLLMENT_OU`.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

Before:
<img width="473" height="217" alt="Screenshot 2026-05-11 at 10 59 39" src="https://github.com/user-attachments/assets/667ab4d3-22d2-4c6f-8215-d2528cee20f3" />


After:
<img width="485" height="236" alt="Screenshot 2026-05-11 at 10 58 56" src="https://github.com/user-attachments/assets/55fa39a8-7fc7-44e6-8783-917fc5639729" />
