### PR TITLE
chore: remove unused initial metadata

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-12T10:29:27.262Z\n"
-"PO-Revision-Date: 2026-05-12T10:29:27.262Z\n"
+"POT-Creation-Date: 2026-05-13T12:26:32.491Z\n"
+"PO-Revision-Date: 2026-05-13T12:26:32.492Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -987,12 +987,6 @@ msgstr "Not answered"
 msgid "Registration date"
 msgstr "Registration date"
 
-msgid "Event status"
-msgstr "Event status"
-
-msgid "Program status"
-msgstr "Program status"
-
 msgid "Completed date"
 msgstr "Completed date"
 
@@ -1013,6 +1007,9 @@ msgstr "Scheduled date"
 
 msgid "Event org. unit"
 msgstr "Event org. unit"
+
+msgid "Event status"
+msgstr "Event status"
 
 msgid "Enrollment org. unit"
 msgstr "Enrollment org. unit"

--- a/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
+++ b/src/components/app-wrapper/metadata-provider/__tests__/metadata-store.spec.ts
@@ -433,18 +433,6 @@ describe('MetadataStore', () => {
               "id": "enrollmentDate",
               "name": "Enrollment date",
             },
-            "eventDate": {
-              "dimensionId": "eventDate",
-              "dimensionType": "PERIOD",
-              "id": "eventDate",
-              "name": "Event date",
-            },
-            "eventStatus": {
-              "dimensionId": "eventStatus",
-              "dimensionType": "STATUS",
-              "id": "eventStatus",
-              "name": "Event status",
-            },
             "gWxh7DiRmG7": {
               "dimensionId": "gWxh7DiRmG7",
               "dimensionType": "PROGRAM_INDICATOR",
@@ -486,21 +474,9 @@ describe('MetadataStore', () => {
               "id": "lastUpdatedOn",
               "name": "Last updated on",
             },
-            "ou": {
-              "dimensionId": "ou",
-              "dimensionType": "ORGANISATION_UNIT",
-              "id": "ou",
-              "name": "Organisation unit",
-            },
             "pe": {
               "id": "pe",
               "name": "Period",
-            },
-            "programStatus": {
-              "dimensionId": "programStatus",
-              "dimensionType": "STATUS",
-              "id": "programStatus",
-              "name": "Program status",
             },
             "sGna2pquXOO": {
               "dimensionId": "sGna2pquXOO",
@@ -554,9 +530,9 @@ describe('MetadataStore', () => {
         const snapshot2Keys = new Set(Object.keys(snapshot2))
 
         // Length grows and decreases
-        expect(snapshot0Keys.size).toBe(53)
-        expect(snapshot1Keys.size).toBe(82)
-        expect(snapshot2Keys.size).toBe(68)
+        expect(snapshot0Keys.size).toBe(43)
+        expect(snapshot1Keys.size).toBe(78)
+        expect(snapshot2Keys.size).toBe(64)
 
         // Initial metadata is always included
         expect(snapshot0Keys.isSubsetOf(snapshot1Keys)).toBe(true)
@@ -602,6 +578,12 @@ describe('MetadataStore', () => {
             )
         ).toMatchInlineSnapshot(`
           [
+            "completedDate",
+            "createdDate",
+            "enrollmentDate",
+            "incidentDate",
+            "lastUpdatedOn",
+            "scheduledDate",
             "lastUpdated",
             "createdBy",
             "lastUpdatedBy",
@@ -728,9 +710,7 @@ describe('MetadataStore', () => {
             const snapshot = metadataStore.getMetadataSnapshot()
             expect(snapshot.ou).toEqual({
                 id: 'ou',
-                dimensionId: 'ou',
                 name: 'Organisation Unit UPDATED',
-                dimensionType: 'ORGANISATION_UNIT',
             })
         })
 
@@ -754,9 +734,7 @@ describe('MetadataStore', () => {
             const snapshot = metadataStore.getMetadataSnapshot()
             expect(snapshot.eventDate).toEqual({
                 id: 'eventDate',
-                dimensionId: 'eventDate',
                 name: 'Report date',
-                dimensionType: 'PERIOD',
             })
         })
     })

--- a/src/components/app-wrapper/metadata-provider/initial-metadata.ts
+++ b/src/components/app-wrapper/metadata-provider/initial-metadata.ts
@@ -1,16 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
-import {
-    getCreatedDimension,
-    getProgramDimensions,
-    getTimeDimensions,
-} from '@modules/dimension'
+import { getCreatedDimension } from '@modules/dimension'
 import { getStatusNames } from '@modules/status'
-import type {
-    InitialMetadataItems,
-    MetadataInputMap,
-    UserOrgUnit,
-    RelativePeriod,
-} from '@types'
+import type { InitialMetadataItems, UserOrgUnit, RelativePeriod } from '@types'
 
 const getOrganisationUnits = (): Record<UserOrgUnit, string> => ({
     USER_ORGUNIT: i18n.t('User organisation unit'),
@@ -54,27 +45,12 @@ const getRelativePeriods = (): Record<RelativePeriod, string> => ({
     LAST_YEAR: i18n.t('Last year'),
 })
 
-export const getTimeDimensionsMetadata = (): MetadataInputMap =>
-    Object.values(getTimeDimensions()).reduce(
-        (acc, { id, dimensionType, defaultName }) => {
-            acc[id] = {
-                id,
-                name: defaultName,
-                dimensionType,
-            }
-            return acc
-        },
-        {}
-    )
-
 export const getInitialMetadata = (): InitialMetadataItems => ({
     // analytics metadata does not always return a name for pe
     // force a default to avoid the metadata store to throw an error when processing the analytics response
     pe: i18n.t('Period'),
     ...getStatusNames(),
-    ...getProgramDimensions(),
     ...getCreatedDimension(),
-    ...getTimeDimensionsMetadata(),
     ...getRelativePeriods(),
     ...getOrganisationUnits(),
 })

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -3,7 +3,6 @@ import { describe, it, expect } from 'vitest'
 import {
     getCreatedDimension,
     getMainDimensions,
-    getProgramDimensions,
     transformDimensions,
     isTimeDimensionId,
     getTimeDimensions,
@@ -44,19 +43,6 @@ describe('getMainDimensions', () => {
         expect(result).toHaveProperty('created')
         expect(result.created?.dimensionType).toBe('PERIOD')
         expect(result).toHaveProperty('lastUpdated')
-    })
-})
-
-describe('getProgramDimensions', () => {
-    it('returns program dimensions for a given programId', () => {
-        const programId = 'pid'
-        const result = getProgramDimensions(programId)
-        expect(result).toHaveProperty(`${programId}.ou`)
-        expect(result).toHaveProperty(`${programId}.eventStatus`)
-        expect(result).toHaveProperty(`${programId}.programStatus`)
-        expect(result[`${programId}.ou`].dimensionType).toBe(
-            'ORGANISATION_UNIT'
-        )
     })
 })
 

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -1,10 +1,7 @@
 import { TIME_DIMENSION_IDS } from '@constants/dimensions'
 import { USER_ORGUNIT } from '@constants/org-units'
 import i18n from '@dhis2/d2-i18n'
-import {
-    getDefaultOrgUnitLabel,
-    getDefaultOrgUnitMetadata,
-} from '@modules/metadata'
+import { getDefaultOrgUnitMetadata } from '@modules/metadata'
 import type {
     CurrentVisualization,
     DimensionArray,
@@ -104,29 +101,6 @@ export const getMainDimensions = (
         dimensionId: 'lastUpdatedBy',
         dimensionType: 'USER',
         name: i18n.t('Last updated by'),
-    },
-})
-
-const prefixDimensionId = (dimensionId: string, prefix?: string): string =>
-    prefix ? `${prefix}.${dimensionId}` : dimensionId
-
-export const getProgramDimensions = (
-    programId?: string
-): DimensionRecordObject => ({
-    [prefixDimensionId('ou', programId)]: {
-        id: prefixDimensionId('ou', programId),
-        dimensionType: 'ORGANISATION_UNIT',
-        name: getDefaultOrgUnitLabel(),
-    },
-    [prefixDimensionId('eventStatus', programId)]: {
-        id: prefixDimensionId('eventStatus', programId),
-        dimensionType: 'STATUS',
-        name: i18n.t('Event status'),
-    },
-    [prefixDimensionId('programStatus', programId)]: {
-        id: prefixDimensionId('programStatus', programId),
-        dimensionType: 'STATUS',
-        name: i18n.t('Program status'),
     },
 })
 


### PR DESCRIPTION
Implements N/A

### Description

While working on some other tasks it became apparent to me that some of the initial metadata has keys that do not match the app-local compound IDs. This metadata with the correct keys is produced while extracting the metadata from the visualization. So this initial metadata is now useless and can be removed.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---
