### PR TITLE
chore: remove registration date from TET card

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-12T10:29:27.262Z\n"
-"PO-Revision-Date: 2026-05-12T10:29:27.262Z\n"
+"POT-Creation-Date: 2026-05-12T13:34:36.969Z\n"
+"PO-Revision-Date: 2026-05-12T13:34:36.970Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -365,12 +365,6 @@ msgstr "Switch to {{trackedEntityTypeName}} list"
 
 msgid "Update {{trackedEntityTypeName}} list"
 msgstr "Update {{trackedEntityTypeName}} list"
-
-msgid "Not valid with registration date or registration org. unit"
-msgstr "Not valid with registration date or registration org. unit"
-
-msgid "Not valid with registration date"
-msgstr "Not valid with registration date"
 
 msgid "Not valid with registration org. unit"
 msgstr "Not valid with registration org. unit"
@@ -983,9 +977,6 @@ msgstr "No"
 
 msgid "Not answered"
 msgstr "Not answered"
-
-msgid "Registration date"
-msgstr "Registration date"
 
 msgid "Event status"
 msgstr "Event status"

--- a/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
+++ b/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
@@ -395,7 +395,7 @@ describe('MetadataStore', () => {
               "dimensionId": "created",
               "dimensionType": "PERIOD",
               "id": "created",
-              "name": "Registration date",
+              "name": "Created on",
               "valueType": "DATE",
             },
             "createdBy": {

--- a/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
@@ -111,12 +111,6 @@ const metadata = {
         programId: 'p3',
         trackedEntityTypeId: 'tei2',
     },
-    'tei1.created': {
-        id: 'tei1.created',
-        name: 'Registration date',
-        dimensionType: 'DATA_ELEMENT',
-        valueType: 'DATE',
-    },
     'tei1.enrollmentOu': {
         id: 'tei1.enrollmentOu',
         name: 'Registration org. unit',
@@ -306,33 +300,6 @@ describe('useActionButton for Event button', () => {
         })
     })
 
-    it('returns correct result for: LL, registration date in layout', async () => {
-        const { result } = await renderHookWithAppWrapper(
-            () => useActionButton('EVENT'),
-            createStoreWithPreloadedState({
-                dimensionSelection: {
-                    dataSourceId: metadata.p2.id,
-                },
-                visUiConfig: {
-                    layout: {
-                        columns: [
-                            metadata['p2.p2s1.d1'].id,
-                            metadata['tei1.created'].id,
-                        ],
-                    },
-                    visualizationType: 'LINE_LIST',
-                },
-            })
-        )
-
-        const output = result.current
-
-        expect(output.action).toEqual('create')
-        expect(output.tooltipConfig).toEqual({
-            content: 'Not valid with registration date',
-        })
-    })
-
     it('returns correct result for: LL, registration org. unit in layout', async () => {
         const { result } = await renderHookWithAppWrapper(
             () => useActionButton('EVENT'),
@@ -357,35 +324,6 @@ describe('useActionButton for Event button', () => {
         expect(output.action).toEqual('create')
         expect(output.tooltipConfig).toEqual({
             content: 'Not valid with registration org. unit',
-        })
-    })
-
-    it('returns correct result for: LL, registration date and registration org. unit in layout', async () => {
-        const { result } = await renderHookWithAppWrapper(
-            () => useActionButton('EVENT'),
-            createStoreWithPreloadedState({
-                dimensionSelection: {
-                    dataSourceId: metadata.p2.id,
-                },
-                visUiConfig: {
-                    layout: {
-                        columns: [
-                            metadata['p2.p2s1.d1'].id,
-                            metadata['tei1.enrollmentOu'].id,
-                            metadata['tei1.created'].id,
-                        ],
-                    },
-                    visualizationType: 'LINE_LIST',
-                },
-            })
-        )
-
-        const output = result.current
-
-        expect(output.action).toEqual('create')
-        expect(output.tooltipConfig).toEqual({
-            content:
-                'Not valid with registration date or registration org. unit',
         })
     })
 
@@ -546,33 +484,6 @@ describe('useActionButton for Enrollment button', () => {
         })
     })
 
-    it('returns correct result for: LL, registration date in layout', async () => {
-        const { result } = await renderHookWithAppWrapper(
-            () => useActionButton('ENROLLMENT'),
-            createStoreWithPreloadedState({
-                dimensionSelection: {
-                    dataSourceId: metadata.p2.id,
-                },
-                visUiConfig: {
-                    layout: {
-                        columns: [
-                            metadata['p2.p2s1.d1'].id,
-                            metadata['tei1.created'].id,
-                        ],
-                    },
-                    visualizationType: 'LINE_LIST',
-                },
-            })
-        )
-
-        const output = result.current
-
-        expect(output.action).toEqual('create')
-        expect(output.tooltipConfig).toEqual({
-            content: 'Not valid with registration date',
-        })
-    })
-
     it('returns correct result for: LL, registration org. unit in layout', async () => {
         const { result } = await renderHookWithAppWrapper(
             () => useActionButton('ENROLLMENT'),
@@ -597,35 +508,6 @@ describe('useActionButton for Enrollment button', () => {
         expect(output.action).toEqual('create')
         expect(output.tooltipConfig).toEqual({
             content: 'Not valid with registration org. unit',
-        })
-    })
-
-    it('returns correct result for: LL, registration date and registration org. unit in layout', async () => {
-        const { result } = await renderHookWithAppWrapper(
-            () => useActionButton('ENROLLMENT'),
-            createStoreWithPreloadedState({
-                dimensionSelection: {
-                    dataSourceId: metadata.p2.id,
-                },
-                visUiConfig: {
-                    layout: {
-                        columns: [
-                            metadata['p2.p2s1.d1'].id,
-                            metadata['tei1.enrollmentOu'].id,
-                            metadata['tei1.created'].id,
-                        ],
-                    },
-                    visualizationType: 'LINE_LIST',
-                },
-            })
-        )
-
-        const output = result.current
-
-        expect(output.action).toEqual('create')
-        expect(output.tooltipConfig).toEqual({
-            content:
-                'Not valid with registration date or registration org. unit',
         })
     })
 

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -19,30 +19,9 @@ import type { ButtonAction } from './base-button'
 
 type TooltipContent = { content: string; openDelay?: number } | undefined
 
-type RegistrationLayoutState = {
-    isRegistrationDateInLayout: boolean
-    isRegistrationOuInLayout: boolean
-}
-
-const getRegistrationTooltipContent = ({
-    isRegistrationDateInLayout,
-    isRegistrationOuInLayout,
-}: RegistrationLayoutState): TooltipContent => {
-    if (isRegistrationDateInLayout && isRegistrationOuInLayout) {
-        return {
-            content: i18n.t(
-                'Not valid with registration date or registration org. unit'
-            ),
-        }
-    }
-    if (isRegistrationDateInLayout) {
-        return { content: i18n.t('Not valid with registration date') }
-    }
-    if (isRegistrationOuInLayout) {
-        return { content: i18n.t('Not valid with registration org. unit') }
-    }
-    return undefined
-}
+const getRegistrationOuTooltipContent = (): TooltipContent => ({
+    content: i18n.t('Not valid with registration org. unit'),
+})
 
 type CategoryLayoutState = {
     hasCategoryInLayout: boolean
@@ -73,7 +52,6 @@ type EventTooltipContentParams = {
     hasNoProgramInLayout: boolean
     hasMultipleProgramsInLayout: boolean
     hasMultipleProgramStagesInLayout: boolean
-    isRegistrationDateInLayout: boolean
     isRegistrationOuInLayout: boolean
     visualizationType: string
 }
@@ -82,7 +60,6 @@ const getEventTooltipContent = ({
     hasNoProgramInLayout,
     hasMultipleProgramsInLayout,
     hasMultipleProgramStagesInLayout,
-    isRegistrationDateInLayout,
     isRegistrationOuInLayout,
     visualizationType,
 }: EventTooltipContentParams): TooltipContent => {
@@ -98,11 +75,8 @@ const getEventTooltipContent = ({
         return { content: i18n.t('Not valid with multiple programs') }
     }
 
-    if (isRegistrationDateInLayout || isRegistrationOuInLayout) {
-        return getRegistrationTooltipContent({
-            isRegistrationDateInLayout,
-            isRegistrationOuInLayout,
-        })
+    if (isRegistrationOuInLayout) {
+        return getRegistrationOuTooltipContent()
     }
 
     if (hasMultipleProgramStagesInLayout) {
@@ -118,7 +92,6 @@ type EnrollmentTooltipContentParams = {
     hasCategoryOptionGroupSetInLayout: boolean
     hasMultipleProgramsInLayout: boolean
     hasNoProgramInLayout: boolean
-    isRegistrationDateInLayout: boolean
     isRegistrationOuInLayout: boolean
     visualizationType: string
 }
@@ -129,7 +102,6 @@ const getEnrollmentTooltipContent = ({
     hasCategoryOptionGroupSetInLayout,
     hasNoProgramInLayout,
     hasMultipleProgramsInLayout,
-    isRegistrationDateInLayout,
     isRegistrationOuInLayout,
     visualizationType,
 }: EnrollmentTooltipContentParams): TooltipContent => {
@@ -149,11 +121,8 @@ const getEnrollmentTooltipContent = ({
         return { content: i18n.t('Not valid with event programs') }
     }
 
-    if (isRegistrationDateInLayout || isRegistrationOuInLayout) {
-        return getRegistrationTooltipContent({
-            isRegistrationDateInLayout,
-            isRegistrationOuInLayout,
-        })
+    if (isRegistrationOuInLayout) {
+        return getRegistrationOuTooltipContent()
     }
 
     return getCategoryTooltipContent({
@@ -341,11 +310,6 @@ export const useActionButton = (
         [layoutDimensionIds, metadataStore]
     )
 
-    const isRegistrationDateInLayout = useMemo(
-        () => (tetId ? isDimensionInLayout(layout, `${tetId}.created`) : false),
-        [layout, tetId]
-    )
-
     const isRegistrationOuInLayout = useMemo(
         () =>
             tetId
@@ -370,7 +334,6 @@ export const useActionButton = (
                     hasNoProgramInLayout,
                     hasMultipleProgramsInLayout,
                     hasMultipleProgramStagesInLayout,
-                    isRegistrationDateInLayout,
                     isRegistrationOuInLayout,
                     visualizationType,
                 })
@@ -381,7 +344,6 @@ export const useActionButton = (
                     hasCategoryOptionGroupSetInLayout,
                     hasNoProgramInLayout,
                     hasMultipleProgramsInLayout,
-                    isRegistrationDateInLayout,
                     isRegistrationOuInLayout,
                     visualizationType,
                 })
@@ -407,7 +369,6 @@ export const useActionButton = (
         hasMultipleTetInLayout,
         hasProgramIndicatorsInLayout,
         isLayoutEmpty,
-        isRegistrationDateInLayout,
         isRegistrationOuInLayout,
         visualizationType,
     ])

--- a/src/components/main-sidebar/cards-program-with-registration/card-tracked-entity-type.tsx
+++ b/src/components/main-sidebar/cards-program-with-registration/card-tracked-entity-type.tsx
@@ -48,10 +48,7 @@ export const CardTrackedEntityType: FC<CardTrackedEntityTypeProps> = ({
             program.trackedEntityType.name,
     })
     const fixedDimensions = useMemo(
-        () =>
-            getTrackedEntityTypeFixedDimensions(
-                program.trackedEntityType
-            ).filter((dimension) => dimension.dimensionId === 'enrollmentOu'),
+        () => getTrackedEntityTypeFixedDimensions(program.trackedEntityType),
         [program.trackedEntityType]
     )
     const baseQuery = useMemo(

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -558,7 +558,7 @@ describe('getCompoundDimensionId', () => {
         ).toBe('prog1.someField')
     })
 
-    it('uses trackedEntityTypeId prefix for TEI registration dimensions', () => {
+    it('uses trackedEntityTypeId prefix for the TEI registration org unit', () => {
         expect(
             getCompoundDimensionId(
                 { dimension: 'enrollmentOu', items: [] },
@@ -566,14 +566,6 @@ describe('getCompoundDimensionId', () => {
                 'tet1'
             )
         ).toBe('tet1.enrollmentOu')
-
-        expect(
-            getCompoundDimensionId(
-                { dimension: 'created', items: [] },
-                'TRACKED_ENTITY_INSTANCE',
-                'tet1'
-            )
-        ).toBe('tet1.created')
     })
 
     it('does not prefix non-registration dimensions with trackedEntityTypeId', () => {
@@ -609,12 +601,11 @@ describe('getCompoundDimensionId', () => {
 })
 
 describe('getTrackedEntityTypeFixedDimensions', () => {
-    it('returns registration org unit and registration date dimensions', () => {
+    it('returns the registration org unit dimension', () => {
         const fixedDimensions = getTrackedEntityTypeFixedDimensions({
             id: 'tet1',
         })
 
-        expect(fixedDimensions).toHaveLength(2)
         expect(fixedDimensions).toEqual([
             expect.objectContaining({
                 id: 'tet1.enrollmentOu',
@@ -622,21 +613,14 @@ describe('getTrackedEntityTypeFixedDimensions', () => {
                 dimensionType: 'ORGANISATION_UNIT',
                 trackedEntityTypeId: 'tet1',
             }),
-            expect.objectContaining({
-                id: 'tet1.created',
-                dimensionId: 'created',
-                dimensionType: 'PERIOD',
-                trackedEntityTypeId: 'tet1',
-            }),
         ])
     })
 
-    it('uses the tracked entity type id in compound IDs', () => {
+    it('uses the tracked entity type id in the compound ID', () => {
         const fixedDimensions = getTrackedEntityTypeFixedDimensions({
             id: 'custom-tet',
         })
 
         expect(fixedDimensions[0].id).toBe('custom-tet.enrollmentOu')
-        expect(fixedDimensions[1].id).toBe('custom-tet.created')
     })
 })

--- a/src/modules/__tests__/visualization.spec.ts
+++ b/src/modules/__tests__/visualization.spec.ts
@@ -486,16 +486,6 @@ describe('analyticsHeaderToCanonicalDimensionId', () => {
         )
     })
 
-    it('rewrites bare `created` to `tetId.created` in TE', () => {
-        const vis = buildVis({
-            outputType: 'TRACKED_ENTITY_INSTANCE',
-            trackedEntityType: { id: TET, name: 'Person' },
-        })
-        expect(analyticsHeaderToCanonicalDimensionId('created', vis)).toBe(
-            `${TET}.created`
-        )
-    })
-
     it('returns plain for other bare wire dims in TE', () => {
         const vis = buildVis({
             outputType: 'TRACKED_ENTITY_INSTANCE',

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -72,7 +72,7 @@ export const getCreatedDimension = (): Partial<
         id: 'created',
         dimensionId: 'created',
         dimensionType: 'PERIOD',
-        name: i18n.t('Registration date'),
+        name: i18n.t('Created on'),
         valueType: 'DATE',
     },
 })
@@ -371,7 +371,6 @@ const ENROLLMENT_SCOPED_DIMENSION_IDS: ReadonlySet<string> = new Set([
  * Must match what getTrackedEntityTypeFixedDimensions produces. */
 const TEI_REGISTRATION_DIMENSION_IDS: ReadonlySet<string> = new Set([
     'enrollmentOu',
-    'created',
 ])
 
 /**
@@ -512,13 +511,5 @@ export const getTrackedEntityTypeFixedDimensions = (trackedEntityType: {
         name: i18n.t('Registration org. unit'),
         trackedEntityTypeId: trackedEntityType.id,
         valueType: 'ORGANISATION_UNIT',
-    },
-    {
-        id: `${trackedEntityType.id}.created`,
-        dimensionId: 'created',
-        dimensionType: 'PERIOD',
-        name: i18n.t('Registration date'),
-        trackedEntityTypeId: trackedEntityType.id,
-        valueType: 'DATE',
     },
 ]

--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -128,9 +128,6 @@ export const analyticsHeaderToCanonicalDimensionId = (
         if (tetId && appLocalDim === 'ou') {
             return `${tetId}.enrollmentOu`
         }
-        if (tetId && appLocalDim === 'created') {
-            return `${tetId}.created`
-        }
         return appLocalDim
     }
 


### PR DESCRIPTION
Implements N/A

### Description

As discussed, this removes the "Registration date" fixed dimension from the TET card when choosing a TET data source. By this removal the TET cards for data sources of type tracker program, and TET are further aligned so this allowed for some code cleanup.

Some further cleanup was possible because we had some special handling (incl. tests) in place for this removed dimension.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---
