### PR TITLE
chore: switching between custom value and event tables

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-09T12:01:10.007Z\n"
-"PO-Revision-Date: 2026-06-09T12:01:10.007Z\n"
+"POT-Creation-Date: 2026-06-10T07:32:11.618Z\n"
+"PO-Revision-Date: 2026-06-10T07:32:11.618Z\n"
 
 msgid "Add to {{- axisName}}"
 msgstr "Add to {{- axisName}}"
@@ -317,6 +317,9 @@ msgstr "Configure custom value"
 msgid "Choose the numeric data element to show in table cells."
 msgstr "Choose the numeric data element to show in table cells."
 
+msgid "Search data items"
+msgstr "Search data items"
+
 msgid "Loading data"
 msgstr "Loading data"
 
@@ -337,6 +340,9 @@ msgstr "This stage does not have any numeric data elements available."
 
 msgid "This program does not have any numeric data elements available."
 msgstr "This program does not have any numeric data elements available."
+
+msgid "No data elements match \"{{- searchTerm}}\""
+msgstr "No data elements match \"{{- searchTerm}}\""
 
 msgid "Aggregation"
 msgstr "Aggregation"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,13 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-<<<<<<< chore/switch-between-custom-value-and-event-list
-"POT-Creation-Date: 2026-06-10T07:32:11.618Z\n"
-"PO-Revision-Date: 2026-06-10T07:32:11.618Z\n"
-=======
-"POT-Creation-Date: 2026-06-10T06:40:30.936Z\n"
-"PO-Revision-Date: 2026-06-10T06:40:30.936Z\n"
->>>>>>> master
+"POT-Creation-Date: 2026-06-10T14:25:39.903Z\n"
+"PO-Revision-Date: 2026-06-10T14:25:39.903Z\n"
 
 msgid "Add to {{- axisName}}"
 msgstr "Add to {{- axisName}}"

--- a/package.json
+++ b/package.json
@@ -96,5 +96,5 @@
             "prettier --check"
         ]
     },
-    "packageManager": "pnpm@11.1.3+sha512.c85357fe17ca12dd23dd7071822666dfd7e3cb76fe214e3370b5ea2fb34f2a231185509b63e717f3cd0acb38dd3f8d82bcd5e8172400ae678b70ea4fbed0896d"
+    "packageManager": "pnpm@11.5.2+sha512.71c631e382066efc25625d5cf029075de07b61b37f6e27350fbd84b1bda5864c8c1967adc280776b45c30a715c0359a3be08fef42d5bb09e2b99029979692916"
 }

--- a/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/__tests__/use-action-button.spec.tsx
@@ -1137,4 +1137,80 @@ describe('useActionButton for Custom value button', () => {
             content: 'Not valid with multiple program stages',
         })
     })
+
+    it('returns "update" for: PT, EVENT output, custom value active (currentVis has a value)', async () => {
+        const { result } = await renderHookWithAppWrapper(
+            () => useActionButton('EVENT', 'CUSTOM_VALUE'),
+            createStoreWithPreloadedState({
+                currentVis: {
+                    outputType: 'EVENT',
+                    type: 'PIVOT_TABLE',
+                    value: { id: metadata['p2.p2s1.d1'].id },
+                },
+                dimensionSelection: {
+                    dataSourceId: metadata.p2.id,
+                },
+                visUiConfig: {
+                    layout: {
+                        columns: [metadata['p2.p2s1.d1'].id],
+                    },
+                    outputType: 'EVENT',
+                    visualizationType: 'PIVOT_TABLE',
+                },
+            })
+        )
+
+        expect(result.current.action).toEqual('update')
+    })
+})
+
+describe('useActionButton for Event button in PIVOT_TABLE custom value mode', () => {
+    it('returns "switch" when a custom value is active (currentVis has a value)', async () => {
+        const { result } = await renderHookWithAppWrapper(
+            () => useActionButton('EVENT', 'EVENT'),
+            createStoreWithPreloadedState({
+                currentVis: {
+                    outputType: 'EVENT',
+                    type: 'PIVOT_TABLE',
+                    value: { id: metadata['p2.p2s1.d1'].id },
+                },
+                dimensionSelection: {
+                    dataSourceId: metadata.p2.id,
+                },
+                visUiConfig: {
+                    layout: {
+                        columns: [metadata['p2.p2s1.d1'].id],
+                    },
+                    outputType: 'EVENT',
+                    visualizationType: 'PIVOT_TABLE',
+                },
+            })
+        )
+
+        expect(result.current.action).toEqual('switch')
+    })
+
+    it('returns "update" when no custom value is active (currentVis has no value)', async () => {
+        const { result } = await renderHookWithAppWrapper(
+            () => useActionButton('EVENT', 'EVENT'),
+            createStoreWithPreloadedState({
+                currentVis: {
+                    outputType: 'EVENT',
+                    type: 'PIVOT_TABLE',
+                },
+                dimensionSelection: {
+                    dataSourceId: metadata.p2.id,
+                },
+                visUiConfig: {
+                    layout: {
+                        columns: [metadata['p2.p2s1.d1'].id],
+                    },
+                    outputType: 'EVENT',
+                    visualizationType: 'PIVOT_TABLE',
+                },
+            })
+        )
+
+        expect(result.current.action).toEqual('update')
+    })
 })

--- a/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
@@ -30,7 +30,7 @@ const BaseButton: FC<BaseButtonProps> = ({
 
     const onClick = () => {
         dispatch(setVisUiConfigOutputType(type))
-        dispatch(tUpdateCurrentVisFromVisUiConfig('EVENT'))
+        dispatch(tUpdateCurrentVisFromVisUiConfig(false))
     }
 
     return (

--- a/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/base-button.tsx
@@ -1,11 +1,7 @@
 import { IconSync16, Tooltip } from '@dhis2/ui'
 import { useAppDispatch } from '@hooks'
 import { tUpdateCurrentVisFromVisUiConfig } from '@store/thunks'
-import {
-    setVisUiConfigLastActiveButton,
-    setVisUiConfigOutputType,
-} from '@store/vis-ui-config-slice'
-import type { LastActiveButton } from '@store/vis-ui-config-slice'
+import { setVisUiConfigOutputType } from '@store/vis-ui-config-slice'
 import type { OutputType } from '@types'
 import cx from 'classnames'
 import { type FC } from 'react'
@@ -18,7 +14,6 @@ export type BaseButtonProps = {
     dataTest?: string
     disabled?: boolean
     label: string
-    lastActiveButton?: LastActiveButton
     tooltipProps?: object
     type: OutputType
 }
@@ -28,18 +23,14 @@ const BaseButton: FC<BaseButtonProps> = ({
     dataTest,
     disabled = false,
     label,
-    lastActiveButton,
     tooltipProps,
     type,
 }) => {
     const dispatch = useAppDispatch()
 
     const onClick = () => {
-        if (lastActiveButton !== undefined) {
-            dispatch(setVisUiConfigLastActiveButton(lastActiveButton))
-        }
         dispatch(setVisUiConfigOutputType(type))
-        dispatch(tUpdateCurrentVisFromVisUiConfig())
+        dispatch(tUpdateCurrentVisFromVisUiConfig('EVENT'))
     }
 
     return (

--- a/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
@@ -11,7 +11,6 @@ import {
 import { tUpdateCurrentVisFromVisUiConfig } from '@store/thunks'
 import {
     getVisUiConfigCustomValue,
-    setVisUiConfigLastActiveButton,
     setVisUiConfigOutputType,
 } from '@store/vis-ui-config-slice'
 import cx from 'classnames'
@@ -115,9 +114,8 @@ export const CustomValueButton: FC = () => {
 
     const onUpdateClick = useCallback(() => {
         if (customValue) {
-            dispatch(setVisUiConfigLastActiveButton('CUSTOM_VALUE'))
             dispatch(setVisUiConfigOutputType('EVENT'))
-            dispatch(tUpdateCurrentVisFromVisUiConfig())
+            dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
         } else {
             setIsModalOpen(true)
         }

--- a/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/custom-value-button.tsx
@@ -115,7 +115,7 @@ export const CustomValueButton: FC = () => {
     const onUpdateClick = useCallback(() => {
         if (customValue) {
             dispatch(setVisUiConfigOutputType('EVENT'))
-            dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
+            dispatch(tUpdateCurrentVisFromVisUiConfig(true))
         } else {
             setIsModalOpen(true)
         }

--- a/src/components/layout-panel/bottom-bar/action-buttons/event-button.tsx
+++ b/src/components/layout-panel/bottom-bar/action-buttons/event-button.tsx
@@ -65,7 +65,6 @@ export const EventButton: FC = () => {
                     visualizationType === 'PIVOT_TABLE' ? 'table' : 'list'
                 ]
             }
-            lastActiveButton="EVENT"
             tooltipConfig={tooltipConfig}
             type="EVENT"
         />

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -9,7 +9,6 @@ import { isDataSourceProgramWithoutRegistration } from '@modules/data-source'
 import { isDimensionInLayout, resolveProgramIds } from '@modules/layout'
 import { isVisualizationEmpty } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
-import type { EventOutputTypeVariant } from '@store/thunks'
 import {
     getVisUiConfigLayout,
     getVisUiConfigLayoutAllDimensionIds,
@@ -20,6 +19,10 @@ import {
 import type { OutputType, Program } from '@types'
 import { useMemo } from 'react'
 import type { ButtonAction } from './base-button'
+
+/* The two table kinds that share the EVENT output type: a plain event table
+ * and a custom value table. Used to label the EVENT/custom-value buttons. */
+export type EventOutputTypeVariant = 'EVENT' | 'CUSTOM_VALUE'
 
 type TooltipConfig = { content: string; openDelay?: number } | undefined
 

--- a/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
+++ b/src/components/layout-panel/bottom-bar/action-buttons/use-action-button.ts
@@ -9,15 +9,14 @@ import { isDataSourceProgramWithoutRegistration } from '@modules/data-source'
 import { isDimensionInLayout, resolveProgramIds } from '@modules/layout'
 import { isVisualizationEmpty } from '@modules/visualization'
 import { getCurrentVis } from '@store/current-vis-slice'
+import type { EventOutputTypeVariant } from '@store/thunks'
 import {
-    getVisUiConfigLastActiveButton,
     getVisUiConfigLayout,
     getVisUiConfigLayoutAllDimensionIds,
     getVisUiConfigLayoutIsEmpty,
     getVisUiConfigOutputType,
     getVisUiConfigVisualizationType,
 } from '@store/vis-ui-config-slice'
-import type { LastActiveButton } from '@store/vis-ui-config-slice'
 import type { OutputType, Program } from '@types'
 import { useMemo } from 'react'
 import type { ButtonAction } from './base-button'
@@ -189,12 +188,11 @@ const getTrackedEntityInstanceTooltipContent = ({
 
 export const useActionButton = (
     buttonType: OutputType,
-    buttonVariant?: LastActiveButton
+    buttonVariant?: EventOutputTypeVariant
 ) => {
     const currentVis = useAppSelector(getCurrentVis)
     const tetId = useTetId()
     const programStageIds = useProgramStageIds()
-    const lastActiveButton = useAppSelector(getVisUiConfigLastActiveButton)
     const layout = useAppSelector(getVisUiConfigLayout)
     const layoutDimensionIds = useAppSelector(
         getVisUiConfigLayoutAllDimensionIds
@@ -232,20 +230,17 @@ export const useActionButton = (
                 buttonType === 'EVENT' &&
                 buttonVariant !== undefined
             ) {
-                return lastActiveButton === buttonVariant ? 'update' : 'switch'
+                const hasCustomValue = Boolean(currentVis.value?.id)
+                const activeVariant: EventOutputTypeVariant = hasCustomValue
+                    ? 'CUSTOM_VALUE'
+                    : 'EVENT'
+                return activeVariant === buttonVariant ? 'update' : 'switch'
             }
             return 'update'
         } else {
             return 'switch'
         }
-    }, [
-        buttonType,
-        buttonVariant,
-        currentVis,
-        lastActiveButton,
-        outputType,
-        visualizationType,
-    ])
+    }, [buttonType, buttonVariant, currentVis, outputType, visualizationType])
 
     const hasCategoryInLayout: boolean = useMemo(
         () =>

--- a/src/components/layout-panel/custom-value-modal/__tests__/custom-value-modal.spec.tsx
+++ b/src/components/layout-panel/custom-value-modal/__tests__/custom-value-modal.spec.tsx
@@ -1,8 +1,7 @@
+import { getCurrentVis } from '@store/current-vis-slice'
 import {
-    visUiConfigSlice,
     initialState as visUiConfigInitialState,
     getVisUiConfigCustomValue,
-    getVisUiConfigLastActiveButton,
 } from '@store/vis-ui-config-slice'
 import { renderWithAppWrapper, type MockOptions } from '@test-utils/app-wrapper'
 import { createDeferredQuery } from '@test-utils/deferred-query'
@@ -91,7 +90,6 @@ const buildMockOptions = (
     metadata,
     queryData: queryDataOverride,
     partialStore: {
-        reducer: { visUiConfig: visUiConfigSlice.reducer },
         preloadedState: deepmerge(initialPreloadedState, {
             visUiConfig: {
                 layout: {
@@ -215,7 +213,7 @@ describe('CustomValueModal', () => {
         })
     })
 
-    it('keeps the Update button disabled until a data element is picked, then dispatches and closes on click', async () => {
+    it('keeps the Update button disabled until a data element is picked, then applies and closes on click', async () => {
         const onClose = vi.fn()
         const user = userEvent.setup()
         const { store } = await renderWithAppWrapper(
@@ -240,8 +238,34 @@ describe('CustomValueModal', () => {
             aggregationType: 'SUM',
             id: 's1.de1',
         })
-        expect(getVisUiConfigLastActiveButton(store.getState())).toBe(
-            'CUSTOM_VALUE'
+        expect(getCurrentVis(store.getState()).value).toEqual({ id: 's1.de1' })
+    })
+
+    it('filters the data element list by the search term', async () => {
+        const user = userEvent.setup()
+        await renderWithAppWrapper(
+            <CustomValueModal onClose={() => {}} />,
+            buildMockOptions(['s1.de1'])
         )
+
+        await waitFor(() => {
+            expect(screen.getByText('Weight in kg')).toBeInTheDocument()
+            expect(screen.getByText('Height in cm')).toBeInTheDocument()
+        })
+
+        await user.type(
+            screen.getByPlaceholderText('Search data items'),
+            'height'
+        )
+
+        expect(screen.queryByText('Weight in kg')).not.toBeInTheDocument()
+        expect(screen.getByText('Height in cm')).toBeInTheDocument()
+
+        await user.clear(screen.getByPlaceholderText('Search data items'))
+        await user.type(screen.getByPlaceholderText('Search data items'), 'zzz')
+
+        expect(
+            screen.getByText('No data elements match "zzz"')
+        ).toBeInTheDocument()
     })
 })

--- a/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
+++ b/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
@@ -7,6 +7,7 @@ import {
     Button,
     ButtonStrip,
     CircularLoader,
+    InputField,
     Modal,
     ModalActions,
     ModalContent,
@@ -21,13 +22,14 @@ import {
     useMetadataItem,
     useMetadataStore,
 } from '@hooks'
+import { tUpdateCurrentVisFromVisUiConfig } from '@store/thunks'
 import {
     getVisUiConfigCustomValue,
     setVisUiConfigCustomValue,
-    setVisUiConfigLastActiveButton,
+    setVisUiConfigOutputType,
 } from '@store/vis-ui-config-slice'
 import type { AggregationType } from '@types'
-import { type FC, useCallback, useState } from 'react'
+import { type FC, useCallback, useMemo, useState } from 'react'
 import { CustomValueOption } from './custom-value-option'
 import { StageNotice } from './stage-notice'
 import classes from './styles/custom-value-modal.module.css'
@@ -52,6 +54,7 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
     const [dataElement, setDataElement] = useState<
         CustomValueDataElement | undefined
     >(undefined)
+    const [searchTerm, setSearchTerm] = useState('')
 
     const {
         dataElements,
@@ -61,6 +64,16 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
         filteredByStageName,
         customValueStageMismatch,
     } = useCustomValueDataElements()
+
+    const visibleDataElements = useMemo(() => {
+        const term = searchTerm.trim().toLocaleLowerCase()
+        if (!term) {
+            return dataElements
+        }
+        return dataElements?.filter((dataElement) =>
+            dataElement.name.toLocaleLowerCase().includes(term)
+        )
+    }, [dataElements, searchTerm])
 
     const onAggregationTypeChange = useCallback(
         ({ selected }) => setAggregationType(selected),
@@ -78,7 +91,6 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
 
     const onUpdate = useCallback(() => {
         if (dataElement) {
-            dispatch(setVisUiConfigLastActiveButton('CUSTOM_VALUE'))
             dispatch(
                 setVisUiConfigCustomValue({
                     aggregationType:
@@ -88,6 +100,8 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
                     id: dataElement.id,
                 })
             )
+            dispatch(setVisUiConfigOutputType('EVENT'))
+            dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
         }
 
         onClose()
@@ -107,6 +121,19 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
                     customValueStageMismatch={customValueStageMismatch}
                     customValueDataElementName={customValueMetadata?.name}
                 />
+                {!isLoading && !isError && dataElements?.length !== 0 && (
+                    <div className={classes.search}>
+                        <InputField
+                            value={searchTerm}
+                            onChange={({ value }) => setSearchTerm(value ?? '')}
+                            placeholder={i18n.t('Search data items')}
+                            dataTest="custom-value-modal-search-field"
+                            dense
+                            initialFocus
+                            type="search"
+                        />
+                    </div>
+                )}
                 <div className={classes.listContainer}>
                     {isLoading && (
                         <div className={classes.listLoading}>
@@ -149,7 +176,18 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
                     )}
                     {!isLoading &&
                         !isError &&
-                        dataElements?.map((dataElement) => (
+                        dataElements?.length !== 0 &&
+                        visibleDataElements?.length === 0 && (
+                            <div className={classes.noMatches}>
+                                {i18n.t(
+                                    'No data elements match "{{- searchTerm}}"',
+                                    { searchTerm }
+                                )}
+                            </div>
+                        )}
+                    {!isLoading &&
+                        !isError &&
+                        visibleDataElements?.map((dataElement) => (
                             <CustomValueOption
                                 key={dataElement.id}
                                 label={dataElement.name}

--- a/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
+++ b/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
@@ -101,7 +101,7 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
                 })
             )
             dispatch(setVisUiConfigOutputType('EVENT'))
-            dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
+            dispatch(tUpdateCurrentVisFromVisUiConfig(true))
         }
 
         onClose()

--- a/src/components/layout-panel/custom-value-modal/styles/custom-value-modal.module.css
+++ b/src/components/layout-panel/custom-value-modal/styles/custom-value-modal.module.css
@@ -10,6 +10,10 @@
     font-size: 14px;
 }
 
+.search {
+    margin-block-end: var(--spacers-dp8);
+}
+
 .listContainer {
     flex: 1;
     overflow-y: auto;
@@ -28,6 +32,19 @@
     min-block-size: 200px;
     color: var(--colors-grey700);
     font-size: 14px;
+}
+
+.noMatches {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    block-size: 100%;
+    min-block-size: 200px;
+    padding: var(--spacers-dp16);
+    color: var(--colors-grey600);
+    font-size: 14px;
+    font-style: italic;
+    text-align: center;
 }
 
 .aggregationSelect {

--- a/src/components/layout-panel/custom-value-modal/styles/custom-value-option.module.css
+++ b/src/components/layout-panel/custom-value-modal/styles/custom-value-option.module.css
@@ -14,6 +14,15 @@
     font-family: inherit;
 }
 
+.option:focus {
+    outline: 3px solid var(--theme-focus);
+    outline-offset: -3px;
+}
+
+.option:focus:not(:focus-visible) {
+    outline: none;
+}
+
 .option:hover {
     background-color: var(--colors-grey200);
 }

--- a/src/components/plugin-wrapper/plugin-wrapper.tsx
+++ b/src/components/plugin-wrapper/plugin-wrapper.tsx
@@ -26,10 +26,14 @@ const getCurrentVisLayoutKey = createSelector(
     (state: RootState) => state.currentVis.columns,
     (state: RootState) => state.currentVis.rows,
     (state: RootState) => state.currentVis.filters,
+    (state: RootState) => state.currentVis.value?.id,
+    (state: RootState) => state.currentVis.aggregationType,
     // eslint-disable-next-line max-params
-    (outputType, columns, rows, filters) =>
+    (outputType, columns, rows, filters, valueId, aggregationType) =>
         [
             outputType ?? '',
+            valueId ?? '',
+            aggregationType ?? '',
             ...[...(columns ?? []), ...(rows ?? []), ...(filters ?? [])].map(
                 (d) => d.dimension
             ),

--- a/src/modules/__tests__/visualization.spec.ts
+++ b/src/modules/__tests__/visualization.spec.ts
@@ -207,7 +207,6 @@ const testCases = {
                 filters: [],
             },
             outputType: 'EVENT',
-            lastActiveButton: 'EVENT',
         },
     },
     lineListTrackedEntity: {

--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -2,7 +2,6 @@ import { getRequestOptions } from '@components/plugin-wrapper/hooks/query-tools-
 import { DEFAULT_OPTIONS } from '@constants/options'
 import { layoutGetAllDimensions } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
-import type { LastActiveButton } from '@store/vis-ui-config-slice'
 import type {
     ApiSavedVisualization,
     DimensionArray,
@@ -510,10 +509,6 @@ export const getVisualizationUiConfig = (
     const tetId = vis.trackedEntityType?.id
     const toDimId = (dim: DimensionArray[number]) =>
         getCompoundDimensionId(dim, outputType, tetId)
-    let lastActiveButton: LastActiveButton | undefined
-    if (outputType === 'EVENT') {
-        lastActiveButton = vis.value?.id ? 'CUSTOM_VALUE' : 'EVENT'
-    }
 
     return {
         visualizationType: vis.type,
@@ -545,7 +540,6 @@ export const getVisualizationUiConfig = (
                 aggregationType: vis.aggregationType || 'DEFAULT',
             },
         }),
-        lastActiveButton,
     }
 }
 

--- a/src/store/__tests__/thunks.spec.tsx
+++ b/src/store/__tests__/thunks.spec.tsx
@@ -1,0 +1,107 @@
+import { getCurrentVis } from '@store/current-vis-slice'
+import { tUpdateCurrentVisFromVisUiConfig } from '@store/thunks'
+import { initialState as visUiConfigInitialState } from '@store/vis-ui-config-slice'
+import {
+    renderHookWithAppWrapper,
+    type MockOptions,
+} from '@test-utils/app-wrapper'
+import type { CurrentVisualization, RootState } from '@types'
+import deepmerge from 'deepmerge'
+import { describe, it, expect } from 'vitest'
+
+const stage1 = {
+    id: 's1',
+    name: 'Stage 1',
+    repeatable: false,
+    hideDueDate: false,
+    program: { id: 'p1' },
+}
+const metadata = {
+    p1: {
+        id: 'p1',
+        name: 'Program 1',
+        programType: 'WITH_REGISTRATION',
+        programStages: [stage1],
+    },
+    s1: stage1,
+    's1.de1': {
+        id: 's1.de1',
+        name: 'DE 1',
+        dimensionType: 'DATA_ELEMENT',
+        valueType: 'NUMBER',
+    },
+}
+
+const customValue = { id: 's1.de1', aggregationType: 'AVERAGE' as const }
+
+const buildMockOptions = (
+    currentVisOverride: Partial<CurrentVisualization>
+): MockOptions => ({
+    metadata,
+    partialStore: {
+        preloadedState: deepmerge(
+            {
+                visUiConfig: deepmerge(visUiConfigInitialState, {
+                    outputType: 'EVENT',
+                    visualizationType: 'PIVOT_TABLE',
+                    layout: { columns: ['s1.de1'] },
+                    customValue,
+                }),
+            } as Partial<RootState>,
+            { currentVis: currentVisOverride } as Partial<RootState>
+        ),
+    },
+})
+
+const customValueVis: Partial<CurrentVisualization> = {
+    type: 'PIVOT_TABLE',
+    outputType: 'EVENT',
+    columns: [{ dimension: 's1.de1' }],
+    value: { id: 's1.de1' },
+    aggregationType: 'AVERAGE',
+}
+
+const eventVis: Partial<CurrentVisualization> = {
+    type: 'PIVOT_TABLE',
+    outputType: 'EVENT',
+    columns: [{ dimension: 's1.de1' }],
+}
+
+describe('tUpdateCurrentVisFromVisUiConfig', () => {
+    it('clears the value when rebuilding in EVENT mode, keeping customValue remembered', async () => {
+        const { store } = await renderHookWithAppWrapper(
+            () => null,
+            buildMockOptions(customValueVis)
+        )
+
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig('EVENT'))
+
+        expect(getCurrentVis(store.getState()).value).toBeUndefined()
+        // The remembered selection survives the switch to the event table
+        expect(store.getState().visUiConfig.customValue).toEqual(customValue)
+    })
+
+    it('restores the value from the remembered customValue when rebuilding in CUSTOM_VALUE mode', async () => {
+        const { store } = await renderHookWithAppWrapper(
+            () => null,
+            buildMockOptions(eventVis)
+        )
+
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
+
+        const currentVis = getCurrentVis(store.getState())
+        expect(currentVis.value).toEqual({ id: 's1.de1' })
+        expect(currentVis.aggregationType).toBe('AVERAGE')
+    })
+
+    it('preserves the current mode when no variant is passed', async () => {
+        const { store } = await renderHookWithAppWrapper(
+            () => null,
+            buildMockOptions(customValueVis)
+        )
+
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig())
+
+        expect(getCurrentVis(store.getState()).value).toEqual({ id: 's1.de1' })
+    })
+})

--- a/src/store/__tests__/thunks.spec.tsx
+++ b/src/store/__tests__/thunks.spec.tsx
@@ -35,14 +35,15 @@ const metadata = {
 const customValue = { id: 's1.de1', aggregationType: 'AVERAGE' as const }
 
 const buildMockOptions = (
-    currentVisOverride: Partial<CurrentVisualization>
+    currentVisOverride: Partial<CurrentVisualization>,
+    outputType = 'EVENT'
 ): MockOptions => ({
     metadata,
     partialStore: {
         preloadedState: deepmerge(
             {
                 visUiConfig: deepmerge(visUiConfigInitialState, {
-                    outputType: 'EVENT',
+                    outputType,
                     visualizationType: 'PIVOT_TABLE',
                     layout: { columns: ['s1.de1'] },
                     customValue,
@@ -74,7 +75,7 @@ describe('tUpdateCurrentVisFromVisUiConfig', () => {
             buildMockOptions(customValueVis)
         )
 
-        store.dispatch(tUpdateCurrentVisFromVisUiConfig('EVENT'))
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig(false))
 
         expect(getCurrentVis(store.getState()).value).toBeUndefined()
         // The remembered selection survives the switch to the event table
@@ -87,14 +88,14 @@ describe('tUpdateCurrentVisFromVisUiConfig', () => {
             buildMockOptions(eventVis)
         )
 
-        store.dispatch(tUpdateCurrentVisFromVisUiConfig('CUSTOM_VALUE'))
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig(true))
 
         const currentVis = getCurrentVis(store.getState())
         expect(currentVis.value).toEqual({ id: 's1.de1' })
         expect(currentVis.aggregationType).toBe('AVERAGE')
     })
 
-    it('preserves the current mode when no variant is passed', async () => {
+    it('preserves the current mode when withCustomValue is not passed', async () => {
         const { store } = await renderHookWithAppWrapper(
             () => null,
             buildMockOptions(customValueVis)
@@ -103,5 +104,19 @@ describe('tUpdateCurrentVisFromVisUiConfig', () => {
         store.dispatch(tUpdateCurrentVisFromVisUiConfig())
 
         expect(getCurrentVis(store.getState()).value).toEqual({ id: 's1.de1' })
+    })
+
+    it('drops the value for a non-EVENT output type even when withCustomValue is true', async () => {
+        const { store } = await renderHookWithAppWrapper(
+            () => null,
+            buildMockOptions(customValueVis, 'ENROLLMENT')
+        )
+
+        // Even explicitly asking for a custom value must not add one when
+        // the output type is not EVENT.
+        store.dispatch(tUpdateCurrentVisFromVisUiConfig(true))
+
+        expect(getCurrentVis(store.getState()).value).toBeUndefined()
+        expect(store.getState().visUiConfig.customValue).toEqual(customValue)
     })
 })

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -40,6 +40,8 @@ type AppThunk = () => (
     extra: ThunkExtraArg
 ) => void
 
+export type EventOutputTypeVariant = 'EVENT' | 'CUSTOM_VALUE'
+
 export const tClearVisualization: AppThunk = () => (dispatch) => {
     dispatch(clearUi())
     dispatch(clearSavedVis())
@@ -104,15 +106,32 @@ export const tLoadSavedVisualization = createAsyncThunk<
     }
 )
 
-export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
-    () => (dispatch, getState, extra) => {
+export const tUpdateCurrentVisFromVisUiConfig =
+    (variant?: EventOutputTypeVariant) =>
+    (
+        dispatch: AppDispatch,
+        getState: () => RootState,
+        extra: ThunkExtraArg
+    ) => {
         const state = getState()
         const { currentVis, visUiConfig } = state
         const { metadataStore } = extra
         const { customValue } = visUiConfig
 
+        const resolvedVariant: EventOutputTypeVariant =
+            variant ?? (currentVis.value?.id ? 'CUSTOM_VALUE' : 'EVENT')
+        const customValueFields =
+            resolvedVariant === 'CUSTOM_VALUE' && customValue
+                ? {
+                      value: { id: customValue.id },
+                      aggregationType: customValue.aggregationType,
+                  }
+                : { value: undefined }
+
         // Build fresh from visUiConfig so stale currentVis fields can't leak
         // through. Carry over only id and sorting from the previous currentVis.
+        // The custom value fields go after the options spread so the value's
+        // own aggregation type wins over the options default.
         const updatedCurrentVis: CurrentVisualization = {
             id: isCurrentVisualizationPersisted(currentVis)
                 ? currentVis.id
@@ -142,12 +161,9 @@ export const tUpdateCurrentVisFromVisUiConfig: AppThunk =
                 visUiConfig,
                 metadataStore
             ),
-            value: customValue ? { id: customValue.id } : undefined,
-            aggregationType:
-                customValue?.aggregationType ??
-                visUiConfig.options.aggregationType,
             ...getEnabledOptions(visUiConfig.options),
             ...resolveTeiFields(visUiConfig, metadataStore),
+            ...customValueFields,
         }
 
         dispatch(setCurrentVis(updatedCurrentVis))

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -40,8 +40,6 @@ type AppThunk = () => (
     extra: ThunkExtraArg
 ) => void
 
-export type EventOutputTypeVariant = 'EVENT' | 'CUSTOM_VALUE'
-
 export const tClearVisualization: AppThunk = () => (dispatch) => {
     dispatch(clearUi())
     dispatch(clearSavedVis())
@@ -106,8 +104,48 @@ export const tLoadSavedVisualization = createAsyncThunk<
     }
 )
 
+const shouldShowCustomValue = (
+    state: RootState,
+    withCustomValue?: boolean
+): boolean => {
+    // Only EVENT output can carry a custom value
+    if (state.visUiConfig.outputType !== 'EVENT') {
+        return false
+    }
+    if (withCustomValue !== undefined) {
+        return withCustomValue // explicit request: add or strip
+    }
+    return Boolean(state.currentVis.value?.id) // preserve what the current vis shows
+}
+
+const resolveCustomValueFields = (
+    state: RootState,
+    withCustomValue?: boolean
+) => {
+    // Always include the `value` key: setCurrentVis merges into the previous
+    // currentVis, so omitting it would leave a stale value behind.
+    if (!shouldShowCustomValue(state, withCustomValue)) {
+        return { value: undefined }
+    }
+
+    const { customValue } = state.visUiConfig
+
+    if (!customValue) {
+        throw new Error(
+            'shouldShowCustomValue is true but visUiConfig.customValue is missing'
+        )
+    }
+    return {
+        value: { id: customValue.id },
+        aggregationType: customValue.aggregationType,
+    }
+}
+
+/* `withCustomValue` overrides whether the rebuilt vis carries the custom
+ * value: true forces it on, false strips it; omit it to preserve the
+ * current vis. */
 export const tUpdateCurrentVisFromVisUiConfig =
-    (variant?: EventOutputTypeVariant) =>
+    (withCustomValue?: boolean) =>
     (
         dispatch: AppDispatch,
         getState: () => RootState,
@@ -116,17 +154,6 @@ export const tUpdateCurrentVisFromVisUiConfig =
         const state = getState()
         const { currentVis, visUiConfig } = state
         const { metadataStore } = extra
-        const { customValue } = visUiConfig
-
-        const resolvedVariant: EventOutputTypeVariant =
-            variant ?? (currentVis.value?.id ? 'CUSTOM_VALUE' : 'EVENT')
-        const customValueFields =
-            resolvedVariant === 'CUSTOM_VALUE' && customValue
-                ? {
-                      value: { id: customValue.id },
-                      aggregationType: customValue.aggregationType,
-                  }
-                : { value: undefined }
 
         // Build fresh from visUiConfig so stale currentVis fields can't leak
         // through. Carry over only id and sorting from the previous currentVis.
@@ -163,7 +190,7 @@ export const tUpdateCurrentVisFromVisUiConfig =
             ),
             ...getEnabledOptions(visUiConfig.options),
             ...resolveTeiFields(visUiConfig, metadataStore),
-            ...customValueFields,
+            ...resolveCustomValueFields(state, withCustomValue),
         }
 
         dispatch(setCurrentVis(updatedCurrentVis))

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -104,7 +104,7 @@ export const tLoadSavedVisualization = createAsyncThunk<
     }
 )
 
-const shouldShowCustomValue = (
+const shouldPopulateCustomValueFields = (
     state: RootState,
     withCustomValue?: boolean
 ): boolean => {
@@ -124,7 +124,7 @@ const resolveCustomValueFields = (
 ) => {
     // Always include the `value` key: setCurrentVis merges into the previous
     // currentVis, so omitting it would leave a stale value behind.
-    if (!shouldShowCustomValue(state, withCustomValue)) {
+    if (!shouldPopulateCustomValueFields(state, withCustomValue)) {
         return { value: undefined }
     }
 
@@ -132,7 +132,7 @@ const resolveCustomValueFields = (
 
     if (!customValue) {
         throw new Error(
-            'shouldShowCustomValue is true but visUiConfig.customValue is missing'
+            'shouldPopulateCustomValueFields is true but visUiConfig.customValue is missing'
         )
     }
     return {

--- a/src/store/thunks.ts
+++ b/src/store/thunks.ts
@@ -125,7 +125,7 @@ const resolveCustomValueFields = (
     // Always include the `value` key: setCurrentVis merges into the previous
     // currentVis, so omitting it would leave a stale value behind.
     if (!shouldPopulateCustomValueFields(state, withCustomValue)) {
-        return { value: undefined }
+        return { value: undefined, aggregationType: undefined }
     }
 
     const { customValue } = state.visUiConfig

--- a/src/store/vis-ui-config-slice.ts
+++ b/src/store/vis-ui-config-slice.ts
@@ -25,8 +25,6 @@ export type CustomValueObject = {
     aggregationType: AggregationType
 }
 
-export type LastActiveButton = 'EVENT' | 'CUSTOM_VALUE'
-
 export type RepetitionsObject = {
     mostRecent: number
     oldest: number
@@ -49,7 +47,6 @@ export interface VisUiConfigState {
     itemsByDimension: Record<string, string[]>
     conditionsByDimension: Record<string, ConditionsObject | undefined>
     customValue?: CustomValueObject
-    lastActiveButton?: LastActiveButton
     repetitionsByDimension: Record<string, RepetitionsObject | undefined>
     options: EventVisualizationOptions
 }
@@ -193,12 +190,6 @@ export const visUiConfigSlice = createSlice({
             action: PayloadAction<CustomValueObject>
         ) => {
             state.customValue = action.payload
-        },
-        setVisUiConfigLastActiveButton: (
-            state,
-            action: PayloadAction<LastActiveButton>
-        ) => {
-            state.lastActiveButton = action.payload
         },
         setVisUiConfigRepetitionsByDimension: (
             state,
@@ -361,7 +352,6 @@ export const visUiConfigSlice = createSlice({
         getVisUiConfigConditionsByDimension: (state, dimensionId: string) =>
             state.conditionsByDimension[dimensionId] || EMPTY_CONDITIONS_OBJECT,
         getVisUiConfigCustomValue: (state) => state.customValue,
-        getVisUiConfigLastActiveButton: (state) => state.lastActiveButton,
         getVisUiConfigRepetitionsByDimension: (state, dimensionId: string) =>
             state.repetitionsByDimension[dimensionId] ||
             DEFAULT_REPETITIONS_OBJECT,
@@ -393,7 +383,6 @@ export const {
     setVisUiConfigItemsByDimension,
     setVisUiConfigConditionsByDimension,
     setVisUiConfigCustomValue,
-    setVisUiConfigLastActiveButton,
     setVisUiConfigRepetitionsByDimension,
     addVisUiConfigLayoutDimension,
     addVisUiConfigLayoutDimensions,
@@ -410,7 +399,6 @@ export const {
     getVisUiConfigItemsByDimension,
     getVisUiConfigConditionsByDimension,
     getVisUiConfigCustomValue,
-    getVisUiConfigLastActiveButton,
     getVisUiConfigRepetitionsByDimension,
     getVisUiConfigLayoutAllDimensionIds,
     getVisUiConfigLayoutIsEmpty,


### PR DESCRIPTION
Implements various things:
- demo blocking issue "Switching from custom value table to event table"
- [DHIS2-21279](https://dhis2.atlassian.net/browse/DHIS2-21279)
- Some addition improvements

### Description

- Switching between custom value and event list now works:
    - The custom value `value` field is now cleared from the current vis when switching to a different `outputType`, or from custom-value-list to event-list (technically the same `outputType`). The remembered custom value selection is kept in `visUiConfig`, so switching back reuses it without reopening the modal.
    - The custom values fields are now taken into account when computing the `currentVisLayoutKey`. This causes the event-list and custom-value-list to have a different key
- The above gave us a way to determine the last active button from the `currentVis` so we were able to remove the `lastActiveButton` state completely ([DHIS2-21279](https://dhis2.atlassian.net/browse/DHIS2-21279))
- [BONUS] Added a search field above the data-elements-list in the custom-value-modal
- [BONUS] Fixed focus styles on the the data-elements-list-items in the custom-value-modal
- [BONUS] Clicking Update" in the custom value modal now both updates the custom value config AND it updates the pivot-table

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---

### ToDos

<!--Checkmate-->

- [x] Get approval on bonus-features (approved by @cooper-joe on Slack)

---

### Screenshots

<img width="823" height="550" alt="Screenshot 2026-06-10 at 10 54 42" src="https://github.com/user-attachments/assets/3f88aedb-a532-40c6-99f5-981496a8f49f" />


[DHIS2-21279]: https://dhis2.atlassian.net/browse/DHIS2-21279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-21279]: https://dhis2.atlassian.net/browse/DHIS2-21279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ