### PR TITLE
chore: ensure TET from program is added to the metadata store

### DIFF
--- a/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
+++ b/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
@@ -1231,6 +1231,32 @@ describe('MetadataStore — TEA enrichment with trackedEntityTypeId', () => {
         })
     })
 
+    it('EVENT viz on a tracker program stores TET from programDimensions in the metadata store', () => {
+        const store = new TestMetadataStore({}, [])
+
+        const vis = {
+            outputType: 'EVENT',
+            programDimensions: [
+                {
+                    id: 'progA',
+                    name: 'Child Programme',
+                    programType: 'WITH_REGISTRATION',
+                    trackedEntityType: { id: 'tetA', name: 'Person' },
+                },
+            ],
+            attributeDimensions: [],
+            columns: [],
+            rows: [],
+            filters: [],
+            metaData: {},
+        } as unknown as SavedVisualization
+
+        store.setVisualizationMetadata(vis)
+
+        const snapshot = store.getMetadataSnapshot()
+        expect(snapshot['tetA']).toEqual({ id: 'tetA', name: 'Person' })
+    })
+
     it('EVENT viz with attributeDimensions but no trackedEntityType does NOT attach trackedEntityTypeId', () => {
         const store = new TestMetadataStore(
             {},

--- a/src/components/app-wrapper/metadata-provider/visualization.ts
+++ b/src/components/app-wrapper/metadata-provider/visualization.ts
@@ -59,7 +59,7 @@ export const extractTrackedEntityTypeMetadata = (
 export const extractProgramDimensionsMetadata = (
     visualization: SavedVisualization
 ): MetadataInputMap => {
-    const programDimensionsMetadata = {}
+    const programDimensionsMetadata: MetadataInputMap = {}
 
     if (visualization.outputType === 'TRACKED_ENTITY_INSTANCE') {
         return programDimensionsMetadata
@@ -72,6 +72,15 @@ export const extractProgramDimensionsMetadata = (
             program.programStages.forEach((stage) => {
                 programDimensionsMetadata[stage.id!] = stage
             })
+        }
+
+        /* EVENT/ENROLLMENT visualizations don't carry a top-level
+         * trackedEntityType, but tracker programs reference one. The layout's
+         * TET resolver walks program.trackedEntityType.id, so the store needs
+         * an entry for that id to be looked up. */
+        const tet = program.trackedEntityType
+        if (tet?.id && !programDimensionsMetadata[tet.id]) {
+            programDimensionsMetadata[tet.id] = { id: tet.id, name: tet.name }
         }
     })
 


### PR DESCRIPTION
Implements N/A

### Description

When extracting TET metadata from a visualization, do not only look at the top level `trackedEntityType` field, but also look for TET references in programs (via `programDimensions` in the normalised `SavedVisualization`).

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced

---

### ToDo

<!--Checkmate-->

- [x] Wait for #215 #216 and #221 to be merged and tidy up so that only 5ad0c0b6deaf66758b332a7e6a48bb63a36dd252 is part of this PR