### PR TITLE
chore: fix flaky test and add Testing Library ESLint rules [DHIS2-21485]

### DIFF
--- a/.claude/commands/sonarqube-fix.md
+++ b/.claude/commands/sonarqube-fix.md
@@ -2,7 +2,7 @@
 
 Fix SonarQube quality gate failures systematically by fetching issues directly from the API and addressing them in priority order.
 
-**Note**: Designed for **public projects only**. All DHIS2 projects on SonarCloud are public, so no authentication is required. For private projects, authentication would be needed (not covered here).
+**Note**: Designed for **public projects only**. All DHIS2 projects on SonarCloud are public, so every API call in this workflow can be made anonymously — no `SONAR_TOKEN` needed. For private projects you'd need authentication (not covered here).
 
 ## When to Use
 
@@ -114,17 +114,44 @@ Fix any regressions immediately before continuing. Never accumulate fixes withou
 
 ### Step 5: Publish to SonarCloud
 
-Once a batch of fixes is complete and tests pass:
+Local upload and server-side processing are separate steps. The plan is:
+
+1. Record the **previous** `analysisDate` for this branch so we have a baseline to compare against.
+2. Run `pnpm sonar` (waits for the scanner upload to finish).
+3. Poll the same endpoint until `analysisDate` changes — that's how we know the new report has been processed.
+
+Capture the baseline:
+
+```bash
+BEFORE_DATE=$(curl -s "https://sonarcloud.io/api/components/show?component=<org>_<repo>&branch=<branch-name>" \
+  | jq -r '.component.analysisDate')
+echo "$BEFORE_DATE"
+```
+
+URL-encode the branch name (e.g. `feat%2Fupdate-buttons`). If this is the first scan for the branch, `analysisDate` may be `null` — that's fine; the comparison below still works.
+
+Then publish:
 
 ```bash
 pnpm sonar
 ```
 
-This takes several minutes. Wait for it to finish before fetching results.
+The scanner upload takes a minute or two. The tail of the output ends with `ANALYSIS SUCCESSFUL, you can find the results at: ...`. That means the upload finished — but processing is still queued server-side, so don't fetch issues yet.
 
-### Step 6: Fetch Branch Results and Verify
+### Step 6: Wait for Server-Side Processing
 
-After `pnpm sonar` completes, verify using the **branch** parameter (not `pullRequest`):
+Poll until `analysisDate` differs from the baseline. SonarCloud usually processes a report in under a minute, sometimes several:
+
+```bash
+curl -s "https://sonarcloud.io/api/components/show?component=<org>_<repo>&branch=<branch-name>" \
+  | jq -r '.component.analysisDate'
+```
+
+When the returned value is non-null and not equal to `$BEFORE_DATE`, the new analysis has landed. Sleep 10–15 seconds between checks and cap the wait (e.g. 5 minutes). Don't use an uncapped `until` loop — if the URL is mistyped or the branch was deleted you'll spin forever.
+
+### Step 7: Fetch Branch Results and Verify
+
+Once `analysisDate` has updated, verify using the **branch** parameter (not `pullRequest`):
 
 ```bash
 curl -s "https://sonarcloud.io/api/issues/search?componentKeys=<org>_<repo>&branch=<branch-name>&resolved=false&ps=100" \
@@ -136,7 +163,9 @@ Note: URL-encode the branch name (e.g. `feat%2Fupdate-buttons` for `feat/update-
 - Issues remain → return to Step 3 and continue fixing
 - No issues → process is complete
 
-### Step 7: Completion Criteria
+The PR-scoped query (`pullRequest=<pr-number>`) will continue showing the old issues until you push the new commit and GitHub's PR analysis re-runs. After pushing, that view catches up too.
+
+### Step 8: Completion Criteria
 
 The process is complete when all of the following are true:
 
@@ -157,8 +186,9 @@ User: /sonarqube-fix
 3. Create todos for all 3 issues
 4. Fix MINOR BUG first (it's a BUG), then the two CODE_SMELLs
 5. After fixes: pnpm test && pnpm lint → passes
-6. pnpm sonar → publishes results
-7. Branch API → 0 issues remaining ✅
+6. Capture `analysisDate` baseline, then `pnpm sonar` to publish
+7. Poll `/api/components/show` until `analysisDate` changes
+8. Branch API → 0 issues remaining ✅
 ```
 
 ### Example 2: On main branch, multiple open PRs
@@ -198,7 +228,15 @@ User: /sonarqube-fix
 
 - Always re-fetch using the **branch** URL (not the PR URL) after `pnpm sonar`
 - SonarCloud only updates after the publish step — results won't change without running `pnpm sonar`
+- The PR-scoped view stays stuck on the old commit's analysis until you push and CI re-runs against the pushed SHA
 - Continue working through remaining issues from the branch results
+
+### `analysisDate` never changes after `pnpm sonar`
+
+- Confirm the branch name is URL-encoded correctly (e.g. `chore%2Ffix-flaky-test`, not `chore/fix-flaky-test`)
+- Check the scanner output for `ANALYSIS SUCCESSFUL`. If the upload itself failed, no new analysis will ever be queued
+- If you used the wrong component key, the endpoint returns `{"errors":[{"msg":"Component key '...' not found"}]}` — `jq` will yield `null` for `.component.analysisDate` indefinitely
+- Cap your poll loop (e.g. 5 minutes) so a misconfiguration doesn't hang the workflow
 
 ### GitHub CLI issues
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -139,11 +139,6 @@ export default defineConfig([
         rules: {
             // Disabled so we can access DHIS2-UI internals by className etc.
             'testing-library/no-node-access': 'off',
-        },
-    },
-    {
-        files: ['src/**/*.spec.{ts,tsx}'],
-        rules: {
             'no-restricted-globals': [
                 'error',
                 {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -137,16 +137,8 @@ export default defineConfig([
         files: ['src/**/*.spec.{ts,tsx}'],
         extends: [testingLibrary.configs['flat/react']],
         rules: {
-            /* Rules below flag real-best-practices but currently have a
-             * non-trivial number of violations across the codebase. They are
-             * disabled here so the preset can be adopted without a large
-             * cleanup PR; re-enable them one at a time as the cleanups land. */
-            'testing-library/prefer-screen-queries': 'off',
+            // Disabled so we can access DHIS2-UI internals by className etc.
             'testing-library/no-node-access': 'off',
-            'testing-library/no-unnecessary-act': 'off',
-            'testing-library/render-result-naming-convention': 'off',
-            'testing-library/no-wait-for-multiple-assertions': 'off',
-            'testing-library/prefer-presence-queries': 'off',
         },
     },
     {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { includeIgnoreFile } from '@eslint/compat'
 import dhis2ReactConfig from '@dhis2/config-eslint/react'
 import { defineConfig, globalIgnores } from 'eslint/config'
 import { fileURLToPath } from 'node:url'
+import testingLibrary from 'eslint-plugin-testing-library'
 
 const gitignorePath = fileURLToPath(new URL('.gitignore', import.meta.url))
 
@@ -127,7 +128,27 @@ export default defineConfig([
         },
     },
 
-    // Override: vitest spec files
+    // Override: vitest spec files — apply testing-library/react preset to
+    // catch missing-await on async utils (`waitFor`, `findBy*`, etc.) and
+    // other React Testing Library footguns. Scoped to Vitest specs only;
+    // Cypress component tests use a different auto-retrying query API and
+    // would produce false positives under these rules.
+    {
+        files: ['src/**/*.spec.{ts,tsx}'],
+        extends: [testingLibrary.configs['flat/react']],
+        rules: {
+            /* Rules below flag real-best-practices but currently have a
+             * non-trivial number of violations across the codebase. They are
+             * disabled here so the preset can be adopted without a large
+             * cleanup PR; re-enable them one at a time as the cleanups land. */
+            'testing-library/prefer-screen-queries': 'off',
+            'testing-library/no-node-access': 'off',
+            'testing-library/no-unnecessary-act': 'off',
+            'testing-library/render-result-naming-convention': 'off',
+            'testing-library/no-wait-for-multiple-assertions': 'off',
+            'testing-library/prefer-presence-queries': 'off',
+        },
+    },
     {
         files: ['src/**/*.spec.{ts,tsx}'],
         rules: {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "cypress-real-events": "^1.15.0",
         "cypress-tags": "^1.2.2",
         "eslint": "^9.39.4",
+        "eslint-plugin-testing-library": "^7.16.2",
         "jsdom": "^29.1.1",
         "lint-staged": "^16.4.0",
         "openapi-typescript": "^7.13.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4
+      eslint-plugin-testing-library:
+        specifier: ^7.16.2
+        version: 7.16.2(eslint@9.39.4)(typescript@5.9.3)
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
@@ -4329,6 +4332,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-testing-library@7.16.2:
+    resolution: {integrity: sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -13909,6 +13918,15 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-testing-library@7.16.2(eslint@9.39.4)(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.58.1
+      '@typescript-eslint/utils': 8.58.1(eslint@9.39.4)(typescript@5.9.3)
+      eslint: 9.39.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   eslint-scope@5.1.1:
     dependencies:

--- a/src/components/app-wrapper/metadata-provider/__tests__/metadata-provider.spec.tsx
+++ b/src/components/app-wrapper/metadata-provider/__tests__/metadata-provider.spec.tsx
@@ -537,9 +537,7 @@ describe('PluginMetadataProvider API and return value types', () => {
                 result.current.useMetadataStoreResult.getMetadataItems,
         }
 
-        act(() => {
-            rerender()
-        })
+        rerender()
 
         expect(result.current.useAddMetadataResult).toEqual(
             initialFunctions.useAddMetadata
@@ -645,7 +643,10 @@ describe('PluginMetadataProvider — compound-key alias resolution via hooks', (
             result.current.store.addMetadata(makeDimension('Weight v1'))
         })
 
-        const rendersAfterFirstAdd = renderCount
+        /* False positive: the rule sees `renderCount` on the RHS and
+         * misclassifies this as a `render()` result. It's a plain number. */
+        // eslint-disable-next-line testing-library/render-result-naming-convention
+        const countAfterFirstAdd = renderCount
 
         // Now update the item under the canonical key
         act(() => {
@@ -653,7 +654,7 @@ describe('PluginMetadataProvider — compound-key alias resolution via hooks', (
         })
 
         // Hook should have re-rendered because the subscribed 3-part alias key was notified
-        expect(renderCount).toBeGreaterThan(rendersAfterFirstAdd)
+        expect(renderCount).toBeGreaterThan(countAfterFirstAdd)
         expect(result.current.item?.name).toBe('Weight v2')
     })
 

--- a/src/components/layout-panel/axis/__tests__/drop-insert-marker.spec.tsx
+++ b/src/components/layout-panel/axis/__tests__/drop-insert-marker.spec.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { type ClientRect, type DndMonitorListener } from '@dnd-kit/core'
 import type { useSortable } from '@dnd-kit/sortable'
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { DropInsertMarker } from '../drop-insert-marker'
 import classes from '../styles/drop-insert-marker.module.css'
@@ -70,7 +70,7 @@ describe('DropInsertMarker', () => {
             rect: { current: createMockRect({ left: 0, width: 100 }) },
         } as any
 
-        const { queryByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -78,7 +78,9 @@ describe('DropInsertMarker', () => {
             />
         )
 
-        expect(queryByTestId('drop-insert-marker')).not.toBeInTheDocument()
+        expect(
+            screen.queryByTestId('drop-insert-marker')
+        ).not.toBeInTheDocument()
     })
 
     it('should render marker at start when dragged from different axis (before center)', () => {
@@ -95,7 +97,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { getByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -106,7 +108,7 @@ describe('DropInsertMarker', () => {
         // pointerX = 120 + 0 = 120, before chip center at 150
         fireDragMove({ active, clientX: 120, deltaX: 0 })
 
-        const marker = getByTestId('drop-insert-marker')
+        const marker = screen.getByTestId('drop-insert-marker')
         expect(marker).toBeInTheDocument()
         expect(marker).not.toHaveClass(classes.atEnd)
     })
@@ -125,7 +127,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { getByTestId, queryByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -136,7 +138,7 @@ describe('DropInsertMarker', () => {
         // pointerX = 120 + 0 = 120, before chip center at 150
         fireDragMove({ active, clientX: 120, deltaX: 0 })
 
-        let marker = getByTestId('drop-insert-marker')
+        const marker = screen.getByTestId('drop-insert-marker')
         expect(marker).toBeInTheDocument()
         expect(marker).not.toHaveClass(classes.atEnd)
 
@@ -144,9 +146,9 @@ describe('DropInsertMarker', () => {
         fireDragMove({ active, clientX: 100, deltaX: 100 })
 
         await waitFor(() => {
-            marker = queryByTestId('drop-insert-marker')!
-            expect(marker).toBeInTheDocument()
-            expect(marker).toHaveClass(classes.atEnd)
+            expect(screen.queryByTestId('drop-insert-marker')).toHaveClass(
+                classes.atEnd
+            )
         })
     })
 
@@ -165,7 +167,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { getByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={setInsertAfter}
@@ -175,13 +177,17 @@ describe('DropInsertMarker', () => {
 
         // pointerX = 120 + 0 = 120, before chip center at 150
         fireDragMove({ active, clientX: 120, deltaX: 0 })
-        expect(getByTestId('drop-insert-marker')).not.toHaveClass(classes.atEnd)
+        expect(screen.getByTestId('drop-insert-marker')).not.toHaveClass(
+            classes.atEnd
+        )
 
         // Move past chip center (pointerX = 50 + 150 = 200 > 150)
         fireDragMove({ active, clientX: 50, deltaX: 150 })
 
         await waitFor(() => {
-            expect(getByTestId('drop-insert-marker')).toHaveClass(classes.atEnd)
+            expect(screen.getByTestId('drop-insert-marker')).toHaveClass(
+                classes.atEnd
+            )
             expect(setInsertAfter).toHaveBeenCalledWith(true)
         })
     })
@@ -200,7 +206,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { queryByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -213,7 +219,9 @@ describe('DropInsertMarker', () => {
         fireDragMove({ active, clientX: 100, deltaX: 100 })
 
         await waitFor(() => {
-            expect(queryByTestId('drop-insert-marker')).not.toBeInTheDocument()
+            expect(
+                screen.queryByTestId('drop-insert-marker')
+            ).not.toBeInTheDocument()
         })
     })
 
@@ -231,7 +239,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { queryByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -243,7 +251,9 @@ describe('DropInsertMarker', () => {
         // adjacentIndex = 1-1 = 0 = activeIndex → no-op
         fireDragMove({ active, clientX: 120, deltaX: 0 })
 
-        expect(queryByTestId('drop-insert-marker')).not.toBeInTheDocument()
+        expect(
+            screen.queryByTestId('drop-insert-marker')
+        ).not.toBeInTheDocument()
     })
 
     it('should render when hovering non-adjacent chip on same axis', () => {
@@ -260,7 +270,7 @@ describe('DropInsertMarker', () => {
             rect: { current: chipRect },
         } as any
 
-        const { getByTestId } = render(
+        render(
             <DropInsertMarker
                 sortable={mockSortable}
                 setInsertAfter={vi.fn()}
@@ -271,7 +281,7 @@ describe('DropInsertMarker', () => {
         // pointerX = 120 + 0 = 120, before chip center at 150
         fireDragMove({ active, clientX: 120, deltaX: 0 })
 
-        const marker = getByTestId('drop-insert-marker')
+        const marker = screen.getByTestId('drop-insert-marker')
         expect(marker).toBeInTheDocument()
     })
 })

--- a/src/components/main-sidebar/__tests__/unified-search-input.spec.tsx
+++ b/src/components/main-sidebar/__tests__/unified-search-input.spec.tsx
@@ -86,9 +86,7 @@ describe('UnifiedSearchInput', () => {
         const input = screen.getByTestId('unified-search-input')
 
         // Type a search term using fireEvent (not userEvent to avoid timer conflicts)
-        act(() => {
-            fireEvent.change(input, { target: { value: 'test' } })
-        })
+        fireEvent.change(input, { target: { value: 'test' } })
 
         // Should not dispatch immediately
         expect(mockDispatch).not.toHaveBeenCalled()
@@ -118,9 +116,7 @@ describe('UnifiedSearchInput', () => {
         const input = screen.getByTestId('unified-search-input')
 
         // Type a single character
-        act(() => {
-            fireEvent.change(input, { target: { value: 'a' } })
-        })
+        fireEvent.change(input, { target: { value: 'a' } })
 
         // Fast-forward past debounce time
         act(() => {
@@ -144,9 +140,7 @@ describe('UnifiedSearchInput', () => {
         const input = screen.getByTestId('unified-search-input')
 
         // Clear the search
-        act(() => {
-            fireEvent.change(input, { target: { value: '' } })
-        })
+        fireEvent.change(input, { target: { value: '' } })
 
         // Fast-forward past debounce time
         act(() => {
@@ -169,9 +163,7 @@ describe('UnifiedSearchInput', () => {
         const input = screen.getByTestId('unified-search-input')
 
         // Type '123'
-        act(() => {
-            fireEvent.change(input, { target: { value: '123' } })
-        })
+        fireEvent.change(input, { target: { value: '123' } })
 
         // Fast-forward past debounce time - should dispatch
         act(() => {
@@ -192,9 +184,7 @@ describe('UnifiedSearchInput', () => {
         })
 
         // Type '1234'
-        act(() => {
-            fireEvent.change(input, { target: { value: '1234' } })
-        })
+        fireEvent.change(input, { target: { value: '1234' } })
 
         // Fast-forward but not past debounce time
         act(() => {
@@ -202,9 +192,7 @@ describe('UnifiedSearchInput', () => {
         })
 
         // Before debounce elapses, change back to '123'
-        act(() => {
-            fireEvent.change(input, { target: { value: '123' } })
-        })
+        fireEvent.change(input, { target: { value: '123' } })
 
         // Fast-forward past debounce time
         act(() => {
@@ -222,9 +210,7 @@ describe('UnifiedSearchInput', () => {
             const input = screen.getByTestId('unified-search-input')
 
             // Type a single character
-            act(() => {
-                fireEvent.change(input, { target: { value: 'a' } })
-            })
+            fireEvent.change(input, { target: { value: 'a' } })
 
             // Should not show help message immediately
             expect(
@@ -282,9 +268,7 @@ describe('UnifiedSearchInput', () => {
             const input = screen.getByTestId('unified-search-input')
 
             // Type a single character
-            act(() => {
-                fireEvent.change(input, { target: { value: 'a' } })
-            })
+            fireEvent.change(input, { target: { value: 'a' } })
 
             // Fast-forward to show help message
             act(() => {
@@ -295,9 +279,7 @@ describe('UnifiedSearchInput', () => {
             ).toBeInTheDocument()
 
             // Clear the input (empty is valid)
-            act(() => {
-                fireEvent.change(input, { target: { value: '' } })
-            })
+            fireEvent.change(input, { target: { value: '' } })
 
             // Help message should disappear immediately
             expect(
@@ -311,9 +293,7 @@ describe('UnifiedSearchInput', () => {
             const input = screen.getByTestId('unified-search-input')
 
             // Type a single character
-            act(() => {
-                fireEvent.change(input, { target: { value: 'a' } })
-            })
+            fireEvent.change(input, { target: { value: 'a' } })
 
             // Fast-forward partway (1000ms)
             act(() => {
@@ -321,9 +301,7 @@ describe('UnifiedSearchInput', () => {
             })
 
             // Make it valid before help message would show
-            act(() => {
-                fireEvent.change(input, { target: { value: 'ab' } })
-            })
+            fireEvent.change(input, { target: { value: 'ab' } })
 
             // Fast-forward past original 2000ms
             act(() => {
@@ -429,9 +407,7 @@ describe('UnifiedSearchInput', () => {
             const input = screen.getByTestId('unified-search-input')
 
             // Type a search term while loading
-            act(() => {
-                fireEvent.change(input, { target: { value: 'test' } })
-            })
+            fireEvent.change(input, { target: { value: 'test' } })
 
             // Fast-forward past debounce time (250ms)
             act(() => {

--- a/src/components/main-sidebar/__tests__/use-resizable-sidebar.spec.ts
+++ b/src/components/main-sidebar/__tests__/use-resizable-sidebar.spec.ts
@@ -26,11 +26,10 @@ const createStore = (mainSidebarWidth = MAIN_SIDEBAR_DEFAULT_WIDTH) =>
 
 const renderResizableHook = (mainSidebarWidth = MAIN_SIDEBAR_DEFAULT_WIDTH) => {
     const store = createStore(mainSidebarWidth)
-    const hookResult = renderHookWithReduxStoreProvider(
-        () => useResizableSidebar(),
-        store
-    )
-    return { ...hookResult, store }
+    return {
+        ...renderHookWithReduxStoreProvider(() => useResizableSidebar(), store),
+        store,
+    }
 }
 
 describe('useResizableSidebar', () => {

--- a/src/components/main-sidebar/use-dimension-list/__tests__/use-dimension-list.spec.ts
+++ b/src/components/main-sidebar/use-dimension-list/__tests__/use-dimension-list.spec.ts
@@ -159,12 +159,12 @@ describe('useDimensionList - Fake Timers with Real Redux Store', () => {
         hook: () => ReturnType<typeof useDimensionList>,
         store: ReturnType<typeof setupStore>
     ) => {
-        const renderResult = renderHookWithReduxStoreProvider(hook, store)
+        const view = renderHookWithReduxStoreProvider(hook, store)
 
         // Advance timers to complete initial fetch (mount effect + API delay)
         await act(() => vi.advanceTimersByTimeAsync(mockApiDelay))
 
-        return renderResult
+        return view
     }
 
     // ===== BASIC HOOK TESTS =====

--- a/src/components/plugin-wrapper/__tests__/plugin-wrapper.spec.tsx
+++ b/src/components/plugin-wrapper/__tests__/plugin-wrapper.spec.tsx
@@ -6,6 +6,7 @@ import { getIsVisualizationLoading } from '@store/loader-slice'
 import { setNavigationState } from '@store/navigation-slice'
 import type { RootState } from '@store/store'
 import { renderWithAppWrapper, type MockOptions } from '@test-utils/app-wrapper'
+import { createDeferredQuery } from '@test-utils/deferred-query'
 import { act, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { Sorting } from '@types'
@@ -21,16 +22,21 @@ describe('PluginWrapper', () => {
     const eventVisualization2Id = 'waPjzoJyIQ9'
     const mockOnDataSorted = vi.fn()
     const mockOnResponsesReceived = vi.fn()
+    /* The analytics handler is deferred so each test can hold the response
+     * in flight long enough to assert the in-flight UI (spinner shown), then
+     * call `releaseAll()` to let the response arrive and assert the settled
+     * UI (spinner gone). A fixed `setTimeout`-based delay left the
+     * spinner-visible window racing against `userEvent.click` + scheduling
+     * jitter on slow CI runners — the spinner could disappear before
+     * `waitFor`'s first poll, causing flakes. */
+    const deferredAnalytics = createDeferredQuery()
     const mockOptions = {
         queryData: {
-            analytics: async (_, query) => {
-                await new Promise((resolve) => setTimeout(resolve, 200)) // For this follow-up request
-                if (query.params.dimension.includes('qrur9Dvnyt5:GE:5:LE:10')) {
-                    return analyticsResponse1
-                } else {
-                    return analyticsResponse2
-                }
-            },
+            analytics: deferredAnalytics.defer((_, query) =>
+                query.params.dimension.includes('qrur9Dvnyt5:GE:5:LE:10')
+                    ? analyticsResponse1
+                    : analyticsResponse2
+            ),
             // mock the POST to dataStatistics done in the eventVisualization endpoint
             dataStatistics: {},
             eventVisualizations: async (_, query) => {
@@ -114,6 +120,8 @@ describe('PluginWrapper', () => {
             ).not.toBeInTheDocument()
         })
 
+        await deferredAnalytics.releaseAll()
+
         // When analytics data comes in, the loader is removed and the table shows
         await waitFor(() => {
             expect(
@@ -128,6 +136,7 @@ describe('PluginWrapper', () => {
 
     beforeEach(() => {
         vi.clearAllMocks()
+        deferredAnalytics.reset()
     })
 
     it('should render the loading spinner while loading and switching visualizations', async () => {
@@ -179,6 +188,8 @@ describe('PluginWrapper', () => {
             ).not.toBeInTheDocument()
         })
 
+        await deferredAnalytics.releaseAll()
+
         // When analytics data comes in, the loader is removed and the table shows
         await waitFor(() => {
             expect(
@@ -219,6 +230,8 @@ describe('PluginWrapper', () => {
                 screen.getByTestId('line-list-data-table')
             ).toBeInTheDocument()
         })
+
+        await deferredAnalytics.releaseAll()
 
         // When analytics data comes in, the loader is removed and the table still shows
         await waitFor(() => {
@@ -267,6 +280,8 @@ describe('PluginWrapper', () => {
                 screen.getByTestId('line-list-data-table')
             ).toBeInTheDocument()
         })
+
+        await deferredAnalytics.releaseAll()
 
         // When analytics data comes in, the loader is removed and the table still shows
         await waitFor(() => {

--- a/src/components/toolbar/title-bar/__tests__/title-bar.spec.tsx
+++ b/src/components/toolbar/title-bar/__tests__/title-bar.spec.tsx
@@ -1,7 +1,7 @@
 import { setCurrentVis } from '@store/current-vis-slice'
 import { setSavedVis } from '@store/saved-vis-slice'
 import { renderWithAppWrapper } from '@test-utils/app-wrapper'
-import { act, screen, waitFor } from '@testing-library/react'
+import { act, screen } from '@testing-library/react'
 import type { SavedVisualization } from '@types'
 import { describe, it, expect } from 'vitest'
 import eventVisualization1 from '../__fixtures__/inpatient-cases-5-to-15-years-this-year.json'
@@ -31,12 +31,8 @@ describe('TitleBar', () => {
             )
         )
 
-        waitFor(() => {
-            expect(screen.getByTestId('title-bar')).toBeInTheDocument()
-            expect(
-                screen.getByText('Unsaved visualization')
-            ).toBeInTheDocument()
-        })
+        expect(screen.getByTestId('title-bar')).toBeInTheDocument()
+        expect(screen.getByText('Unsaved visualization')).toBeInTheDocument()
     })
 
     it('should render the visualization title when looking at a saved visualization', async () => {
@@ -58,12 +54,8 @@ describe('TitleBar', () => {
             )
         )
 
-        waitFor(() => {
-            expect(screen.getByTestId('title-bar')).toBeInTheDocument()
-            expect(
-                screen.getByText(eventVisualization1.name)
-            ).toBeInTheDocument()
-        })
+        expect(screen.getByTestId('title-bar')).toBeInTheDocument()
+        expect(screen.getByText(eventVisualization1.name)).toBeInTheDocument()
     })
 
     it('should render the visualization title with the Edited label when editing a loaded visualization', async () => {
@@ -86,12 +78,8 @@ describe('TitleBar', () => {
             )
         )
 
-        waitFor(() => {
-            expect(screen.getByTestId('title-bar')).toBeInTheDocument()
-            expect(
-                screen.getByText(eventVisualization1.name)
-            ).toBeInTheDocument()
-            expect(screen.getByText('Edited')).toBeInTheDocument()
-        })
+        expect(screen.getByTestId('title-bar')).toBeInTheDocument()
+        expect(screen.getByText(eventVisualization1.name)).toBeInTheDocument()
+        expect(screen.getByText('Edited')).toBeInTheDocument()
     })
 })

--- a/src/components/toolbar/title-bar/__tests__/title-bar.spec.tsx
+++ b/src/components/toolbar/title-bar/__tests__/title-bar.spec.tsx
@@ -11,7 +11,7 @@ describe('TitleBar', () => {
     it('should not render a title text when the visualization is empty', async () => {
         await renderWithAppWrapper(<TitleBar />)
 
-        expect(screen.queryByTestId('title-bar')).toBeInTheDocument()
+        expect(screen.getByTestId('title-bar')).toBeInTheDocument()
         expect(screen.queryByTestId('title-text')).not.toBeInTheDocument()
     })
 

--- a/src/test-utils/__tests__/deferred-query.spec.ts
+++ b/src/test-utils/__tests__/deferred-query.spec.ts
@@ -1,0 +1,68 @@
+import { createDeferredQuery } from '@test-utils/deferred-query'
+import { describe, it, expect } from 'vitest'
+
+describe('createDeferredQuery', () => {
+    it('keeps wrapped requests pending until releaseAll is called', async () => {
+        const { defer, releaseAll, pendingCount } = createDeferredQuery()
+        const handler = defer(() => 'response')
+
+        let resolved: string | undefined
+        const requestPromise = (handler('any', {}) as Promise<string>).then(
+            (value) => {
+                resolved = value
+            }
+        )
+
+        // Microtask flush — handler is pending, has not resolved
+        await Promise.resolve()
+        expect(resolved).toBeUndefined()
+        expect(pendingCount()).toBe(1)
+
+        await releaseAll()
+        await requestPromise
+
+        expect(resolved).toBe('response')
+        expect(pendingCount()).toBe(0)
+    })
+
+    it('releases all in-flight handlers in a single releaseAll call', async () => {
+        const { defer, releaseAll, pendingCount } = createDeferredQuery()
+        const handler = defer((_, query: { id: string }) => query.id)
+
+        const first = handler('any', { id: 'a' }) as Promise<string>
+        const second = handler('any', { id: 'b' }) as Promise<string>
+
+        expect(pendingCount()).toBe(2)
+
+        await releaseAll()
+
+        expect(await first).toBe('a')
+        expect(await second).toBe('b')
+        expect(pendingCount()).toBe(0)
+    })
+
+    it('passes errors thrown in the handler through to the caller', async () => {
+        const { defer, releaseAll } = createDeferredQuery()
+        const handler = defer(() => {
+            throw new Error('boom')
+        })
+
+        const requestPromise = handler('any', {}) as Promise<unknown>
+        await releaseAll()
+
+        await expect(requestPromise).rejects.toThrow('boom')
+    })
+
+    it('reset clears pending requests without resolving them', () => {
+        const { defer, reset, pendingCount } = createDeferredQuery()
+        const handler = defer(() => 'response')
+
+        handler('any', {})
+        handler('any', {})
+        expect(pendingCount()).toBe(2)
+
+        reset()
+
+        expect(pendingCount()).toBe(0)
+    })
+})

--- a/src/test-utils/deferred-query.ts
+++ b/src/test-utils/deferred-query.ts
@@ -24,21 +24,27 @@ type QueryHandler<T> = (type: any, query: any) => T | Promise<T>
 export const createDeferredQuery = () => {
     let pending: Array<() => void> = []
 
+    const enqueue = <T>(
+        handler: QueryHandler<T>,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        type: any,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        query: any
+    ) =>
+        new Promise<T>((resolve, reject) => {
+            pending.push(() => {
+                try {
+                    Promise.resolve(handler(type, query)).then(resolve, reject)
+                } catch (err) {
+                    reject(err)
+                }
+            })
+        })
+
     const defer =
         <T>(handler: QueryHandler<T>): QueryHandler<T> =>
         (type, query) =>
-            new Promise<T>((resolve, reject) => {
-                pending.push(() => {
-                    try {
-                        Promise.resolve(handler(type, query)).then(
-                            resolve,
-                            reject
-                        )
-                    } catch (err) {
-                        reject(err)
-                    }
-                })
-            })
+            enqueue(handler, type, query)
 
     const releaseAll = async () => {
         await waitFor(() => {

--- a/src/test-utils/deferred-query.ts
+++ b/src/test-utils/deferred-query.ts
@@ -1,0 +1,63 @@
+import { waitFor } from '@testing-library/react'
+
+/* Query/type are loosely typed because the upstream `queryData` mock surface
+ * (via CustomDataProvider in @dhis2/app-runtime) is not strongly typed either,
+ * and the existing mocks in the codebase rely on implicit-any access on
+ * `query.params.*` and `query.id`. Forcing `unknown` here would push casts
+ * into every test for no real safety win. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type QueryHandler<T> = (type: any, query: any) => T | Promise<T>
+
+/**
+ * Wraps `queryData` handlers used by `renderWithAppWrapper` so the test can
+ * decide when each mocked request resolves. `defer(handler)` returns a handler
+ * whose returned Promise only settles once `releaseAll()` is called; until then
+ * the request stays in flight and the app stays in its loading state.
+ *
+ * The reason this exists: a plain `setTimeout(N)`-based mock leaves the
+ * spinner-visible window racing against `userEvent.click` + scheduler jitter,
+ * which on slow CI can elapse the window before the test's first DOM poll. A
+ * deferred resolution removes the timing race entirely — the response arrives
+ * when the test says so, the way a real server's response does after a real
+ * (variable) latency.
+ */
+export const createDeferredQuery = () => {
+    let pending: Array<() => void> = []
+
+    const defer =
+        <T>(handler: QueryHandler<T>): QueryHandler<T> =>
+        (type, query) =>
+            new Promise<T>((resolve, reject) => {
+                pending.push(() => {
+                    try {
+                        Promise.resolve(handler(type, query)).then(
+                            resolve,
+                            reject
+                        )
+                    } catch (err) {
+                        reject(err)
+                    }
+                })
+            })
+
+    const releaseAll = async () => {
+        await waitFor(() => {
+            if (pending.length === 0) {
+                throw new Error(
+                    'createDeferredQuery: no pending requests to release'
+                )
+            }
+        })
+        const toRelease = pending
+        pending = []
+        toRelease.forEach((fn) => fn())
+    }
+
+    const reset = () => {
+        pending = []
+    }
+
+    const pendingCount = () => pending.length
+
+    return { defer, releaseAll, reset, pendingCount }
+}


### PR DESCRIPTION
Implements [DHIS2-21485](https://dhis2.atlassian.net/browse/DHIS2-21485)

### Description

While working on fixing the flaky tests I ran into some other things that could be improved, so now this PR has a broader scope:
1. The flaky test was fixed by adding the `createDeferredQuery` helper. This is now being used in the problematic `src/components/plugin-wrapper/__tests__/plugin-wrapper.spec.tsx` file. Instead of working with timeouts and hoping that we avoid race conditions we can control when queries resolve in the test. This is useful when you are asserting loading states because you can now write tests steps like these:
    1. Take action that triggers request
    2. Assert loading state
    3. Resolve the request
    4. Assert loaded state
5. After introducing this helper Claude scanned the codebase for other tests that might benefit from the new helper. It didn't identify any tests, but it did spot one test where we were calling `waitFor()` directly instead of calling `await waitFor()`. This basically makes the test running skip all the assertions in the test, so I fixed the offending test, but also realised this is quite a significant issue in general.
6. So then I did some research into how we could avoid common Testing Library pitfalls in the future and identified `eslint-plugin-testing-library` as a solution. After enabling all the rules for this plugin a lot of issues surfaced. Most of them were fixed by Claude but the `testing-library/no-node-access` violations we decided to not fix but to disable the rule instead. This is because we do some important assertions on elements from dhis2/ui.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---


[DHIS2-21485]: https://dhis2.atlassian.net/browse/DHIS2-21485?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ