### PR TITLE
chore: clean up old dimension names and normalize [DHIS2-21504]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,13 @@ pnpm generate-types # Regenerate DHIS2 API types from OpenAPI specs
 
 ## Code Conventions
 
+### Communicating with the user
+
+- Write plainly. Short sentences, common words, no filler.
+- Explain things the way you would to a colleague, not in dense prose.
+- No hedging or clever phrasing that has to be re-read to parse.
+- Prefer a few clear lines over a wall of text.
+
 ### Code Style
 
 - **Self-documenting code over comments**: Prefer well-named intermediate variables and

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-28T13:09:23.445Z\n"
-"PO-Revision-Date: 2026-05-28T13:09:23.445Z\n"
+"POT-Creation-Date: 2026-06-01T14:14:08.533Z\n"
+"PO-Revision-Date: 2026-06-01T14:14:08.533Z\n"
 
 msgid "Add to {{- axisName}}"
 msgstr "Add to {{- axisName}}"
@@ -920,12 +920,6 @@ msgstr "Created by"
 
 msgid "Completed on"
 msgstr "Completed on"
-
-msgid "Completed date"
-msgstr "Completed date"
-
-msgid "Created date"
-msgstr "Created date"
 
 msgid "Event date"
 msgstr "Event date"

--- a/src/constants/dimensions.ts
+++ b/src/constants/dimensions.ts
@@ -16,10 +16,8 @@ export const YOUR_DIMENSION_TYPES = asStringLiteralSubsetArray<DimensionType>()(
 
 export const DIMENSION_IDS = [
     'completed',
-    'completedDate',
     'created',
     'createdBy',
-    'createdDate',
     'enrollmentDate',
     'enrollmentOu',
     'eventDate',
@@ -27,7 +25,6 @@ export const DIMENSION_IDS = [
     'incidentDate',
     'lastUpdated',
     'lastUpdatedBy',
-    'lastUpdatedOn',
     'ou',
     'programStatus',
     'scheduledDate',
@@ -36,12 +33,9 @@ export const DIMENSION_IDS = [
 export const DIMENSION_ID_ORGUNIT: DimensionId = 'ou'
 
 export const TIME_DIMENSION_IDS = [
-    'completedDate', // XXX: is this a thing? or should it be completed
-    'createdDate', // XXX: same for this one
     'enrollmentDate',
     'eventDate',
     'incidentDate',
     'lastUpdated',
-    'lastUpdatedOn',
     'scheduledDate',
 ] as const

--- a/src/modules/__tests__/dimension.spec.ts
+++ b/src/modules/__tests__/dimension.spec.ts
@@ -132,22 +132,6 @@ describe('getTimeDimensions', () => {
         const result = getTimeDimensions()
         expect(result).toMatchInlineSnapshot(`
           {
-            "completedDate": {
-              "defaultName": "Completed date",
-              "dimensionType": "PERIOD",
-              "formatType": "DATE",
-              "id": "completedDate",
-              "nameParentProperty": "stage",
-              "nameProperty": "displayCompletedDateLabel",
-            },
-            "createdDate": {
-              "defaultName": "Created date",
-              "dimensionType": "PERIOD",
-              "formatType": "DATE",
-              "id": "createdDate",
-              "nameParentProperty": "stage",
-              "nameProperty": "displayCreatedDateLabel",
-            },
             "enrollmentDate": {
               "defaultName": "Enrollment date",
               "dimensionType": "PERIOD",
@@ -171,14 +155,6 @@ describe('getTimeDimensions', () => {
               "id": "incidentDate",
               "nameParentProperty": "program",
               "nameProperty": "displayIncidentDateLabel",
-            },
-            "lastUpdatedOn": {
-              "defaultName": "Last updated on",
-              "dimensionType": "PERIOD",
-              "formatType": "DATE",
-              "id": "lastUpdatedOn",
-              "nameParentProperty": "stage",
-              "nameProperty": "displayLastUpdatedOnLabel",
             },
             "scheduledDate": {
               "defaultName": "Scheduled date",

--- a/src/modules/__tests__/visualization.spec.ts
+++ b/src/modules/__tests__/visualization.spec.ts
@@ -1,5 +1,9 @@
 import { DEFAULT_OPTIONS } from '@constants/options'
-import type { CurrentVisualization, SavedVisualization } from '@types'
+import type {
+    ApiSavedVisualization,
+    CurrentVisualization,
+    SavedVisualization,
+} from '@types'
 import { describe, it, expect } from 'vitest'
 import {
     analyticsHeaderToCanonicalDimensionId,
@@ -7,6 +11,7 @@ import {
     getAnalyticsRequestHeaderName,
     getSaveableVisualization,
     getVisualizationUiConfig,
+    normalizeApiSavedVisualization,
 } from '../visualization'
 
 const testCases = {
@@ -683,5 +688,109 @@ describe('getAnalyticsRequestHeaderName', () => {
                 visualization: buildVis({ showHierarchy: true }),
             })
         ).toBe(`${SID}.ounamehierarchy`)
+    })
+})
+
+describe('normalizeApiSavedVisualization', () => {
+    const buildApiVis = (
+        overrides: Partial<ApiSavedVisualization> = {}
+    ): ApiSavedVisualization =>
+        ({
+            type: 'LINE_LIST',
+            outputType: 'EVENT',
+            columns: [],
+            rows: [],
+            filters: [],
+            programDimensions: [],
+            ...overrides,
+        }) as unknown as ApiSavedVisualization
+
+    const dimensionsOf = (vis: SavedVisualization): string[] =>
+        [
+            ...(vis.columns ?? []),
+            ...(vis.rows ?? []),
+            ...(vis.filters ?? []),
+        ].map((dim) => dim.dimension)
+
+    it.each([
+        ['createdDate', 'created'],
+        ['completedDate', 'completed'],
+        ['lastUpdatedOn', 'lastUpdated'],
+    ])('renames %s to %s and marks the vis legacy', (oldId, newId) => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({
+                columns: [
+                    { dimension: oldId, dimensionType: 'PERIOD' },
+                ] as ApiSavedVisualization['columns'],
+            })
+        )
+
+        expect(dimensionsOf(result)).toContain(newId)
+        expect(dimensionsOf(result)).not.toContain(oldId)
+        expect(result.legacy).toBe(true)
+    })
+
+    it('leaves a canonical vis untouched and does not mark it legacy', () => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({
+                columns: [
+                    {
+                        dimension: 'created',
+                        dimensionType: 'PERIOD',
+                        programStage: { id: SID },
+                    },
+                ] as ApiSavedVisualization['columns'],
+            })
+        )
+
+        expect(dimensionsOf(result)).toEqual(['created'])
+        expect(result.legacy).toBeUndefined()
+    })
+
+    it('marks legacy when top-level program/programStage is present', () => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({
+                program: { id: PID },
+                programStage: { id: SID },
+                columns: [
+                    { dimension: UID, dimensionType: 'DATA_ELEMENT' },
+                ] as ApiSavedVisualization['columns'],
+            } as Partial<ApiSavedVisualization>)
+        )
+
+        expect(result.legacy).toBe(true)
+    })
+
+    it('marks legacy when a `pe` dimension is converted to a time dimension', () => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({
+                outputType: 'EVENT',
+                columns: [
+                    { dimension: 'pe', dimensionType: 'PERIOD' },
+                ] as ApiSavedVisualization['columns'],
+            })
+        )
+
+        expect(dimensionsOf(result)).toContain('eventDate')
+        expect(result.legacy).toBe(true)
+    })
+
+    it('marks legacy when an `orgUnitField` is converted to an ou filter', () => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({
+                orgUnitField: 'someOuField',
+            } as Partial<ApiSavedVisualization>)
+        )
+
+        expect(dimensionsOf(result)).toContain('ou')
+        expect(result.legacy).toBe(true)
+    })
+
+    it('honours an explicit incoming legacy flag', () => {
+        const result = normalizeApiSavedVisualization(
+            buildApiVis({ legacy: true } as Partial<ApiSavedVisualization>)
+        )
+
+        expect(result.legacy).toBe(true)
     })
 })

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -30,6 +30,7 @@ export const outputTypeTimeDimensionMap: Record<OutputType, DimensionId> = {
 export const timeFieldTimeDimensionMap: Record<string, DimensionId> = {
     COMPLETED_DATE: 'completed',
     CREATED: 'created',
+    CREATED_DATE: 'created',
     ENROLLMENT_DATE: 'enrollmentDate',
     EVENT_DATE: 'eventDate',
     INCIDENT_DATE: 'incidentDate',

--- a/src/modules/dimension.ts
+++ b/src/modules/dimension.ts
@@ -28,7 +28,7 @@ export const outputTypeTimeDimensionMap: Record<OutputType, DimensionId> = {
  * concrete time-dimension id the app uses internally. Used when
  * materialising a legacy `pe` dimension into a proper time dimension. */
 export const timeFieldTimeDimensionMap: Record<string, DimensionId> = {
-    COMPLETED_DATE: 'completedDate',
+    COMPLETED_DATE: 'completed',
     CREATED: 'created',
     ENROLLMENT_DATE: 'enrollmentDate',
     EVENT_DATE: 'eventDate',
@@ -180,25 +180,9 @@ type TimeDimension = {
     nameProperty: string
 }
 export const getTimeDimensions = (): Record<
-    Exclude<TimeDimensionId, 'created' | 'lastUpdated'>,
+    Exclude<TimeDimensionId, 'lastUpdated'>,
     TimeDimension
 > => ({
-    completedDate: {
-        id: 'completedDate',
-        dimensionType: 'PERIOD',
-        defaultName: i18n.t('Completed date'),
-        nameParentProperty: 'stage',
-        nameProperty: 'displayCompletedDateLabel',
-        formatType: 'DATE',
-    },
-    createdDate: {
-        id: 'createdDate',
-        dimensionType: 'PERIOD',
-        defaultName: i18n.t('Created date'),
-        nameParentProperty: 'stage',
-        nameProperty: 'displayCreatedDateLabel',
-        formatType: 'DATE',
-    },
     eventDate: {
         id: 'eventDate',
         dimensionType: 'PERIOD',
@@ -221,14 +205,6 @@ export const getTimeDimensions = (): Record<
         defaultName: i18n.t('Incident date'),
         nameParentProperty: 'program',
         nameProperty: 'displayIncidentDateLabel',
-        formatType: 'DATE',
-    },
-    lastUpdatedOn: {
-        id: 'lastUpdatedOn',
-        dimensionType: 'PERIOD',
-        defaultName: i18n.t('Last updated on'),
-        nameParentProperty: 'stage',
-        nameProperty: 'displayLastUpdatedOnLabel',
         formatType: 'DATE',
     },
     scheduledDate: {

--- a/src/modules/metadata-store/__tests__/metadata-store.spec.ts
+++ b/src/modules/metadata-store/__tests__/metadata-store.spec.ts
@@ -385,12 +385,6 @@ describe('MetadataStore', () => {
               "programStageId": "Zj7UnCAulEk",
               "valueType": "INTEGER_POSITIVE",
             },
-            "completedDate": {
-              "dimensionId": "completedDate",
-              "dimensionType": "PERIOD",
-              "id": "completedDate",
-              "name": "Completed date",
-            },
             "created": {
               "dimensionId": "created",
               "dimensionType": "PERIOD",
@@ -403,12 +397,6 @@ describe('MetadataStore', () => {
               "dimensionType": "USER",
               "id": "createdBy",
               "name": "Created by",
-            },
-            "createdDate": {
-              "dimensionId": "createdDate",
-              "dimensionType": "PERIOD",
-              "id": "createdDate",
-              "name": "Created date",
             },
             "eBAyeGv0exc": {
               "displayIncidentDate": false,
@@ -467,12 +455,6 @@ describe('MetadataStore', () => {
               "dimensionType": "USER",
               "id": "lastUpdatedBy",
               "name": "Last updated by",
-            },
-            "lastUpdatedOn": {
-              "dimensionId": "lastUpdatedOn",
-              "dimensionType": "PERIOD",
-              "id": "lastUpdatedOn",
-              "name": "Last updated on",
             },
             "pe": {
               "dimensionId": "pe",
@@ -533,8 +515,8 @@ describe('MetadataStore', () => {
 
         // Length grows and decreases
         expect(snapshot0Keys.size).toBe(43)
-        expect(snapshot1Keys.size).toBe(78)
-        expect(snapshot2Keys.size).toBe(64)
+        expect(snapshot1Keys.size).toBe(75)
+        expect(snapshot2Keys.size).toBe(61)
 
         // Initial metadata is always included
         expect(snapshot0Keys.isSubsetOf(snapshot1Keys)).toBe(true)
@@ -580,11 +562,8 @@ describe('MetadataStore', () => {
             )
         ).toMatchInlineSnapshot(`
           [
-            "completedDate",
-            "createdDate",
             "enrollmentDate",
             "incidentDate",
-            "lastUpdatedOn",
             "scheduledDate",
             "lastUpdated",
             "createdBy",

--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -51,12 +51,9 @@ export const headersMap: Record<DimensionId, string> = {
     programStatus: 'programstatus',
     eventStatus: 'eventstatus',
     completed: 'completed',
-    completedDate: 'completeddate',
     created: 'created',
     createdBy: 'createdbydisplayname',
-    createdDate: 'createddate',
     lastUpdatedBy: 'lastupdatedbydisplayname',
-    lastUpdatedOn: 'lastupdatedon', // XXX: needed here? is this used also in LL?
     eventDate: 'eventdate',
     enrollmentDate: 'enrollmentdate',
     enrollmentOu: 'enrollmentouname',
@@ -569,16 +566,28 @@ export const getSingleProgramStageFromVisualization = (
     return stages[0]
 }
 
+/* Old dimension IDs (created by the legacy event-visualizer / Event Reports
+ * app) mapped onto the canonical IDs this app and the backend analytics API
+ * use. `createdDate` is a genuine persisted alias of `created`; the other two
+ * are normalised defensively (the backend never persists them). */
+const LEGACY_DIMENSION_ID_RENAMES: Record<string, DimensionId> = {
+    createdDate: 'created',
+    completedDate: 'completed',
+    lastUpdatedOn: 'lastUpdated',
+}
+
 /**
  * Legacy → canonical normalisation for saved visualizations received from the
- * eventVisualizations API. Converts either of the two legacy shapes (old
- * line-listing `legacy: true`, and old event-visualizer top-level
- * program/programStage) into the canonical shape this app persists.
+ * eventVisualizations API. Converts the legacy shapes (old line-listing
+ * `legacy: true`, old event-visualizer top-level program/programStage, and old
+ * dimension IDs) into the canonical shape this app persists.
  *
  * Scope:
  * - Propagate top-level program/programStage onto individual dimensions
  * - Ensure `programDimensions` includes the top-level program
  * - Convert legacy `pe` dimension into the proper time dimension
+ * - Rename old dimension IDs (`createdDate`/`completedDate`/`lastUpdatedOn`)
+ *   to their canonical form
  * - Convert legacy `orgUnitField` into an `ou` filter
  * - Drop `timeField` when it holds a known backend enum value (e.g.
  *   `EVENT_DATE`) — the corresponding "which column" information is now
@@ -587,12 +596,13 @@ export const getSingleProgramStageFromVisualization = (
  *   data-element / attribute UID, since that's still a live analytics
  *   parameter
  * - Drop top-level `program` and `programStage`
- * - Mark output as `legacy: true` when either legacy shape was detected, so
- *   the vis cannot be overwritten in place — only "Save as" is allowed.
- *   Overwriting would silently persist in the canonical format, breaking
- *   older apps that still read the legacy shape.
+ * - Mark output as `legacy: true` whenever any of the above upgraded the
+ *   persisted shape, so the vis cannot be overwritten in place — only "Save
+ *   as" is allowed. Overwriting would silently persist in the canonical
+ *   format, breaking older apps that still read the legacy shape.
  *
- * Out of scope (handled downstream):
+ * Out of scope (handled downstream — these run on every load, not just legacy
+ * visualizations, so they do not imply the `legacy` flag):
  * - `completedOnly` → `eventStatus=COMPLETED` filter (not legacy-only)
  * - `PROGRAM_DATA_ELEMENT` → `DATA_ELEMENT` (wire → app shape)
  * - `dy`/`latitude`/`longitude` stripping (wire → app shape)
@@ -605,7 +615,7 @@ export const normalizeApiSavedVisualization = (
         programStage,
         orgUnitField,
         timeField,
-        legacy,
+        legacy: apiVisLegacy,
         columns = [],
         rows = [],
         filters = [],
@@ -619,11 +629,23 @@ export const normalizeApiSavedVisualization = (
     const stageRef = programStage ? { id: programStage.id } : undefined
     const outputType = rest.outputType as OutputType | undefined
 
+    // The vis is legacy whenever anything here upgrades the persisted shape:
+    // re-saving in canonical format would then break older apps still reading
+    // the original shape, so block the in-place save path. Seed it from the
+    // top-level legacy signals (explicit flag, old event-visualizer
+    // program/programStage, legacy `orgUnitField`); the per-dimension pass and
+    // the `timeField` drop below flip it too.
+    let legacy =
+        Boolean(apiVisLegacy) ||
+        Boolean(program || programStage) ||
+        Boolean(orgUnitField)
+
     // Single pass per dimension:
     //   - propagate top-level program/programStage onto dimensions that
     //     don't carry them (old event-visualizer shape)
     //   - convert a legacy `pe` dimension into the concrete time dimension
     //     (legacy line-listing shape)
+    //   - rename old dimension IDs to their canonical form
     const normalizeDimensions = (dims: DimensionArray): DimensionArray =>
         dims.map((dim) => {
             let out = dim
@@ -645,7 +667,14 @@ export const normalizeApiSavedVisualization = (
                         dimension: targetDim,
                         dimensionType: 'PERIOD',
                     }
+                    legacy = true
                 }
+            }
+
+            const renamedDimension = LEGACY_DIMENSION_ID_RENAMES[out.dimension]
+            if (renamedDimension) {
+                out = { ...out, dimension: renamedDimension }
+                legacy = true
             }
 
             return out
@@ -667,15 +696,12 @@ export const normalizeApiSavedVisualization = (
     // `timeField` holding a known backend enum value has been materialised
     // into a concrete time dimension above; keep it only when it holds a
     // data-element / attribute UID (non-legacy usage that the analytics
-    // request still needs).
+    // request still needs). Dropping a known-enum `timeField` is an upgrade.
     const preserveTimeField =
         typeof timeField === 'string' && !KNOWN_TIME_FIELD_VALUES.has(timeField)
-
-    // Detect either legacy shape — shape-1 carried an explicit `legacy: true`
-    // flag; shape-2 didn't, but having top-level program/programStage is the
-    // tell. In both cases, re-saving in canonical format would break older
-    // apps still reading the legacy shape, so block the save path.
-    const markLegacy = Boolean(legacy || program || programStage)
+    if (typeof timeField === 'string' && !preserveTimeField) {
+        legacy = true
+    }
 
     return {
         ...rest,
@@ -684,7 +710,7 @@ export const normalizeApiSavedVisualization = (
         filters: normalizedFilters,
         programDimensions: normalizedProgramDimensions,
         ...(preserveTimeField ? { timeField } : {}),
-        ...(markLegacy ? { legacy: true } : {}),
+        ...(legacy ? { legacy: true } : {}),
         ...(sortOrder !== 0 && { sortOrder }),
         ...(topLimit !== 0 && { topLimit }),
     } as SavedVisualization


### PR DESCRIPTION
Implements [DHIS2-21504](https://dhis2.atlassian.net/browse/DHIS2-21504)

### Description

The app used three old dimension IDs — `createdDate`, `completedDate` and `lastUpdatedOn` — as time dimensions. These were redundant duplicates of the real metadata dimensions `created`, `completed` and `lastUpdated`. The analytics API and the line-listing-app both use the canonical names, so the old ones were removed and we now only generate `created`/`completed`/`lastUpdated`.

We still normalize on load because saved visualizations from the old event-visualizer (Event Reports) app can contain the old IDs (`createdDate` is a real alias). When one loads, `normalizeApiSavedVisualization` rewrites the old IDs to the new ones so the app can render them.

The API accepts some old names as aliases, but we still mark any rewritten visualization as **legacy** (only "Save as" enabled): the old app may rely on the old names (e.g. for labels), so we never overwrite it in place. The rule is now simple — if loading changed anything, the visualization is legacy. 

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A


[DHIS2-21504]: https://dhis2.atlassian.net/browse/DHIS2-21504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
