### PR TITLE
fix: strip program/programStage from all contextless dimensions

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-18T13:11:36.297Z\n"
-"PO-Revision-Date: 2026-05-18T13:11:36.297Z\n"
+"POT-Creation-Date: 2026-05-19T14:03:47.193Z\n"
+"PO-Revision-Date: 2026-05-19T14:03:47.195Z\n"
 
 msgid "User organisation unit"
 msgstr "User organisation unit"
@@ -526,21 +526,6 @@ msgstr "Failed to load data sources."
 msgid "Filter data sources"
 msgstr "Filter data sources"
 
-msgid "Last updated on"
-msgstr "Last updated on"
-
-msgid "Last updated by"
-msgstr "Last updated by"
-
-msgid "Created on"
-msgstr "Created on"
-
-msgid "Created by"
-msgstr "Created by"
-
-msgid "Completed on"
-msgstr "Completed on"
-
 msgid "Metadata"
 msgstr "Metadata"
 
@@ -980,6 +965,21 @@ msgstr "No"
 
 msgid "Not answered"
 msgstr "Not answered"
+
+msgid "Created on"
+msgstr "Created on"
+
+msgid "Last updated on"
+msgstr "Last updated on"
+
+msgid "Last updated by"
+msgstr "Last updated by"
+
+msgid "Created by"
+msgstr "Created by"
+
+msgid "Completed on"
+msgstr "Completed on"
 
 msgid "Completed date"
 msgstr "Completed date"

--- a/src/components/main-sidebar/dimension-card/card-metadata.tsx
+++ b/src/components/main-sidebar/dimension-card/card-metadata.tsx
@@ -8,51 +8,14 @@ import {
     type UseSelectedDimensionCountMatchFn,
 } from '@components/main-sidebar/use-selected-dimension-count'
 import i18n from '@dhis2/d2-i18n'
-import type { DimensionMetadataItem } from '@types'
+import {
+    getFixedDimensions,
+    CONTEXTLESS_DIMENSION_IDS,
+} from '@modules/dimension'
 import { useMemo, type FC } from 'react'
 
-const getFixedDimensions = (): DimensionMetadataItem[] => [
-    {
-        id: 'lastUpdated',
-        dimensionId: 'lastUpdated',
-        name: i18n.t('Last updated on'),
-        dimensionType: 'PERIOD',
-        valueType: 'DATE',
-    },
-    {
-        id: 'lastUpdatedBy',
-        dimensionId: 'lastUpdatedBy',
-        name: i18n.t('Last updated by'),
-        dimensionType: 'USER',
-    },
-    {
-        id: 'created',
-        dimensionId: 'created',
-        name: i18n.t('Created on'),
-        dimensionType: 'PERIOD',
-        valueType: 'DATE',
-    },
-    {
-        id: 'createdBy',
-        dimensionId: 'createdBy',
-        name: i18n.t('Created by'),
-        dimensionType: 'USER',
-    },
-    {
-        id: 'completed',
-        dimensionId: 'completed',
-        name: i18n.t('Completed on'),
-        dimensionType: 'PERIOD',
-        valueType: 'DATE',
-    },
-]
-
-const METADATA_DIMENSION_IDS = new Set(
-    getFixedDimensions().map((dimension) => dimension.id)
-)
-
 const isSelectedMatchFn: UseSelectedDimensionCountMatchFn = (dimension) =>
-    METADATA_DIMENSION_IDS.has(dimension.dimensionId)
+    CONTEXTLESS_DIMENSION_IDS.has(dimension.dimensionId)
 
 export const CardMetadata: FC = () => {
     const fixedDimensions = useMemo(getFixedDimensions, [])

--- a/src/components/main-sidebar/dimension-card/card-metadata.tsx
+++ b/src/components/main-sidebar/dimension-card/card-metadata.tsx
@@ -8,17 +8,14 @@ import {
     type UseSelectedDimensionCountMatchFn,
 } from '@components/main-sidebar/use-selected-dimension-count'
 import i18n from '@dhis2/d2-i18n'
-import {
-    getFixedDimensions,
-    CONTEXTLESS_DIMENSION_IDS,
-} from '@modules/dimension'
+import { getFixedMetaDimensions, META_DIMENSION_IDS } from '@modules/dimension'
 import { useMemo, type FC } from 'react'
 
 const isSelectedMatchFn: UseSelectedDimensionCountMatchFn = (dimension) =>
-    CONTEXTLESS_DIMENSION_IDS.has(dimension.dimensionId)
+    META_DIMENSION_IDS.has(dimension.dimensionId)
 
 export const CardMetadata: FC = () => {
-    const fixedDimensions = useMemo(getFixedDimensions, [])
+    const fixedDimensions = useMemo(getFixedMetaDimensions, [])
     const listProps = useDimensionList({ fixedDimensions })
     const selectedCount = useSelectedDimensionCount(isSelectedMatchFn)
 

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -2,6 +2,8 @@ import type { DimensionArray, Program, ProgramStage } from '@types'
 import { describe, it, expect } from 'vitest'
 import {
     getCreatedDimension,
+    getFixedDimensions,
+    CONTEXTLESS_DIMENSION_IDS,
     getMainDimensions,
     transformDimensions,
     isTimeDimensionId,
@@ -325,6 +327,67 @@ describe('toAppLocalDimensions', () => {
         const result = toAppLocalDimensions(dims)
         expect(result[0].items).toEqual([{ id: 'urban' }, { id: 'rural' }])
         expect(result[0].dimensionType).toBe('ORGANISATION_UNIT_GROUP_SET')
+    })
+
+    it.each([...CONTEXTLESS_DIMENSION_IDS])(
+        'strips program and programStage from contextless dimension by ID: %s',
+        (dimensionId) => {
+            const dims: DimensionArray = [
+                {
+                    dimension: dimensionId,
+                    items: [],
+                    program: { id: 'prog1' },
+                    programStage: { id: 'stage1' },
+                },
+            ]
+            const result = toAppLocalDimensions(dims)
+            expect(result[0].dimension).toBe(dimensionId)
+            expect(result[0].program).toBeUndefined()
+            expect(result[0].programStage).toBeUndefined()
+        }
+    )
+})
+
+describe('getFixedDimensions', () => {
+    it('returns all five fixed metadata dimensions', () => {
+        const result = getFixedDimensions()
+        expect(result).toHaveLength(5)
+        expect(result.map((d) => d.id)).toEqual([
+            'lastUpdated',
+            'lastUpdatedBy',
+            'created',
+            'createdBy',
+            'completed',
+        ])
+    })
+
+    it('returns correctly shaped items', () => {
+        const result = getFixedDimensions()
+        for (const dim of result) {
+            expect(dim.id).toBe(dim.dimensionId)
+            expect(typeof dim.name).toBe('string')
+            expect(dim.dimensionType).toMatch(/^(PERIOD|USER)$/)
+        }
+    })
+
+    it('assigns PERIOD dimensionType to date-based dimensions', () => {
+        const result = getFixedDimensions()
+        const dateDims = result.filter((d) => d.valueType === 'DATE')
+        expect(dateDims.map((d) => d.id)).toEqual([
+            'lastUpdated',
+            'created',
+            'completed',
+        ])
+        dateDims.forEach((d) => expect(d.dimensionType).toBe('PERIOD'))
+    })
+
+    it('assigns USER dimensionType to user-based dimensions', () => {
+        const result = getFixedDimensions()
+        const userDims = result.filter((d) => d.dimensionType === 'USER')
+        expect(userDims.map((d) => d.id)).toEqual([
+            'lastUpdatedBy',
+            'createdBy',
+        ])
     })
 })
 

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -2,8 +2,8 @@ import type { DimensionArray, Program, ProgramStage } from '@types'
 import { describe, it, expect } from 'vitest'
 import {
     getCreatedDimension,
-    getFixedDimensions,
-    CONTEXTLESS_DIMENSION_IDS,
+    getFixedMetaDimensions,
+    META_DIMENSION_IDS,
     getMainDimensions,
     transformDimensions,
     isTimeDimensionId,
@@ -329,7 +329,7 @@ describe('toAppLocalDimensions', () => {
         expect(result[0].dimensionType).toBe('ORGANISATION_UNIT_GROUP_SET')
     })
 
-    it.each([...CONTEXTLESS_DIMENSION_IDS])(
+    it.each([...META_DIMENSION_IDS])(
         'strips program and programStage from contextless dimension by ID: %s',
         (dimensionId) => {
             const dims: DimensionArray = [
@@ -348,9 +348,9 @@ describe('toAppLocalDimensions', () => {
     )
 })
 
-describe('getFixedDimensions', () => {
+describe('getFixedMetaDimensions', () => {
     it('returns all five fixed metadata dimensions', () => {
-        const result = getFixedDimensions()
+        const result = getFixedMetaDimensions()
         expect(result).toHaveLength(5)
         expect(result.map((d) => d.id)).toEqual([
             'lastUpdated',
@@ -362,7 +362,7 @@ describe('getFixedDimensions', () => {
     })
 
     it('returns correctly shaped items', () => {
-        const result = getFixedDimensions()
+        const result = getFixedMetaDimensions()
         for (const dim of result) {
             expect(dim.id).toBe(dim.dimensionId)
             expect(typeof dim.name).toBe('string')
@@ -371,7 +371,7 @@ describe('getFixedDimensions', () => {
     })
 
     it('assigns PERIOD dimensionType to date-based dimensions', () => {
-        const result = getFixedDimensions()
+        const result = getFixedMetaDimensions()
         const dateDims = result.filter((d) => d.valueType === 'DATE')
         expect(dateDims.map((d) => d.id)).toEqual([
             'lastUpdated',
@@ -382,7 +382,7 @@ describe('getFixedDimensions', () => {
     })
 
     it('assigns USER dimensionType to user-based dimensions', () => {
-        const result = getFixedDimensions()
+        const result = getFixedMetaDimensions()
         const userDims = result.filter((d) => d.dimensionType === 'USER')
         expect(userDims.map((d) => d.id)).toEqual([
             'lastUpdatedBy',

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -74,6 +74,42 @@ export const getCreatedDimension = (): Partial<
     },
 })
 
+export const getFixedDimensions = (): DimensionMetadataItem[] => [
+    {
+        id: 'lastUpdated',
+        dimensionId: 'lastUpdated',
+        name: i18n.t('Last updated on'),
+        dimensionType: 'PERIOD',
+        valueType: 'DATE',
+    },
+    {
+        id: 'lastUpdatedBy',
+        dimensionId: 'lastUpdatedBy',
+        name: i18n.t('Last updated by'),
+        dimensionType: 'USER',
+    },
+    {
+        id: 'created',
+        dimensionId: 'created',
+        name: i18n.t('Created on'),
+        dimensionType: 'PERIOD',
+        valueType: 'DATE',
+    },
+    {
+        id: 'createdBy',
+        dimensionId: 'createdBy',
+        name: i18n.t('Created by'),
+        dimensionType: 'USER',
+    },
+    {
+        id: 'completed',
+        dimensionId: 'completed',
+        name: i18n.t('Completed on'),
+        dimensionType: 'PERIOD',
+        valueType: 'DATE',
+    },
+]
+
 export const getMainDimensions = (
     outputType: OutputType
 ): DimensionRecordObject => ({
@@ -259,6 +295,15 @@ export const combineAllDimensionsFromVisualization = (
  * boundary.
  * --------------------------------------------------------------------------- */
 
+/* Dimensions that are not bound to any program or stage. The backend
+ * may still populate program/programStage on these in legacy visualizations;
+ * drop those fields at the API → app-local boundary so that downstream code
+ * (compound ID, save round-trip) treats them as the contextless dimensions
+ * they actually are. */
+export const CONTEXTLESS_DIMENSION_IDS = new Set(
+    getFixedDimensions().map((dimension) => dimension.id)
+)
+
 /* Dimension types that are not bound to any program or stage. The backend
  * may still populate program/programStage on these in legacy visualizations;
  * drop those fields at the API → app-local boundary so that downstream code
@@ -279,8 +324,9 @@ const CONTEXTLESS_DIMENSION_TYPES: ReadonlySet<string> = new Set([
 export const toAppLocalDimensions = (dims: DimensionArray): DimensionArray =>
     dims.map((dim) => {
         if (
-            dim.dimensionType &&
-            CONTEXTLESS_DIMENSION_TYPES.has(dim.dimensionType)
+            (dim.dimensionType &&
+                CONTEXTLESS_DIMENSION_TYPES.has(dim.dimensionType)) ||
+            CONTEXTLESS_DIMENSION_IDS.has(dim.dimension)
         ) {
             const stripped = { ...dim }
             delete stripped.program

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -74,7 +74,7 @@ export const getCreatedDimension = (): Partial<
     },
 })
 
-export const getFixedDimensions = (): DimensionMetadataItem[] => [
+export const getFixedMetaDimensions = (): DimensionMetadataItem[] => [
     {
         id: 'lastUpdated',
         dimensionId: 'lastUpdated',
@@ -300,8 +300,8 @@ export const combineAllDimensionsFromVisualization = (
  * drop those fields at the API → app-local boundary so that downstream code
  * (compound ID, save round-trip) treats them as the contextless dimensions
  * they actually are. */
-export const CONTEXTLESS_DIMENSION_IDS = new Set(
-    getFixedDimensions().map((dimension) => dimension.id)
+export const META_DIMENSION_IDS = new Set(
+    getFixedMetaDimensions().map((dimension) => dimension.id)
 )
 
 /* Dimension types that are not bound to any program or stage. The backend
@@ -326,7 +326,7 @@ export const toAppLocalDimensions = (dims: DimensionArray): DimensionArray =>
         if (
             (dim.dimensionType &&
                 CONTEXTLESS_DIMENSION_TYPES.has(dim.dimensionType)) ||
-            CONTEXTLESS_DIMENSION_IDS.has(dim.dimension)
+            META_DIMENSION_IDS.has(dim.dimension)
         ) {
             const stripped = { ...dim }
             delete stripped.program


### PR DESCRIPTION
### Description

Contextless dimensions are the one that should be passed to the analytics request without a prefix (program/programStage).
The list was already present in the code, it has been moved to `modules/dimension` and used in `toAppLocalDimensions` to strip the program/programStage information from the dimension object.
Now the analytics request is computed correctly.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

Before:
<img width="597" height="115" alt="Screenshot 2026-05-19 at 16 18 32" src="https://github.com/user-attachments/assets/3ccc440e-381d-4c9d-b523-babb1fcdb78b" />
<img width="663" height="179" alt="Screenshot 2026-05-19 at 16 18 40" src="https://github.com/user-attachments/assets/c61d33b0-6d99-437d-ad2a-a47e3e199445" />

After:
<img width="532" height="152" alt="Screenshot 2026-05-19 at 16 19 04" src="https://github.com/user-attachments/assets/00c2c71f-5406-49ee-995c-4c2fa1c999f1" />
<img width="867" height="372" alt="Screenshot 2026-05-19 at 16 18 53" src="https://github.com/user-attachments/assets/396a7d84-3cad-486d-869a-e766c8dda263" />

