### PR TITLE
fix: add invalid case for Completed on in layout (TET button)

### DIFF
--- a/cypress/e2e/interpretations.cy.ts
+++ b/cypress/e2e/interpretations.cy.ts
@@ -81,7 +81,7 @@ describe('interpretations', () => {
         cy.getByDataTest('details-panel').should('not.exist')
     })
 
-    it.skip('a new interpretation can be added, viewed and deleted', () => {
+    it('a new interpretation can be added, viewed and deleted', () => {
         openVisByName('Inpatient: Cases last quarter (case)')
 
         // Make a copy of the visualization

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-13T12:26:32.491Z\n"
-"PO-Revision-Date: 2026-05-13T12:26:32.492Z\n"
+"POT-Creation-Date: 2026-05-18T13:11:36.297Z\n"
+"PO-Revision-Date: 2026-05-18T13:11:36.297Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -389,6 +389,9 @@ msgstr "Not valid with multiple program stages"
 
 msgid "Not valid with event programs"
 msgstr "Not valid with event programs"
+
+msgid "Not valid with Completed on"
+msgstr "Not valid with Completed on"
 
 msgid "Not valid with multiple tracked entity types"
 msgstr "Not valid with multiple tracked entity types"
@@ -978,15 +981,6 @@ msgstr "No"
 msgid "Not answered"
 msgstr "Not answered"
 
-msgid "Event status"
-msgstr "Event status"
-
-msgid "Program status"
-msgstr "Program status"
-
-msgid "Registration date"
-msgstr "Registration date"
-
 msgid "Completed date"
 msgstr "Completed date"
 
@@ -1007,6 +1001,9 @@ msgstr "Scheduled date"
 
 msgid "Event org. unit"
 msgstr "Event org. unit"
+
+msgid "Event status"
+msgstr "Event status"
 
 msgid "Enrollment org. unit"
 msgstr "Enrollment org. unit"

--- a/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
@@ -124,6 +124,12 @@ const metadata = {
         dimensionType: 'PROGRAM_ATTRIBUTE',
         valueType: 'TEXT',
     },
+    completed: {
+        id: 'completed',
+        name: 'Completed on',
+        dimensionType: 'PERIOD',
+        valueType: 'DATE',
+    },
 }
 
 const initialPreloadedState: Partial<RootState> = {
@@ -870,6 +876,33 @@ describe('useActionButton for Tracked entity instance button', () => {
         })
     })
 
+    it('returns correct result for: PT, Completed on in layout', async () => {
+        const { result } = await renderHookWithAppWrapper(
+            () => useActionButton('TRACKED_ENTITY_INSTANCE'),
+            createStoreWithPreloadedState({
+                dimensionSelection: {
+                    dataSourceId: metadata.p2.id,
+                },
+                visUiConfig: {
+                    layout: {
+                        columns: [
+                            metadata['p2.p2s2.d1'].id,
+                            metadata['completed'].id,
+                        ],
+                    },
+                    visualizationType: 'PIVOT_TABLE',
+                },
+            })
+        )
+
+        const output = result.current
+
+        expect(output.action).toEqual('create')
+        expect(output.tooltipConfig).toEqual({
+            content: 'Not valid with Completed on',
+        })
+    })
+
     it('returns correct result for: LL, category and category option group sets in layout', async () => {
         const { result } = await renderHookWithAppWrapper(
             () => useActionButton('TRACKED_ENTITY_INSTANCE'),
@@ -921,6 +954,33 @@ describe('useActionButton for Tracked entity instance button', () => {
         expect(output.action).toEqual('create')
         expect(output.tooltipConfig).toEqual({
             content: 'Not valid with program indicators',
+        })
+    })
+
+    it('returns correct result for: LL, Completed on in layout', async () => {
+        const { result } = await renderHookWithAppWrapper(
+            () => useActionButton('TRACKED_ENTITY_INSTANCE'),
+            createStoreWithPreloadedState({
+                dimensionSelection: {
+                    dataSourceId: metadata.p2.id,
+                },
+                visUiConfig: {
+                    layout: {
+                        columns: [
+                            metadata['p2.p2s2.d1'].id,
+                            metadata['completed'].id,
+                        ],
+                    },
+                    visualizationType: 'LINE_LIST',
+                },
+            })
+        )
+
+        const output = result.current
+
+        expect(output.action).toEqual('create')
+        expect(output.tooltipConfig).toEqual({
+            content: 'Not valid with Completed on',
         })
     })
 })

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -135,6 +135,7 @@ type TrackedEntityInstanceTooltipContentParams = {
     programMetadata: Program | undefined
     hasCategoryInLayout: boolean
     hasCategoryOptionGroupSetInLayout: boolean
+    hasCompletedOnInLayout: boolean
     hasMultipleProgramsInLayout: boolean
     hasMultipleTetInLayout: boolean
     hasProgramIndicatorsInLayout: boolean
@@ -145,11 +146,18 @@ const getTrackedEntityInstanceTooltipContent = ({
     programMetadata,
     hasCategoryInLayout,
     hasCategoryOptionGroupSetInLayout,
+    hasCompletedOnInLayout,
     hasMultipleProgramsInLayout,
     hasMultipleTetInLayout,
     hasProgramIndicatorsInLayout,
     visualizationType,
 }: TrackedEntityInstanceTooltipContentParams): TooltipContent => {
+    if (hasCompletedOnInLayout) {
+        return {
+            content: i18n.t('Not valid with Completed on'),
+        }
+    }
+
     if (hasMultipleTetInLayout) {
         return {
             content: i18n.t('Not valid with multiple tracked entity types'),
@@ -253,6 +261,14 @@ export const useActionButton = (
         [layoutDimensionIds, metadataStore]
     )
 
+    const hasCompletedOnInLayout: boolean = useMemo(
+        () =>
+            layoutDimensionIds.some(
+                (dimensionId) => dimensionId === 'completed'
+            ),
+        [layoutDimensionIds]
+    )
+
     const programCountInLayout = programIdsInLayout.length
 
     const tetCountInLayout = useMemo(() => {
@@ -352,6 +368,7 @@ export const useActionButton = (
                     programMetadata: firstProgramMetadata,
                     hasCategoryInLayout,
                     hasCategoryOptionGroupSetInLayout,
+                    hasCompletedOnInLayout,
                     hasMultipleProgramsInLayout,
                     hasMultipleTetInLayout,
                     hasProgramIndicatorsInLayout,
@@ -363,6 +380,7 @@ export const useActionButton = (
         firstProgramMetadata,
         hasCategoryInLayout,
         hasCategoryOptionGroupSetInLayout,
+        hasCompletedOnInLayout,
         hasNoProgramInLayout,
         hasMultipleProgramsInLayout,
         hasMultipleProgramStagesInLayout,

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -262,10 +262,7 @@ export const useActionButton = (
     )
 
     const hasCompletedOnInLayout: boolean = useMemo(
-        () =>
-            layoutDimensionIds.some(
-                (dimensionId) => dimensionId === 'completed'
-            ),
+        () => layoutDimensionIds.includes('completed'),
         [layoutDimensionIds]
     )
 


### PR DESCRIPTION
### Description

Handle a new invalid case for TET button.
When the "Completed on" (`completed`) dimension in present in the layout, the TET button should be disabled.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

<img width="541" height="214" alt="Screenshot 2026-05-18 at 15 17 51" src="https://github.com/user-attachments/assets/545cb53a-98b3-4b21-84d4-25bffbf9fbc4" />

