### PR TITLE
chore: add loglevel and debug mode utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,3 +450,36 @@ A few conventions to note:
 
 - `visualizationId` will always be populated in the store; the value `new` signifies that no saved AO is selected.
 - A blank URL `/` and `/new` are treated equally, so accessing the app at `#/` will not redirect to `#/new`.
+
+### Debug Mode
+
+The app's debug tooling (verbose logging via [`loglevel`](https://github.com/pimterry/loglevel), Redux DevTools, and the metadata-store `window` globals) is gated behind a single log level. Defaults:
+
+- `pnpm start` (`NODE_ENV=development`): level `info` — logger output is visible, Redux DevTools attaches, `window.getMetadataStore()` is exposed.
+- Production builds (Netlify previews, installed instances) and tests: level `error` — only real errors emit; devtools are silent.
+
+To override the default in any environment, set `EVENT_VISUALIZER_LOG_LEVEL` to one of `trace`, `debug`, `info`, `warn`, `error`, or `silent`. The boolean tools (Redux DevTools, metadata-store globals) are enabled at `trace`/`debug`/`info` and disabled at `warn`/`error`/`silent`.
+
+**In the browser** (e.g. on a Netlify preview or an installed instance), set the `localStorage` key and reload:
+
+```js
+localStorage.setItem('EVENT_VISUALIZER_LOG_LEVEL', 'debug')
+// then reload the page
+```
+
+**In a test run** (or any Node-side invocation), use the environment variable:
+
+```bash
+EVENT_VISUALIZER_LOG_LEVEL=debug pnpm test
+```
+
+If both are set, `localStorage` wins over the env var.
+
+In app code, log via the shared logger instead of `console.*` (the `no-console` ESLint rule enforces this):
+
+```ts
+import { logger } from '@modules/logger'
+
+logger.debug('LL req', req)
+logger.error(error)
+```

--- a/README.md
+++ b/README.md
@@ -456,7 +456,8 @@ A few conventions to note:
 The app's debug tooling (verbose logging via [`loglevel`](https://github.com/pimterry/loglevel), Redux DevTools, and the metadata-store `window` globals) is gated behind a single log level. Defaults:
 
 - `pnpm start` (`NODE_ENV=development`): level `info` — logger output is visible, Redux DevTools attaches, `window.getMetadataStore()` is exposed.
-- Production builds (Netlify previews, installed instances) and tests: level `error` — only real errors emit; devtools are silent.
+- Production builds (Netlify previews, installed instances): level `error` — only real errors emit; devtools are silent.
+- Tests (`NODE_ENV=test`): level `silent` — no logger output, no devtools. Tests routinely exercise error paths, so emitting error logs by default would clutter the output.
 
 To override the default in any environment, set `EVENT_VISUALIZER_LOG_LEVEL` to one of `trace`, `debug`, `info`, `warn`, `error`, or `silent`. The boolean tools (Redux DevTools, metadata-store globals) are enabled at `trace`/`debug`/`info` and disabled at `warn`/`error`/`silent`.
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -29,6 +29,7 @@ const setupNodeEvents = async (
                 'code' in error &&
                 error.code === 'ENOENT'
             ) {
+                // eslint-disable-next-line no-console
                 console.log('Video already deleted')
             } else {
                 throw error

--- a/cypress/plugins/exclude-by-version-tags.ts
+++ b/cypress/plugins/exclude-by-version-tags.ts
@@ -101,8 +101,10 @@ export const excludeByVersionTags = (
 ) => {
     const excludedTags = getExcludedTags(config.env.dhis2InstanceVersion)
 
+    /* eslint-disable no-console -- Cypress startup diagnostic */
     console.log('instanceVersion', config.env.dhis2InstanceVersion)
     console.log('tags to exclude from testing', excludedTags)
+    /* eslint-enable no-console */
 
     config.env.CYPRESS_EXCLUDE_TAGS = excludedTags.join(',')
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -40,6 +40,7 @@ export default defineConfig([
             'react-hooks/use-memo': 'off',
             'react-hooks/globals': 'off',
             'import/no-default-export': 'error',
+            'no-console': 'error',
             'no-restricted-imports': [
                 'error',
                 {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
         "deep-equal": "^2.2.3",
         "deepmerge": "^4.3.1",
         "history": "^5.3.0",
+        "loglevel": "^1.9.2",
         "moment": "^2.30.1",
         "prop-types": "^15.8.1",
         "query-string": "^9.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       history:
         specifier: ^5.3.0
         version: 5.3.0
+      loglevel:
+        specifier: ^1.9.2
+        version: 1.9.2
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -6149,6 +6152,10 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -16369,6 +16376,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
+
+  loglevel@1.9.2: {}
 
   loose-envify@1.4.0:
     dependencies:

--- a/src/api/custom-base-query.ts
+++ b/src/api/custom-base-query.ts
@@ -1,4 +1,5 @@
 import type { Query, Mutation } from '@dhis2/app-service-data'
+import { logger } from '@modules/logger'
 import type { BaseQueryFn, BaseQueryApi } from '@reduxjs/toolkit/query'
 import type {
     AppCachedData,
@@ -53,7 +54,7 @@ export const customBaseQuery: CustomBaseQueryFn = async (
             return { data: queryResult ?? {} }
         }
     } catch (error: unknown) {
-        console.error(error)
+        logger.error(error)
         return { error: parseEngineError(error) }
     }
 }

--- a/src/api/parse-engine-error.ts
+++ b/src/api/parse-engine-error.ts
@@ -1,4 +1,5 @@
 import { FetchError } from '@dhis2/app-runtime'
+import { logger } from '@modules/logger'
 
 export const ENGINE_ERROR_TYPES = [
     'network',
@@ -104,12 +105,8 @@ export const parseEngineError = (error: unknown): EngineError => {
                           : 'An unexpected runtime error occurred',
               }
 
-    // Ensure non-network errors are logged to the console in dev mode
-    if (
-        process.env.NODE_ENV === 'development' &&
-        (parsedError.type === 'unknown' || parsedError.type === 'runtime')
-    ) {
-        console.error(error)
+    if (parsedError.type === 'unknown' || parsedError.type === 'runtime') {
+        logger.error(error)
     }
 
     return parsedError

--- a/src/components/examples/user-profile-example.tsx
+++ b/src/components/examples/user-profile-example.tsx
@@ -1,4 +1,5 @@
 import { useRtkQuery } from '@hooks'
+import { logger } from '@modules/logger'
 import type { MeDto, PickWithFieldFilters } from '@types'
 
 const fieldsFilter = ['id', 'name', 'email', 'settings'] as const
@@ -18,12 +19,12 @@ export const UserProfileExample = () => {
 
     if (isLoading) {
         // Both `error` and `data` will be undefined here
-        console.log(data, error)
+        logger.debug(data, error)
         return <div>Loading user profile...</div>
     }
     if (isError) {
         // `error` will be of type EngineError and `data` will is possibly undefined
-        console.log(data, error)
+        logger.debug(data, error)
         return <div>Error loading profile: {error.message}</div>
     }
 

--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -1,3 +1,4 @@
+import { logger } from '@modules/logger'
 import {
     currentVisSlice,
     initialState as currentVisSliceInitialState,
@@ -141,7 +142,7 @@ describe('<LayoutPanel />', () => {
             },
         })
 
-        console.log(layoutPanelMockOptions)
+        logger.debug(layoutPanelMockOptions)
 
         cy.mount(
             <MockAppWrapper {...layoutPanelMockOptions}>

--- a/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
@@ -12,6 +12,7 @@ import {
     IconVisualizationPivotTable16,
 } from '@dhis2/ui'
 import { useAppDispatch, useAppSelector } from '@hooks'
+import { logger } from '@modules/logger'
 import {
     setVisUiConfigVisualizationType,
     getVisUiConfigVisualizationType,
@@ -64,7 +65,7 @@ export const VisualizationTypeSelector: FC = () => {
     const toggleList = () => setListIsOpen(!listIsOpen)
 
     const onItemClick = () => {
-        console.log('TBD run clearing on the store if needed')
+        logger.debug('TBD run clearing on the store if needed')
     }
 
     const handleListItemClick =

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -14,6 +14,7 @@ import {
     getDimensionSuffixes,
     type SuffixInput,
 } from '@modules/dimension-suffix'
+import { logger } from '@modules/logger'
 import { isValueTypeNumeric } from '@modules/value-type'
 import {
     analyticsHeaderToCanonicalDimensionId,
@@ -87,7 +88,7 @@ const fetchAnalyticsDataForLL = async ({
     const { adaptedVisualization, headers, parameters } =
         getAdaptedVisualization(visualization)
 
-    console.log('adaptedVisualization', adaptedVisualization)
+    logger.debug('adaptedVisualization', adaptedVisualization)
 
     let req = new analyticsEngine.request()
         .fromVisualization(adaptedVisualization)
@@ -136,7 +137,7 @@ const fetchAnalyticsDataForLL = async ({
                 break
         }
     }
-    console.log('LL req', req)
+    logger.debug('LL req', req)
     const analyticsApiEndpoint = getAnalyticsEndpoint(visualization.outputType)
 
     const rawResponse =
@@ -350,7 +351,7 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
                     : { dimension: undefined, direction: undefined }
 
             try {
-                console.log('in fetch analytics data try')
+                logger.debug('in fetch analytics data try')
                 const analyticsResponse = await fetchAnalyticsDataForLL({
                     analyticsEngine,
                     page,
@@ -434,7 +435,7 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
 
                 onResponseReceived(analyticsResponse.metaData.items, headers)
             } catch (error) {
-                console.log('fetch LL data error', error)
+                logger.debug('fetch LL data error', error)
                 setState({
                     data: null,
                     error,

--- a/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
@@ -1,6 +1,7 @@
 import { Analytics, transformEventAggregateResponse } from '@dhis2/analytics'
 // eslint-disable-next-line no-restricted-imports
 import { type FetchError, useDataEngine } from '@dhis2/app-runtime'
+import { logger } from '@modules/logger'
 import { getSingleProgramFromVisualization } from '@modules/visualization'
 import type {
     CurrentUser,
@@ -136,13 +137,13 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
                     relativePeriodDate,
                 })
 
-                console.log('PT analytics response', analyticsResponse)
+                logger.debug('PT analytics response', analyticsResponse)
 
                 // response for PT needs to be transformed
                 const analyticsData =
                     transformEventAggregateResponse(analyticsResponse)
 
-                console.log('analytics data', analyticsData)
+                logger.debug('analytics data', analyticsData)
                 setState({
                     data: analyticsData,
                     error: undefined,
@@ -151,7 +152,7 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
 
                 onResponseReceived(analyticsResponse.metaData.items)
             } catch (error) {
-                console.log('PT fetch error', error)
+                logger.debug('PT fetch error', error)
                 setState({
                     data: null,
                     error,

--- a/src/components/plugin-wrapper/line-list-plugin.tsx
+++ b/src/components/plugin-wrapper/line-list-plugin.tsx
@@ -1,6 +1,7 @@
 import { LineList } from '@components/line-list'
 import type { LineListAnalyticsData } from '@components/line-list'
 import type { DataSortFn, PaginateFn } from '@components/line-list/types'
+import { logger } from '@modules/logger'
 import { transformVisualizationForAnalyticsRequest } from '@modules/visualization'
 import type { CurrentUser, CurrentVisualization, Sorting } from '@types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -127,7 +128,7 @@ export const LineListPlugin: FC<LineListPluginProps> = ({
             isInDashboard={isInDashboard}
             isInModal={isInModal}
             onColumnHeaderClick={(dimensionId) => {
-                console.log(
+                logger.debug(
                     `Show dimension modal for dimension ID ${dimensionId}`
                 )
             }}

--- a/src/components/sidebar/use-dimension-list/use-dimension-list.ts
+++ b/src/components/sidebar/use-dimension-list/use-dimension-list.ts
@@ -1,6 +1,7 @@
 import { api } from '@api/api'
 import { parseEngineError, type EngineError } from '@api/parse-engine-error'
 import { useAppDispatch, useAppSelector, useStableCallback } from '@hooks'
+import { logger } from '@modules/logger'
 import {
     addDimensionListLoadingState,
     getFilter,
@@ -109,7 +110,7 @@ export const useDimensionList = ({
              * remount when the data source changes so this cannot really be called
              * during a fetch. And the internal logic in this hook should not allow,
              * this function to be called when the hook is not in async mode */
-            console.error(
+            logger.error(
                 'performFetch was called during a fetch or for a fixed dimensions list, this should not happen.'
             )
             return

--- a/src/components/toolbar/actions-bar/use-toolbar-actions.ts
+++ b/src/components/toolbar/actions-bar/use-toolbar-actions.ts
@@ -6,6 +6,7 @@ import {
 import { useAlert } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { useAppDispatch, useAppSelector } from '@hooks'
+import { logger } from '@modules/logger'
 import { isVisualizationPersistable } from '@modules/validation'
 import {
     getSaveableVisualization,
@@ -83,7 +84,7 @@ export const useToolbarActions = () => {
 
     const onError = useCallback(
         (error) => {
-            console.error(error)
+            logger.error(error)
             let message = error.message || i18n.t('An unknown error occurred.')
 
             switch (error.errorCode) {

--- a/src/dashboard-plugin.tsx
+++ b/src/dashboard-plugin.tsx
@@ -9,6 +9,7 @@ import { PluginWrapper } from '@components/plugin-wrapper/plugin-wrapper'
 import { DashboardPluginWrapper } from '@dhis2/analytics'
 // eslint-disable-next-line no-restricted-imports
 import { useDataQuery } from '@dhis2/app-runtime'
+import { logger } from '@modules/logger'
 import {
     normalizeApiSavedVisualization,
     toCurrentVis,
@@ -30,8 +31,8 @@ type DashboardPluginProps = {
 }
 
 const DashboardPluginContent: FC<DashboardPluginProps> = (props) => {
-    console.log('DashboardPlugin props', props)
-    console.log('vis id', props.visualization.id)
+    logger.debug('DashboardPlugin props', props)
+    logger.debug('vis id', props.visualization.id)
 
     const metadataStore = useMetadataStore()
 
@@ -91,11 +92,11 @@ const DashboardPluginContent: FC<DashboardPluginProps> = (props) => {
     // TODO: handle errors
     if (error) {
         // `error` will be of type EngineError and `data` will is possibly undefined
-        console.log('ERROR!', data, error)
+        logger.debug('ERROR!', data, error)
         return <div>Error loading event visualization: {error.message}</div>
     }
 
-    console.log(
+    logger.debug(
         'dp currentVisualization',
         currentVisualization,
         'loading',

--- a/src/modules/__tests__/debug-mode.spec.ts
+++ b/src/modules/__tests__/debug-mode.spec.ts
@@ -33,10 +33,10 @@ describe('debug-mode', () => {
             expect(isDebugMode()).toBe(false)
         })
 
-        it("returns 'error' when NODE_ENV=test", async () => {
+        it("returns 'silent' when NODE_ENV=test", async () => {
             vi.stubEnv('NODE_ENV', 'test')
             const { getLogLevel, isDebugMode } = await importDebugMode()
-            expect(getLogLevel()).toBe('error')
+            expect(getLogLevel()).toBe('silent')
             expect(isDebugMode()).toBe(false)
         })
     })

--- a/src/modules/__tests__/debug-mode.spec.ts
+++ b/src/modules/__tests__/debug-mode.spec.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const LOG_LEVEL_KEY = 'EVENT_VISUALIZER_LOG_LEVEL'
+
+const importDebugMode = async () => {
+    vi.resetModules()
+    return await import('../debug-mode')
+}
+
+describe('debug-mode', () => {
+    beforeEach(() => {
+        localStorage.clear()
+        vi.unstubAllEnvs()
+    })
+
+    afterEach(() => {
+        localStorage.clear()
+        vi.unstubAllEnvs()
+    })
+
+    describe('default (no localStorage override)', () => {
+        it("returns 'info' when NODE_ENV=development", async () => {
+            vi.stubEnv('NODE_ENV', 'development')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('info')
+            expect(isDebugMode()).toBe(true)
+        })
+
+        it("returns 'error' when NODE_ENV=production", async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+            expect(isDebugMode()).toBe(false)
+        })
+
+        it("returns 'error' when NODE_ENV=test", async () => {
+            vi.stubEnv('NODE_ENV', 'test')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+            expect(isDebugMode()).toBe(false)
+        })
+    })
+
+    describe('localStorage override wins over env default', () => {
+        const debugLevels = ['trace', 'debug', 'info'] as const
+        const nonDebugLevels = ['warn', 'error', 'silent'] as const
+        const envs = ['development', 'production', 'test'] as const
+
+        for (const env of envs) {
+            for (const level of debugLevels) {
+                it(`'${level}' in ${env} → isDebugMode=true`, async () => {
+                    vi.stubEnv('NODE_ENV', env)
+                    localStorage.setItem(LOG_LEVEL_KEY, level)
+                    const { getLogLevel, isDebugMode } = await importDebugMode()
+                    expect(getLogLevel()).toBe(level)
+                    expect(isDebugMode()).toBe(true)
+                })
+            }
+
+            for (const level of nonDebugLevels) {
+                it(`'${level}' in ${env} → isDebugMode=false`, async () => {
+                    vi.stubEnv('NODE_ENV', env)
+                    localStorage.setItem(LOG_LEVEL_KEY, level)
+                    const { getLogLevel, isDebugMode } = await importDebugMode()
+                    expect(getLogLevel()).toBe(level)
+                    expect(isDebugMode()).toBe(false)
+                })
+            }
+        }
+    })
+
+    describe('invalid localStorage values fall back to env default', () => {
+        it("unknown string in development → 'info'", async () => {
+            vi.stubEnv('NODE_ENV', 'development')
+            localStorage.setItem(LOG_LEVEL_KEY, 'banana')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('info')
+        })
+
+        it("unknown string in production → 'error'", async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            localStorage.setItem(LOG_LEVEL_KEY, 'banana')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+        })
+
+        it('empty string → env default', async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            localStorage.setItem(LOG_LEVEL_KEY, '')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+        })
+    })
+
+    describe('env var override (process.env.EVENT_VISUALIZER_LOG_LEVEL)', () => {
+        it('env var overrides env default in production', async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            vi.stubEnv(LOG_LEVEL_KEY, 'debug')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('debug')
+            expect(isDebugMode()).toBe(true)
+        })
+
+        it('env var overrides env default in development', async () => {
+            vi.stubEnv('NODE_ENV', 'development')
+            vi.stubEnv(LOG_LEVEL_KEY, 'warn')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('warn')
+            expect(isDebugMode()).toBe(false)
+        })
+
+        it('env var overrides env default in test', async () => {
+            vi.stubEnv('NODE_ENV', 'test')
+            vi.stubEnv(LOG_LEVEL_KEY, 'trace')
+            const { getLogLevel, isDebugMode } = await importDebugMode()
+            expect(getLogLevel()).toBe('trace')
+            expect(isDebugMode()).toBe(true)
+        })
+
+        it('invalid env var falls back to env default', async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            vi.stubEnv(LOG_LEVEL_KEY, 'banana')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+        })
+
+        it('localStorage wins over env var', async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            vi.stubEnv(LOG_LEVEL_KEY, 'error')
+            localStorage.setItem(LOG_LEVEL_KEY, 'debug')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('debug')
+        })
+    })
+
+    describe('module-load caching', () => {
+        it('does not re-read localStorage on subsequent calls', async () => {
+            vi.stubEnv('NODE_ENV', 'production')
+            const { getLogLevel } = await importDebugMode()
+            expect(getLogLevel()).toBe('error')
+
+            localStorage.setItem(LOG_LEVEL_KEY, 'debug')
+
+            expect(getLogLevel()).toBe('error')
+        })
+    })
+})

--- a/src/modules/debug-mode.ts
+++ b/src/modules/debug-mode.ts
@@ -21,7 +21,7 @@ const isLogLevel = (value: unknown): value is LogLevel =>
 
 const readLocalStorageOverride = (): LogLevel | null => {
     try {
-        const raw = window.localStorage?.getItem(LOG_LEVEL_KEY)
+        const raw = globalThis.localStorage?.getItem(LOG_LEVEL_KEY)
         return isLogLevel(raw) ? raw : null
     } catch {
         return null

--- a/src/modules/debug-mode.ts
+++ b/src/modules/debug-mode.ts
@@ -1,0 +1,55 @@
+import { type LogLevelNames } from 'loglevel'
+
+const LOG_LEVEL_KEY = 'EVENT_VISUALIZER_LOG_LEVEL'
+
+export type LogLevel = LogLevelNames | 'silent'
+
+const LOG_LEVELS: readonly LogLevel[] = [
+    'trace',
+    'debug',
+    'info',
+    'warn',
+    'error',
+    'silent',
+]
+
+const DEBUG_LEVELS: ReadonlySet<LogLevel> = new Set(['trace', 'debug', 'info'])
+
+const isLogLevel = (value: unknown): value is LogLevel =>
+    typeof value === 'string' &&
+    (LOG_LEVELS as readonly string[]).includes(value)
+
+const readLocalStorageOverride = (): LogLevel | null => {
+    try {
+        const raw = window.localStorage?.getItem(LOG_LEVEL_KEY)
+        return isLogLevel(raw) ? raw : null
+    } catch {
+        return null
+    }
+}
+
+const readEnvOverride = (): LogLevel | null => {
+    if (typeof process === 'undefined' || !process.env) {
+        return null
+    }
+    const value = process.env[LOG_LEVEL_KEY]
+    return isLogLevel(value) ? value : null
+}
+
+const computeLogLevel = (): LogLevel => {
+    const localStorageOverride = readLocalStorageOverride()
+    if (localStorageOverride) {
+        return localStorageOverride
+    }
+    const envOverride = readEnvOverride()
+    if (envOverride) {
+        return envOverride
+    }
+    return process.env.NODE_ENV === 'development' ? 'info' : 'error'
+}
+
+const level: LogLevel = computeLogLevel()
+
+export const getLogLevel = (): LogLevel => level
+
+export const isDebugMode = (): boolean => DEBUG_LEVELS.has(level)

--- a/src/modules/debug-mode.ts
+++ b/src/modules/debug-mode.ts
@@ -45,7 +45,13 @@ const computeLogLevel = (): LogLevel => {
     if (envOverride) {
         return envOverride
     }
-    return process.env.NODE_ENV === 'development' ? 'info' : 'error'
+    if (process.env.NODE_ENV === 'development') {
+        return 'info'
+    }
+    if (process.env.NODE_ENV === 'test') {
+        return 'silent'
+    }
+    return 'error'
 }
 
 const level: LogLevel = computeLogLevel()

--- a/src/modules/logger.ts
+++ b/src/modules/logger.ts
@@ -1,0 +1,6 @@
+import log from 'loglevel'
+import { getLogLevel } from './debug-mode'
+
+log.setLevel(getLogLevel())
+
+export const logger = log

--- a/src/modules/metadata-store/metadata-store.tsx
+++ b/src/modules/metadata-store/metadata-store.tsx
@@ -1,4 +1,5 @@
 import type { LineListAnalyticsDataHeader } from '@components/line-list/types'
+import { isDebugMode } from '@modules/debug-mode'
 import {
     isMetadataInputItem,
     isProgramMetadataItem,
@@ -71,10 +72,7 @@ export class MetadataStore {
     ) {
         this.addInitialMetadataItems(initialMetadataItems, rootOrgUnits)
 
-        if (
-            process.env.NODE_ENV === 'development' ||
-            process.env.NODE_ENV === 'test'
-        ) {
+        if (isDebugMode()) {
             window.getMetadataStore = () => Object.fromEntries(this.metadata)
             window.getMetadataStoreItem = (key: string) =>
                 this.getMetadataItem(key)

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,5 @@
 import { api } from '@api/api'
+import { isDebugMode } from '@modules/debug-mode'
 import { getDefaultOptions } from '@modules/options'
 import { configureStore } from '@reduxjs/toolkit'
 import type { AppCachedData, DataEngine, MetadataStore } from '@types'
@@ -45,6 +46,7 @@ export const createStore = (
                 .prepend(listenerMiddleware.middleware)
                 .concat(api.middleware),
         preloadedState: getPreloadedState(appCachedData),
+        devTools: isDebugMode(),
     })
 
 export type AppStore = ReturnType<typeof createStore>

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -6,6 +6,7 @@ import {
     collectProgramDimensions,
     resolveTeiFields,
 } from '@modules/layout'
+import { logger } from '@modules/logger'
 import { getEnabledOptions } from '@modules/options'
 import {
     getVisualizationUiConfig,
@@ -94,7 +95,7 @@ export const tLoadSavedVisualization = createAsyncThunk<
                         },
                         data: {},
                     })
-                    .catch((error) => console.error(error))
+                    .catch((error) => logger.error(error))
             }
         } else if (error) {
             dispatch(setLoadError(error))

--- a/src/test-utils/suppress-console-error.ts
+++ b/src/test-utils/suppress-console-error.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console -- this utility intentionally wraps console.error
+   to suppress specific error messages emitted during tests */
 export const suppressConsoleError = (
     messageToMatch: string,
     fn: () => Promise<void>


### PR DESCRIPTION
Implements N/A

### Description

#### What this enables

- Keeping logs in the codebase if we want to
- Enabling devtools/logs in production builds
- Silencing log output diring test

#### How this works

_Copied from the `README.md` diff_

The app's debug tooling (verbose logging via [`loglevel`](https://github.com/pimterry/loglevel), Redux DevTools, and the metadata-store `window` globals) is gated behind a single log level. Defaults:

- `pnpm start` (`NODE_ENV=development`): level `info` — logger output is visible, Redux DevTools attaches, `window.getMetadataStore()` is exposed.
- Production builds (Netlify previews, installed instances) and tests: level `error` — only real errors emit; devtools are silent.

To override the default in any environment, set `EVENT_VISUALIZER_LOG_LEVEL` to one of `trace`, `debug`, `info`, `warn`, `error`, or `silent`. The boolean tools (Redux DevTools, metadata-store globals) are enabled at `trace`/`debug`/`info` and disabled at `warn`/`error`/`silent`.

**In the browser** (e.g. on a Netlify preview or an installed instance), set the `localStorage` key and reload:

```js
localStorage.setItem('EVENT_VISUALIZER_LOG_LEVEL', 'debug')
// then reload the page
```

**In a test run** (or any Node-side invocation), use the environment variable:

```bash
EVENT_VISUALIZER_LOG_LEVEL=debug pnpm test
```

If both are set, `localStorage` wins over the env var.

In app code, log via the shared logger instead of `console.*` (the `no-console` ESLint rule enforces this):

```ts
import { logger } from '@modules/logger'

logger.debug('LL req', req)
logger.error(error)
```

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---

### Screenshot

_A CI unit test run from a previous PR_
<img width="1440" height="1460" alt="Screenshot 2026-05-29 at 17 46 28" src="https://github.com/user-attachments/assets/644a4d2b-dc5f-4182-b826-e8739ca86176" />

_A CI unit test run from the current PR_
<img width="1439" height="2073" alt="Screenshot 2026-05-29 at 17 52 20" src="https://github.com/user-attachments/assets/c35c57ca-cb90-43cd-964d-428a6df06595" />
