### PR TITLE
fix: implement improvements to the layout panel (DHIS2-21587)

### DIFF
--- a/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
+++ b/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
@@ -1,0 +1,185 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useResizeHandle } from '../use-resize-handle'
+
+type FakeTarget = {
+    setPointerCapture: ReturnType<typeof vi.fn>
+    releasePointerCapture: ReturnType<typeof vi.fn>
+    hasPointerCapture: () => boolean
+}
+
+const createTarget = (hasCapture = true): FakeTarget => ({
+    setPointerCapture: vi.fn(),
+    releasePointerCapture: vi.fn(),
+    hasPointerCapture: () => hasCapture,
+})
+
+const createPointerEvent = (clientY: number, target: FakeTarget) =>
+    ({
+        clientX: 0,
+        clientY,
+        pointerId: 1,
+        currentTarget: target,
+        preventDefault: vi.fn(),
+    }) as unknown as React.PointerEvent
+
+const createNode = (scrollHeight: number) =>
+    ({
+        getBoundingClientRect: () => ({ top: 0, left: 0 }),
+        scrollHeight,
+        scrollWidth: 0,
+    }) as unknown as HTMLDivElement
+
+const STORAGE_KEY = 'test.axesHeight'
+
+const renderResizeHandle = (
+    overrides: { min?: number; max?: number; collapseThreshold?: number } = {}
+) =>
+    renderHook(() =>
+        useResizeHandle({
+            orientation: 'horizontal',
+            storageKey: STORAGE_KEY,
+            min: overrides.min ?? 56,
+            collapseThreshold: overrides.collapseThreshold ?? 24,
+            max: overrides.max ?? 300,
+        })
+    )
+
+afterEach(() => {
+    localStorage.clear()
+})
+
+describe('useResizeHandle', () => {
+    it('lifts a stored size that is below the min up to the min', () => {
+        localStorage.setItem(STORAGE_KEY, '30')
+
+        const { result } = renderResizeHandle({ min: 116 })
+
+        act(() => {
+            result.current.containerRef(createNode(200))
+        })
+
+        expect(result.current.size).toBe(116)
+    })
+
+    it('caps the initial size at the container content height', () => {
+        const { result } = renderResizeHandle({ min: 56, max: 300 })
+
+        act(() => {
+            result.current.containerRef(createNode(120))
+        })
+
+        expect(result.current.size).toBe(120)
+    })
+
+    it('does not collapse when dragging downwards from the min', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 56, max: 300 })
+
+        act(() => {
+            result.current.containerRef(createNode(56))
+        })
+
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(56, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(86, target)
+            )
+        })
+
+        expect(result.current.minReached).toBe(false)
+    })
+
+    it('grows when dragging downwards within the available space', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 56, max: 300 })
+
+        act(() => {
+            result.current.containerRef(createNode(200))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(100, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(60, target)
+            )
+        })
+
+        expect(result.current.minReached).toBe(false)
+        expect(result.current.size).toBe(160)
+    })
+
+    it('shrinks below the min without collapsing while above the collapse threshold', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({
+            min: 116,
+            collapseThreshold: 24,
+            max: 300,
+        })
+
+        act(() => {
+            result.current.containerRef(createNode(116))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(116, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(80, target)
+            )
+        })
+
+        expect(result.current.minReached).toBe(false)
+        expect(result.current.size).toBe(80)
+    })
+
+    it('collapses only when dragging past the collapse threshold', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({
+            min: 116,
+            collapseThreshold: 24,
+            max: 300,
+        })
+
+        act(() => {
+            result.current.containerRef(createNode(116))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(116, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(10, target)
+            )
+        })
+
+        expect(result.current.minReached).toBe(true)
+    })
+
+    it('persists the size to local storage on pointer up', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 56, max: 300 })
+
+        act(() => {
+            result.current.containerRef(createNode(200))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerUp(
+                createPointerEvent(200, target)
+            )
+        })
+
+        expect(localStorage.getItem(STORAGE_KEY)).toBe('200')
+    })
+})

--- a/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
+++ b/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
@@ -23,26 +23,36 @@ const createPointerEvent = (clientY: number, target: FakeTarget) =>
         preventDefault: vi.fn(),
     }) as unknown as React.PointerEvent
 
-const createNode = (scrollHeight: number) =>
+const createNode = (scrollHeight: number, clientHeight = scrollHeight) =>
     ({
         getBoundingClientRect: () => ({ top: 0, left: 0 }),
         scrollHeight,
         scrollWidth: 0,
+        clientHeight,
+        clientWidth: 0,
     }) as unknown as HTMLDivElement
 
 const STORAGE_KEY = 'test.axesHeight'
 
 const renderResizeHandle = (
-    overrides: { min?: number; max?: number; collapseThreshold?: number } = {}
+    overrides: {
+        min?: number
+        max?: number
+        collapseThreshold?: number
+        contentKey?: string
+    } = {}
 ) =>
-    renderHook(() =>
-        useResizeHandle({
-            orientation: 'horizontal',
-            storageKey: STORAGE_KEY,
-            min: overrides.min ?? 56,
-            collapseThreshold: overrides.collapseThreshold ?? 24,
-            max: overrides.max ?? 300,
-        })
+    renderHook(
+        (props: { contentKey: string }) =>
+            useResizeHandle({
+                orientation: 'horizontal',
+                storageKey: STORAGE_KEY,
+                min: overrides.min ?? 56,
+                collapseThreshold: overrides.collapseThreshold ?? 24,
+                contentKey: props.contentKey,
+                max: overrides.max ?? 300,
+            }),
+        { initialProps: { contentKey: overrides.contentKey ?? 'a' } }
     )
 
 afterEach(() => {
@@ -62,7 +72,7 @@ describe('useResizeHandle', () => {
         expect(result.current.size).toBe(116)
     })
 
-    it('caps the initial size at the container content height', () => {
+    it('sets the initial size to the content height', () => {
         const { result } = renderResizeHandle({ min: 56, max: 300 })
 
         act(() => {
@@ -94,10 +104,11 @@ describe('useResizeHandle', () => {
         expect(result.current.minReached).toBe(false)
     })
 
-    it('grows when dragging downwards within the available space', () => {
+    it('follows the cursor displacement while dragging', () => {
         const target = createTarget()
         const { result } = renderResizeHandle({ min: 56, max: 300 })
 
+        // Initial size is the content height (200).
         act(() => {
             result.current.containerRef(createNode(200))
         })
@@ -112,6 +123,7 @@ describe('useResizeHandle', () => {
             )
         })
 
+        // 200 - 40 (moved up 40px) = 160.
         expect(result.current.minReached).toBe(false)
         expect(result.current.size).toBe(160)
     })
@@ -124,6 +136,7 @@ describe('useResizeHandle', () => {
             max: 300,
         })
 
+        // Initial size is the content height (116).
         act(() => {
             result.current.containerRef(createNode(116))
         })
@@ -138,6 +151,7 @@ describe('useResizeHandle', () => {
             )
         })
 
+        // Dragged to 80, below the min (116) but above the collapse threshold.
         expect(result.current.minReached).toBe(false)
         expect(result.current.size).toBe(80)
     })
@@ -150,6 +164,7 @@ describe('useResizeHandle', () => {
             max: 300,
         })
 
+        // Initial size is the content height (116).
         act(() => {
             result.current.containerRef(createNode(116))
         })
@@ -167,10 +182,158 @@ describe('useResizeHandle', () => {
         expect(result.current.minReached).toBe(true)
     })
 
+    it('can be expanded past the content height it had at mount time', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 58, max: 300 })
+
+        // Mounts short (few chips).
+        const node = createNode(58)
+        act(() => {
+            result.current.containerRef(node)
+        })
+
+        // Chips are added: the live content grows, but containerRef is NOT
+        // called again (the bug was the cap staying stuck at the mount value).
+        ;(node as unknown as { scrollHeight: number }).scrollHeight = 220
+
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(58, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(400, target)
+            )
+        })
+
+        expect(result.current.size).toBe(220)
+    })
+
+    it('stops dragging at the live content height', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 58, max: 300 })
+
+        act(() => {
+            result.current.containerRef(createNode(120))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(120, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(400, target)
+            )
+        })
+
+        expect(result.current.size).toBe(120)
+    })
+
+    it('never drags taller than the max even with a large content', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({ min: 58, max: 160 })
+
+        act(() => {
+            result.current.containerRef(createNode(400))
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(100, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(400, target)
+            )
+        })
+
+        expect(result.current.size).toBe(160)
+    })
+
+    it('tracks from the rendered height when dragging after a double-click reset', () => {
+        const target = createTarget()
+        const { result } = renderResizeHandle({
+            min: 58,
+            collapseThreshold: 24,
+            max: 300,
+        })
+
+        // Content is taller than the min (e.g. chips wrapped to two rows).
+        act(() => {
+            result.current.containerRef(createNode(90))
+        })
+        // The double-click reset drops the explicit size; the panel renders at
+        // its content height (90), not the min.
+        act(() => {
+            result.current.resetSize()
+        })
+
+        // Grab at the bottom edge and move up 30px.
+        act(() => {
+            result.current.eventHandlers.onPointerDown(
+                createPointerEvent(90, target)
+            )
+        })
+        act(() => {
+            result.current.eventHandlers.onPointerMove(
+                createPointerEvent(60, target)
+            )
+        })
+
+        // Connected to the cursor from the rendered height (90 - 30 = 60),
+        // not jumping to the min (which would give 58 - 30 = 28).
+        expect(result.current.minReached).toBe(false)
+        expect(result.current.size).toBe(60)
+    })
+
+    it('re-fits to the new content when the layout changes', () => {
+        const { result, rerender } = renderResizeHandle({
+            min: 56,
+            max: 300,
+            contentKey: 'a',
+        })
+
+        const node = createNode(100)
+        act(() => {
+            result.current.containerRef(node)
+        })
+        expect(result.current.size).toBe(100)
+
+        // A chip is added: the live content grows to 200.
+        ;(node as unknown as { scrollHeight: number }).scrollHeight = 200
+        rerender({ contentKey: 'b' })
+
+        expect(result.current.size).toBe(200)
+    })
+
+    it('re-fits smaller when the layout shrinks', () => {
+        const { result, rerender } = renderResizeHandle({
+            min: 56,
+            max: 300,
+            contentKey: 'a',
+        })
+
+        const node = createNode(200)
+        act(() => {
+            result.current.containerRef(node)
+        })
+        expect(result.current.size).toBe(200)
+
+        // Chips are removed: the live content shrinks to 90. The re-fit measures
+        // the auto content, so the stale larger size does not skew it.
+        ;(node as unknown as { scrollHeight: number }).scrollHeight = 90
+        rerender({ contentKey: 'b' })
+
+        expect(result.current.size).toBe(90)
+    })
+
     it('persists the size to local storage on pointer up', () => {
         const target = createTarget()
         const { result } = renderResizeHandle({ min: 56, max: 300 })
 
+        // Initial size is the content height (200).
         act(() => {
             result.current.containerRef(createNode(200))
         })

--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -84,6 +84,14 @@ export const Axes: FC = () => {
         [visualizationType]
     )
 
+    /* Signature of the layout's chips per axis. Changes when a dimension is
+     * added, removed, or moved between axes — the cases that change the content
+     * height and so require the panel to re-fit. */
+    const contentKey = useMemo(
+        () => [columns.join(','), rows.join(','), filters.join(',')].join('|'),
+        [columns, rows, filters]
+    )
+
     const {
         containerRef,
         eventHandlers,
@@ -96,6 +104,7 @@ export const Axes: FC = () => {
         storageKey: AXES_HEIGHT_STORAGE_KEY,
         min: minHeight,
         collapseThreshold: AXES_COLLAPSE_THRESHOLD,
+        contentKey,
         max: maxHeight,
     })
 

--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -53,6 +53,15 @@ const LoadingSkeletons: FC = () => (
 
 const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
 
+/* Height that keeps a single axis row (label + min content area + padding)
+ * fully visible. LINE_LIST stacks one such row (columns/filters); PIVOT_TABLE
+ * stacks two (columns over rows), so its min is twice as tall. */
+const AXIS_ROW_MIN_HEIGHT = 58
+
+/* Height below which dragging collapses the panel. Lower than the visType min
+ * so the panel can be shrunk past its default height before collapsing. */
+const AXES_COLLAPSE_THRESHOLD = 24
+
 export const Axes: FC = () => {
     const dispatch = useAppDispatch()
     const dataSourceId = useAppSelector(getDataSourceId)
@@ -67,6 +76,14 @@ export const Axes: FC = () => {
         [height]
     )
 
+    const minHeight = useMemo(
+        () =>
+            visualizationType === 'LINE_LIST'
+                ? AXIS_ROW_MIN_HEIGHT
+                : AXIS_ROW_MIN_HEIGHT * 2,
+        [visualizationType]
+    )
+
     const {
         containerRef,
         eventHandlers,
@@ -77,7 +94,8 @@ export const Axes: FC = () => {
     } = useResizeHandle({
         orientation: 'horizontal',
         storageKey: AXES_HEIGHT_STORAGE_KEY,
-        min: 56,
+        min: minHeight,
+        collapseThreshold: AXES_COLLAPSE_THRESHOLD,
         max: maxHeight,
     })
 

--- a/src/components/layout-panel/axis/styles/axis.module.css
+++ b/src/components/layout-panel/axis/styles/axis.module.css
@@ -62,6 +62,10 @@
     flex-wrap: wrap;
     flex: 1;
     min-block-size: 32px;
+    /* One empty chip-row of drop space below the last chip. It lives inside the
+     * (scrollable) droppable content, so it stays reachable even when the panel
+     * is capped at its max height and scrolls. */
+    padding-block-end: 24px;
 }
 
 .emptyAxisInsertMarkerAnchor {

--- a/src/components/layout-panel/axis/styles/axis.module.css
+++ b/src/components/layout-panel/axis/styles/axis.module.css
@@ -60,6 +60,7 @@
     align-items: flex-start;
     align-content: flex-start;
     flex-wrap: wrap;
+    flex: 1;
     min-block-size: 32px;
 }
 

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -12,6 +12,7 @@
     grid-template-areas:
         'columns filters'
         'rows filters';
+    grid-template-rows: minmax(min-content, 1fr) minmax(min-content, 1fr);
     gap: 1px;
     border-color: var(--colors-grey300);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.03);
@@ -22,6 +23,7 @@
 
 .axisContainer.lineList {
     grid-template-areas: 'columns filters';
+    grid-template-rows: minmax(min-content, 1fr);
 }
 
 .expandButton {

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 type Orientation = 'horizontal' | 'vertical'
 
@@ -6,6 +6,7 @@ interface UseResizeHandleProps {
     max: number
     min: number
     collapseThreshold: number
+    contentKey: string
     orientation: Orientation
     storageKey: string
 }
@@ -14,16 +15,20 @@ export const useResizeHandle = ({
     max,
     min,
     collapseThreshold,
+    contentKey,
     orientation,
     storageKey,
 }: UseResizeHandleProps) => {
     const [size, setSize] = useState<number | null>(null)
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [minReached, setMinReached] = useState<boolean>(false)
-    const containerMaxSizeRef = useRef<number>(max)
+    const nodeRef = useRef<HTMLDivElement | null>(null)
+    const dragMaxRef = useRef<number>(max)
     const preDragSizeRef = useRef<number | null>(null)
     const dragStartPosRef = useRef<number | null>(null)
     const sizeRef = useRef<number | null>(size)
+    const contentKeyRef = useRef<string>(contentKey)
+    const refitPendingRef = useRef<boolean>(false)
     const storedSizeRef = useRef<number | null>(
         (() => {
             const storedSize = localStorage.getItem(storageKey)
@@ -39,15 +44,17 @@ export const useResizeHandle = ({
     // Computes the effective max size, based on the container, max and stored size
     const containerRef = useCallback(
         (node: HTMLDivElement | null) => {
+            nodeRef.current = node
+
             if (node !== null) {
                 const containerSize =
                     orientation === 'horizontal'
                         ? node.scrollHeight
                         : node.scrollWidth
 
+                /* Fit to the content (which carries its own trailing drop-row
+                 * buffer in CSS), capped at the max — then it scrolls. */
                 const containerMaxSize = Math.min(containerSize, max)
-
-                containerMaxSizeRef.current = containerMaxSize
 
                 /* The min always wins: a stored size (possibly saved under a
                  * different visType) must never shrink the panel below the
@@ -78,14 +85,69 @@ export const useResizeHandle = ({
         setMinReached(false)
     }, [])
 
+    /* Re-fit the panel to the content whenever the layout changes, so it tracks
+     * the chips (and the trailing drop-row buffer they carry in CSS) as they are
+     * added or removed. The size is first dropped to `null` (auto) so the live
+     * content can be measured without the current fixed height skewing it; the
+     * next effect applies the fitted size once the auto layout has committed. */
+    useLayoutEffect(() => {
+        if (contentKeyRef.current === contentKey) {
+            return
+        }
+
+        contentKeyRef.current = contentKey
+        refitPendingRef.current = true
+        setSize(null)
+    }, [contentKey])
+
+    useLayoutEffect(() => {
+        if (!refitPendingRef.current || size !== null) {
+            return
+        }
+
+        const node = nodeRef.current
+
+        if (node === null) {
+            return
+        }
+
+        refitPendingRef.current = false
+
+        const contentSize =
+            orientation === 'horizontal' ? node.scrollHeight : node.scrollWidth
+
+        setSize(Math.max(min, Math.min(contentSize, max)))
+    }, [size, min, max, orientation])
+
     // Start dragging
     const onPointerDown = useCallback(
         (event: React.PointerEvent) => {
             event.preventDefault()
 
-            preDragSizeRef.current = sizeRef.current
-            dragStartPosRef.current =
-                orientation === 'horizontal' ? event.clientY : event.clientX
+            const node = nodeRef.current
+            const horizontal = orientation === 'horizontal'
+
+            /* The drag ceiling is recomputed from the live content on every
+             * grab, so adding chips (which the cached size at mount can't see)
+             * lets the panel be dragged taller. The content carries its own
+             * trailing drop-row buffer in CSS. */
+            const contentSize = node
+                ? horizontal
+                    ? node.scrollHeight
+                    : node.scrollWidth
+                : max
+            dragMaxRef.current = Math.min(contentSize, max)
+
+            /* When the panel has no explicit size (after a double-click reset)
+             * fall back to its rendered size so the drag starts smoothly
+             * instead of jumping to the min. */
+            const renderedSize = node
+                ? horizontal
+                    ? node.clientHeight
+                    : node.clientWidth
+                : null
+            preDragSizeRef.current = sizeRef.current ?? renderedSize
+            dragStartPosRef.current = horizontal ? event.clientY : event.clientX
 
             // This is important since the ResizeHandle presence might be toggled by minReached.
             // When ResizeHandle is available again and this it's draggable, we must avoid that minReached
@@ -96,7 +158,7 @@ export const useResizeHandle = ({
 
             setIsDragging(true)
         },
-        [orientation]
+        [max, orientation]
     )
 
     // Move the drag handle
@@ -134,7 +196,7 @@ export const useResizeHandle = ({
                 setSize(
                     Math.max(
                         collapseThreshold,
-                        Math.min(newSize, containerMaxSizeRef.current)
+                        Math.min(newSize, dragMaxRef.current)
                     )
                 )
             }
@@ -175,6 +237,10 @@ export const useResizeHandle = ({
         }
 
         storedSizeRef.current = null
+
+        /* Re-fit to the content so a double-click reset matches the auto-fit
+         * height applied elsewhere. */
+        refitPendingRef.current = true
 
         resetSize()
     }, [resetSize, storageKey])

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -131,21 +131,19 @@ export const useResizeHandle = ({
              * grab, so adding chips (which the cached size at mount can't see)
              * lets the panel be dragged taller. The content carries its own
              * trailing drop-row buffer in CSS. */
-            const contentSize = node
-                ? horizontal
-                    ? node.scrollHeight
-                    : node.scrollWidth
-                : max
+            let contentSize = max
+            if (node) {
+                contentSize = horizontal ? node.scrollHeight : node.scrollWidth
+            }
             dragMaxRef.current = Math.min(contentSize, max)
 
             /* When the panel has no explicit size (after a double-click reset)
              * fall back to its rendered size so the drag starts smoothly
              * instead of jumping to the min. */
-            const renderedSize = node
-                ? horizontal
-                    ? node.clientHeight
-                    : node.clientWidth
-                : null
+            let renderedSize: number | null = null
+            if (node) {
+                renderedSize = horizontal ? node.clientHeight : node.clientWidth
+            }
             preDragSizeRef.current = sizeRef.current ?? renderedSize
             dragStartPosRef.current = horizontal ? event.clientY : event.clientX
 

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -5,6 +5,7 @@ type Orientation = 'horizontal' | 'vertical'
 interface UseResizeHandleProps {
     max: number
     min: number
+    collapseThreshold: number
     orientation: Orientation
     storageKey: string
 }
@@ -12,15 +13,16 @@ interface UseResizeHandleProps {
 export const useResizeHandle = ({
     max,
     min,
+    collapseThreshold,
     orientation,
     storageKey,
 }: UseResizeHandleProps) => {
     const [size, setSize] = useState<number | null>(null)
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [minReached, setMinReached] = useState<boolean>(false)
-    const containerEdgePosRef = useRef<number>(0)
     const containerMaxSizeRef = useRef<number>(max)
     const preDragSizeRef = useRef<number | null>(null)
+    const dragStartPosRef = useRef<number | null>(null)
     const sizeRef = useRef<number | null>(size)
     const storedSizeRef = useRef<number | null>(
         (() => {
@@ -38,12 +40,6 @@ export const useResizeHandle = ({
     const containerRef = useCallback(
         (node: HTMLDivElement | null) => {
             if (node !== null) {
-                // Store the container edge position to avoid calculating it on each pointer move
-                containerEdgePosRef.current =
-                    orientation === 'horizontal'
-                        ? node.getBoundingClientRect().top
-                        : node.getBoundingClientRect().left
-
                 const containerSize =
                     orientation === 'horizontal'
                         ? node.scrollHeight
@@ -53,8 +49,16 @@ export const useResizeHandle = ({
 
                 containerMaxSizeRef.current = containerMaxSize
 
+                /* The min always wins: a stored size (possibly saved under a
+                 * different visType) must never shrink the panel below the
+                 * height needed to show every axis of the current visType. */
                 if (storedSizeRef.current) {
-                    setSize(Math.min(storedSizeRef.current, containerMaxSize))
+                    setSize(
+                        Math.max(
+                            min,
+                            Math.min(storedSizeRef.current, containerMaxSize)
+                        )
+                    )
                 } else {
                     setSize(Math.max(containerMaxSize, min))
                 }
@@ -75,20 +79,25 @@ export const useResizeHandle = ({
     }, [])
 
     // Start dragging
-    const onPointerDown = useCallback((event: React.PointerEvent) => {
-        event.preventDefault()
+    const onPointerDown = useCallback(
+        (event: React.PointerEvent) => {
+            event.preventDefault()
 
-        preDragSizeRef.current = sizeRef.current
+            preDragSizeRef.current = sizeRef.current
+            dragStartPosRef.current =
+                orientation === 'horizontal' ? event.clientY : event.clientX
 
-        // This is important since the ResizeHandle presence might be toggled by minReached.
-        // When ResizeHandle is available again and this it's draggable, we must avoid that minReached
-        // triggers the logic in the consumer again whenever the hook updates.
-        setMinReached(false)
+            // This is important since the ResizeHandle presence might be toggled by minReached.
+            // When ResizeHandle is available again and this it's draggable, we must avoid that minReached
+            // triggers the logic in the consumer again whenever the hook updates.
+            setMinReached(false)
 
-        event.currentTarget.setPointerCapture(event.pointerId)
+            event.currentTarget.setPointerCapture(event.pointerId)
 
-        setIsDragging(true)
-    }, [])
+            setIsDragging(true)
+        },
+        [orientation]
+    )
 
     // Move the drag handle
     const onPointerMove = useCallback(
@@ -97,18 +106,26 @@ export const useResizeHandle = ({
                 return
             }
 
-            if (!containerEdgePosRef.current) {
-                return
-            }
-
             const size = sizeRef.current
 
-            const newSize =
-                (orientation === 'horizontal' ? event.clientY : event.clientX) -
-                containerEdgePosRef.current
+            /* Size is derived from the pointer's displacement since the grab,
+             * not its absolute position. This keeps the drag direction honest:
+             * dragging down can never produce a size smaller than the pre-drag
+             * size, so the min-reached collapse only fires on a genuine upward
+             * drag past the min. */
+            const pointerPos =
+                orientation === 'horizontal' ? event.clientY : event.clientX
+            const delta = pointerPos - (dragStartPosRef.current ?? pointerPos)
+            const newSize = (preDragSizeRef.current ?? size ?? min) + delta
 
-            // Trigger minReached only when shrinking the container
-            if (newSize < min && size && size >= min) {
+            /* The panel can be dragged below the visType min (cutting into the
+             * axes, which then scroll) all the way down to the collapse
+             * threshold; only crossing that threshold collapses it. */
+            if (
+                newSize < collapseThreshold &&
+                size &&
+                size >= collapseThreshold
+            ) {
                 setSize(preDragSizeRef.current)
 
                 setMinReached(true)
@@ -116,13 +133,13 @@ export const useResizeHandle = ({
             } else {
                 setSize(
                     Math.max(
-                        min,
+                        collapseThreshold,
                         Math.min(newSize, containerMaxSizeRef.current)
                     )
                 )
             }
         },
-        [min, orientation]
+        [collapseThreshold, min, orientation]
     )
 
     // Stop dragging


### PR DESCRIPTION
Implements [DHIS2-21587](https://dhis2.atlassian.net/browse/DHIS2-21587)

### Description

Three files of logic/CSS plus a new test, all in `src/components/layout-panel/`.

  1. Min height now depends on visType
  - min is now 58 for LINE_LIST (one axis row) and 116 for PIVOT_TABLE (two rows)
  - Fixed the stored-size branch so a saved height can never hide an axis

  2. Drag is now relative, not absolute
  - Dragging down can no longer dip below min, so the spurious  collapse on empty layouts is gone. The intentional "drag up past snap point → collapse" gesture is preserved and triggers at 24px

  3. Axis content fills its cell
  - The droppable region now fills the available height — much  easier drop targets

One note on the empty-layout case: an empty axes area can't be dragged taller than its natural content height (the max clamps to the container's content), since there's nothing to reveal — but it no longer collapses, which was the actual bug.
There isn't a decision on this yet.

There are some inconsistencies now between the fixes and the use of user defined height.
When switching visType the user defined height might be ignored depending on the its value.
Some decision will be taken on how the user defined height should work.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

--- 

### Screenshots

Min height for LL:
<img width="855" height="149" alt="Screenshot 2026-06-10 at 11 12 35" src="https://github.com/user-attachments/assets/40b5caed-b3a5-4f0a-9b2e-a03c63b7dbc8" />


Min height for PT:
<img width="851" height="203" alt="Screenshot 2026-06-10 at 11 12 45" src="https://github.com/user-attachments/assets/53b13b5c-510a-4779-a5c4-0018bff3fd28" />



[DHIS2-21587]: https://dhis2.atlassian.net/browse/DHIS2-21587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ