### PR TITLE
fix: avoid crash on PT Limit option with legacy visualizations

### DIFF
--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -610,6 +610,8 @@ export const normalizeApiSavedVisualization = (
         rows = [],
         filters = [],
         programDimensions = [],
+        sortOrder,
+        topLimit,
         ...rest
     } = apiVis
 
@@ -683,5 +685,7 @@ export const normalizeApiSavedVisualization = (
         programDimensions: normalizedProgramDimensions,
         ...(preserveTimeField ? { timeField } : {}),
         ...(markLegacy ? { legacy: true } : {}),
+        ...(sortOrder !== 0 && { sortOrder }),
+        ...(topLimit !== 0 && { topLimit }),
     } as SavedVisualization
 }


### PR DESCRIPTION
### Description

This PR fixes an issue where the `Limit` option in PT crashes when opening the options modal.
This happens with legacy visualizations because the values returned for `sortOrder` and `topLimit` are `0`.
`0` is not an option in the `SortOrder` UI select and this ultimately causes the crash.

`0` in these cases means "not set". The fix is about converting the `0` to `undefined` when loading a visualization.
`undefined` is also the default used in Redux for these options and what is used in the `Limit` option component to determine if the checkbox should be checked or not.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

Before:
<img width="803" height="224" alt="Screenshot 2026-05-21 at 10 30 05" src="https://github.com/user-attachments/assets/f4d5c3f4-98b4-462f-9742-4d730276d8b1" />


After:
<img width="1018" height="762" alt="Screenshot 2026-05-21 at 10 29 43" src="https://github.com/user-attachments/assets/e3ca99d0-65cc-410d-a09a-cc134f560554" />

