### PR TITLE
fix: reorder sidebar cards and layout buttons

### DIFF
--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -238,4 +238,68 @@ describe('<LayoutPanel />', () => {
         // Check that the update buttons are present
         cy.getByDataTest('update-buttons').should('be.visible')
     })
+
+    it('renders the LINE_LIST update buttons in the order tracked entity, enrollment, event', () => {
+        const layoutPanelMockOptions = createMockOptions({
+            dimensionSelection: {
+                ...mockOptions.partialStore?.preloadedState.dimensionSelection,
+                dataSourceId: 'test-id',
+            },
+            visUiConfig: {
+                ...mockOptions.partialStore?.preloadedState.visUiConfig,
+                visualizationType: 'LINE_LIST',
+            },
+        })
+
+        cy.mount(
+            <MockAppWrapper {...layoutPanelMockOptions}>
+                <LayoutPanel />
+            </MockAppWrapper>
+        )
+
+        cy.getByDataTest('update-buttons')
+            .findByDataTestLike('update-button-')
+            .then(($buttons) => {
+                const order = [...$buttons].map((el) =>
+                    el.getAttribute('data-test')
+                )
+                expect(order).to.deep.equal([
+                    'update-button-tracked-entity',
+                    'update-button-enrollment',
+                    'update-button-event',
+                ])
+            })
+    })
+
+    it('renders the PIVOT_TABLE update buttons in the order enrollment, event, custom value', () => {
+        const layoutPanelMockOptions = createMockOptions({
+            dimensionSelection: {
+                ...mockOptions.partialStore?.preloadedState.dimensionSelection,
+                dataSourceId: 'test-id',
+            },
+            visUiConfig: {
+                ...mockOptions.partialStore?.preloadedState.visUiConfig,
+                visualizationType: 'PIVOT_TABLE',
+            },
+        })
+
+        cy.mount(
+            <MockAppWrapper {...layoutPanelMockOptions}>
+                <LayoutPanel />
+            </MockAppWrapper>
+        )
+
+        cy.getByDataTest('update-buttons')
+            .findByDataTestLike('update-button-')
+            .then(($buttons) => {
+                const order = [...$buttons].map((el) =>
+                    el.getAttribute('data-test')
+                )
+                expect(order).to.deep.equal([
+                    'update-button-enrollment',
+                    'update-button-event',
+                    'update-button-custom-value',
+                ])
+            })
+    })
 })

--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -260,9 +260,7 @@ describe('<LayoutPanel />', () => {
         cy.getByDataTest('update-buttons')
             .findByDataTestLike('update-button-')
             .then(($buttons) => {
-                const order = [...$buttons].map((el) =>
-                    el.getAttribute('data-test')
-                )
+                const order = [...$buttons].map((el) => el.dataset.test)
                 expect(order).to.deep.equal([
                     'update-button-tracked-entity',
                     'update-button-enrollment',
@@ -292,9 +290,7 @@ describe('<LayoutPanel />', () => {
         cy.getByDataTest('update-buttons')
             .findByDataTestLike('update-button-')
             .then(($buttons) => {
-                const order = [...$buttons].map((el) =>
-                    el.getAttribute('data-test')
-                )
+                const order = [...$buttons].map((el) => el.dataset.test)
                 expect(order).to.deep.equal([
                     'update-button-enrollment',
                     'update-button-event',

--- a/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
@@ -15,6 +15,7 @@ export type ButtonAction = 'create' | 'switch' | 'update'
 
 export type BaseButtonProps = {
     action: ButtonAction
+    dataTest?: string
     disabled?: boolean
     label: string
     lastActiveButton?: LastActiveButton
@@ -24,6 +25,7 @@ export type BaseButtonProps = {
 
 const BaseButton: FC<BaseButtonProps> = ({
     action,
+    dataTest,
     disabled = false,
     label,
     lastActiveButton,
@@ -45,6 +47,7 @@ const BaseButton: FC<BaseButtonProps> = ({
             type="button"
             onClick={onClick}
             disabled={disabled}
+            data-test={dataTest}
             className={cx(classes.button, {
                 [classes.disabled]: disabled,
                 [classes.update]: action === 'update',

--- a/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
@@ -139,6 +139,7 @@ export const CustomValueButton: FC = () => {
                             type="button"
                             onClick={onUpdateClick}
                             disabled={isUpdateDisabled}
+                            data-test="update-button-custom-value"
                             className={cx(classes.button, {
                                 [classes.disabled]: isUpdateDisabled,
                                 [classes.update]:

--- a/src/components/layout-panel/bottom-bar/action-buttons/enrollment-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/enrollment-button.tsx
@@ -57,6 +57,7 @@ export const EnrollmentButton: FC = () => {
     return (
         <BaseButtonWithConditionalTooltip
             action={action}
+            dataTest="update-button-enrollment"
             disabled={Boolean(tooltipConfig)}
             label={
                 buttonLabelLookup[action][

--- a/src/components/layout-panel/bottom-bar/action-buttons/event-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/event-button.tsx
@@ -58,6 +58,7 @@ export const EventButton: FC = () => {
     return (
         <BaseButtonWithConditionalTooltip
             action={action}
+            dataTest="update-button-event"
             disabled={Boolean(tooltipConfig)}
             label={
                 buttonLabelLookup[action][

--- a/src/components/layout-panel/bottom-bar/action-buttons/tracked-entity-instance-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/tracked-entity-instance-button.tsx
@@ -38,6 +38,7 @@ export const TrackedEntityInstanceButton: FC = () => {
     return (
         <BaseButtonWithConditionalTooltip
             action={action}
+            dataTest="update-button-tracked-entity"
             disabled={Boolean(tooltipConfig)}
             label={buttonLabelLookup[action]['list']}
             tooltipConfig={tooltipConfig}

--- a/src/components/layout-panel/bottom-bar/bottom-bar.tsx
+++ b/src/components/layout-panel/bottom-bar/bottom-bar.tsx
@@ -24,12 +24,18 @@ export const BottomBar: FC = () => {
         >
             {dataSourceId && !isVisualizationLoading && (
                 <div className={classes.container} data-test="update-buttons">
-                    <EventButton />
-                    <EnrollmentButton />
                     {visualizationType === 'PIVOT_TABLE' ? (
-                        <CustomValueButton />
+                        <>
+                            <EnrollmentButton />
+                            <EventButton />
+                            <CustomValueButton />
+                        </>
                     ) : (
-                        <TrackedEntityInstanceButton />
+                        <>
+                            <TrackedEntityInstanceButton />
+                            <EnrollmentButton />
+                            <EventButton />
+                        </>
                     )}
                 </div>
             )}

--- a/src/components/sidebar/cards-program-with-registration/__tests__/cards-program-with-registration.spec.tsx
+++ b/src/components/sidebar/cards-program-with-registration/__tests__/cards-program-with-registration.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import type { DataSourceProgramWithRegistration } from '@types'
+import { describe, it, expect, vi } from 'vitest'
+import { CardsProgramWithRegistration } from '../cards-program-with-registration'
+
+vi.mock('../card-tracked-entity-type', () => ({
+    CardTrackedEntityType: () => (
+        <div data-test="card">Tracked entity registration</div>
+    ),
+}))
+
+vi.mock('../card-enrollment', () => ({
+    CardEnrollment: () => <div data-test="card">Enrollment data</div>,
+}))
+
+vi.mock('../card-event', () => ({
+    CardEvent: () => <div data-test="card">Event data</div>,
+}))
+
+vi.mock('../card-program-indicators', () => ({
+    CardProgramIndicators: () => <div data-test="card">Program indicators</div>,
+}))
+
+const program = { id: 'prog1' } as DataSourceProgramWithRegistration
+
+describe('CardsProgramWithRegistration', () => {
+    it('renders the cards in order: registration, enrollment, event, program indicators', () => {
+        render(<CardsProgramWithRegistration program={program} />)
+
+        const cardTitles = screen
+            .getAllByTestId('card')
+            .map((card) => card.textContent)
+
+        expect(cardTitles).toEqual([
+            'Tracked entity registration',
+            'Enrollment data',
+            'Event data',
+            'Program indicators',
+        ])
+    })
+})

--- a/src/components/sidebar/cards-program-with-registration/cards-program-with-registration.tsx
+++ b/src/components/sidebar/cards-program-with-registration/cards-program-with-registration.tsx
@@ -13,9 +13,9 @@ export const CardsProgramWithRegistration: FC<
     CardsProgramWithRegistrationProps
 > = ({ program }) => (
     <>
+        <CardTrackedEntityType program={program} />
         <CardEnrollment program={program} />
         <CardEvent program={program} />
-        <CardTrackedEntityType program={program} />
         <CardProgramIndicators program={program} />
     </>
 )


### PR DESCRIPTION
Implements [DHIS2-21612](https://dhis2.atlassian.net/browse/DHIS2-21612)

### Description

This PR changes the order of sidebar cards and layout action buttons.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) _N/A_

---

### Screenshots

<img width="939" height="831" alt="image" src="https://github.com/user-attachments/assets/781c33b7-74a8-42c6-85bf-7f5c0e4111a5" />

<img width="922" height="803" alt="image" src="https://github.com/user-attachments/assets/917f8025-910b-4e75-ac9c-ea227698e948" />


[DHIS2-21612]: https://dhis2.atlassian.net/browse/DHIS2-21612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ