### PR TITLE
fix: stop line list header stage suffix from accumulating

### DIFF
--- a/src/components/line-list/__tests__/use-transformed-line-list-data.spec.ts
+++ b/src/components/line-list/__tests__/use-transformed-line-list-data.spec.ts
@@ -1,0 +1,58 @@
+import type { LineListAnalyticsDataHeader } from '@components/line-list/types'
+import { describe, it, expect } from 'vitest'
+import { getHeaderDisplayText } from '../use-transformed-line-list-data'
+
+const buildHeader = (
+    partial: Partial<LineListAnalyticsDataHeader>
+): LineListAnalyticsDataHeader =>
+    ({ valueType: 'TEXT', ...partial }) as LineListAnalyticsDataHeader
+
+describe('getHeaderDisplayText', () => {
+    it('returns the base column name when there is no suffix', () => {
+        expect(
+            getHeaderDisplayText(buildHeader({ column: 'Scheduled date' }))
+        ).toBe('Scheduled date')
+    })
+
+    it('appends the contextual dimension suffix to the base name', () => {
+        expect(
+            getHeaderDisplayText(
+                buildHeader({
+                    column: 'Scheduled date',
+                    dimensionSuffix: 'Birth',
+                })
+            )
+        ).toBe('Scheduled date · Birth')
+    })
+
+    it('does not accumulate the suffix across renders of the same header', () => {
+        const header = buildHeader({
+            column: 'Scheduled date',
+            dimensionSuffix: 'Birth',
+        })
+
+        const first = getHeaderDisplayText(header)
+        const second = getHeaderDisplayText(header)
+
+        expect(first).toBe('Scheduled date · Birth')
+        expect(second).toBe('Scheduled date · Birth')
+    })
+
+    it('combines the dimension suffix with the repetition suffix', () => {
+        expect(
+            getHeaderDisplayText(
+                buildHeader({
+                    column: 'Scheduled date',
+                    dimensionSuffix: 'Birth',
+                    stageOffset: 0,
+                })
+            )
+        ).toBe('Scheduled date · Birth (most recent)')
+    })
+
+    it('returns an empty string when there is no column', () => {
+        expect(
+            getHeaderDisplayText(buildHeader({ dimensionSuffix: 'Birth' }))
+        ).toBe('')
+    })
+})

--- a/src/components/line-list/types.ts
+++ b/src/components/line-list/types.ts
@@ -35,6 +35,8 @@ export type LineListAnalyticsDataHeader = GridHeader & {
      * reused by downstream consumers so the wire-to-canonical translation
      * happens exactly once per response. */
     dimensionId: string
+    /* Stage/program disambiguation suffix, combined with `column` at render. */
+    dimensionSuffix?: string
 }
 export type LineListAnalyticsData = {
     headers: Array<LineListAnalyticsDataHeader>

--- a/src/components/line-list/use-transformed-line-list-data.ts
+++ b/src/components/line-list/use-transformed-line-list-data.ts
@@ -15,12 +15,14 @@ import { useMemo } from 'react'
 const isStageOffsetInteger = (stageOffset: unknown): stageOffset is number =>
     Number.isInteger(stageOffset)
 
-const getHeaderDisplayText = (header: LineListAnalyticsDataHeader) => {
-    const { column, stageOffset } = header
+export const getHeaderDisplayText = (header: LineListAnalyticsDataHeader) => {
+    const { column, stageOffset, dimensionSuffix } = header
 
     if (!column) {
         return ''
     }
+
+    const label = dimensionSuffix ? `${column} · ${dimensionSuffix}` : column
 
     if (isStageOffsetInteger(stageOffset)) {
         let repetitionSuffix
@@ -39,10 +41,10 @@ const getHeaderDisplayText = (header: LineListAnalyticsDataHeader) => {
             })
         }
 
-        return `${column} (${repetitionSuffix})`
+        return `${label} (${repetitionSuffix})`
     }
 
-    return column
+    return label
 }
 
 const NOT_DEFINED_VALUE = 'ND'

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.spec.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.spec.ts
@@ -1,0 +1,94 @@
+import type { UseMetadataStoreReturnValue } from '@components/app-wrapper/metadata-provider/metadata-provider'
+import { extractMetadataFromAnalyticsResponse } from '@modules/metadata-store/analytics-data'
+import type {
+    AnalyticsResponseMetadataItems,
+    CurrentVisualization,
+    DimensionMetadataItem,
+} from '@types'
+import { describe, it, expect } from 'vitest'
+import { extractHeaders } from './use-line-list-analytics-data'
+
+const visualization = {
+    outputType: 'EVENT',
+    programDimensions: [{ id: 'p1' }],
+} as unknown as CurrentVisualization
+
+const analyticsResponse = {
+    headers: [{ name: 's1.scheduledDate' }, { name: 's2.scheduledDate' }],
+    metaData: {
+        items: {
+            s1: { name: 'Birth' },
+            s2: { name: 'Baby Postnatal' },
+        },
+    },
+}
+
+const buildMetadataStore = (
+    scheduledDateName: string
+): UseMetadataStoreReturnValue => {
+    const items: Record<string, Partial<DimensionMetadataItem>> = {
+        's1.scheduledDate': {
+            name: scheduledDateName,
+            programId: 'p1',
+            programStageId: 's1',
+        },
+        's2.scheduledDate': {
+            name: scheduledDateName,
+            programId: 'p1',
+            programStageId: 's2',
+        },
+    }
+    return {
+        getDimensionMetadataItem: (id: string) => items[id],
+    } as unknown as UseMetadataStoreReturnValue
+}
+
+describe('extractHeaders', () => {
+    it('keeps the base name in column and exposes the stage suffix separately', () => {
+        const headers = extractHeaders(
+            analyticsResponse,
+            visualization,
+            buildMetadataStore('Scheduled date')
+        )
+
+        expect(headers[0]).toMatchObject({
+            dimensionId: 's1.scheduledDate',
+            column: 'Scheduled date',
+            dimensionSuffix: 'Birth',
+        })
+        expect(headers[1]).toMatchObject({
+            dimensionId: 's2.scheduledDate',
+            column: 'Scheduled date',
+            dimensionSuffix: 'Baby Postnatal',
+        })
+    })
+
+    it('does not accumulate the stage suffix across repeated updates', () => {
+        const firstHeaders = extractHeaders(
+            analyticsResponse,
+            visualization,
+            buildMetadataStore('Scheduled date')
+        )
+
+        const metadataAfterUpdate = extractMetadataFromAnalyticsResponse(
+            analyticsResponse.metaData
+                .items as unknown as AnalyticsResponseMetadataItems,
+            firstHeaders
+        )
+
+        expect(metadataAfterUpdate['s1.scheduledDate'].name).toBe(
+            'Scheduled date'
+        )
+
+        const storedName = metadataAfterUpdate['s1.scheduledDate']
+            .name as string
+        const secondHeaders = extractHeaders(
+            analyticsResponse,
+            visualization,
+            buildMetadataStore(storedName)
+        )
+
+        expect(secondHeaders[0].column).toBe('Scheduled date')
+        expect(secondHeaders[0].dimensionSuffix).toBe('Birth')
+    })
+})

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -178,7 +178,7 @@ const fetchLegendSets = async ({ legendSetIds, dataEngine }) => {
     return legendSets
 }
 
-const extractHeaders = (
+export const extractHeaders = (
     analyticsResponse,
     visualization: CurrentVisualization,
     metadataStore: UseMetadataStoreReturnValue
@@ -217,12 +217,8 @@ const extractHeaders = (
         (id) => metadata[id]?.name
     )
 
-    const labelById = new Map<string, string>(
-        canonicalIds.map((id) => {
-            const name = metadata[id]?.name ?? id
-            const suffix = suffixes[id]
-            return [id, suffix ? `${name} · ${suffix}` : name]
-        })
+    const nameById = new Map<string, string>(
+        canonicalIds.map((id) => [id, metadata[id]?.name ?? id])
     )
 
     return analyticsResponse.headers.map(
@@ -230,7 +226,8 @@ const extractHeaders = (
             ...header,
             index,
             dimensionId: canonicalIds[index],
-            column: labelById.get(canonicalIds[index]) ?? header.column,
+            column: nameById.get(canonicalIds[index]) ?? header.column,
+            dimensionSuffix: suffixes[canonicalIds[index]],
         })
     )
 }


### PR DESCRIPTION
Implements a demo blocking issue, no JIRA ticket available

### Description

On a saved line list, clicking **Update** repeatedly caused the stage suffix in each table header (and the matching column chip) to accumulate: `Scheduled date · Birth · Birth · Birth …`.

`extractHeaders` built the column label as `baseName · stageSuffix` (reading the base name from the metadata store), and `updateNamesFromHeaders` wrote that suffixed label back into the store's `name`. The next update re-read the suffixed name as the base and appended the suffix again — a feedback loop. The column chips showed the same growth because they read the polluted store name too.

Fix: keep `column` as the base name and carry the suffix in a new `dimensionSuffix` field, combining the two only at render time in `getHeaderDisplayText` (alongside the existing repetition suffix). The store name is no longer mutated with a computed display label. This mirrors how the layout chips already keep `name` and `suffix` separate.

Pivot tables were checked and are not affected — their response path never passes headers to `updateNamesFromHeaders`.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A
