### PR TITLE
fix: repeatability ui improvements

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-10T14:25:39.903Z\n"
-"PO-Revision-Date: 2026-06-10T14:25:39.903Z\n"
+"POT-Creation-Date: 2026-06-11T08:36:04.474Z\n"
+"PO-Revision-Date: 2026-06-11T08:36:04.475Z\n"
 
 msgid "Add to {{- axisName}}"
 msgstr "Add to {{- axisName}}"
@@ -62,14 +62,26 @@ msgstr "Choose legends"
 msgid "Loading legends"
 msgstr "Loading legends"
 
-msgid "From stages with repeatable events, show values for this data element from:"
-msgstr "From stages with repeatable events, show values for this data element from:"
+msgid "From stages with repeatable events, show values from:"
+msgstr "From stages with repeatable events, show values from:"
 
-msgid "Most recent events:"
-msgstr "Most recent events:"
+msgid "Oldest events"
+msgstr "Oldest events"
 
-msgid "Oldest events:"
-msgstr "Oldest events:"
+msgid "Show fewer of the oldest events"
+msgstr "Show fewer of the oldest events"
+
+msgid "Show more of the oldest events"
+msgstr "Show more of the oldest events"
+
+msgid "Most recent events"
+msgstr "Most recent events"
+
+msgid "Show fewer of the most recent events"
+msgstr "Show fewer of the most recent events"
+
+msgid "Show more of the most recent events"
+msgstr "Show more of the most recent events"
 
 msgid "Hide"
 msgstr "Hide"

--- a/src/components/dimension-modal/conditions-modal-content/__tests__/repeated-events-tab-content.spec.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/__tests__/repeated-events-tab-content.spec.tsx
@@ -82,14 +82,28 @@ describe('RepeatedEventsTabContent', () => {
         expect(screen.getByTestId('most-recent-decrement')).toBeDisabled()
     })
 
-    it('exposes each stepper as a group labelled by its heading', () => {
+    it('gives each stepper button a descriptive accessible name', () => {
         setup()
 
         expect(
-            screen.getByRole('group', { name: 'Oldest events' })
+            screen.getByRole('button', {
+                name: 'Show fewer of the oldest events',
+            })
         ).toBeInTheDocument()
         expect(
-            screen.getByRole('group', { name: 'Most recent events' })
+            screen.getByRole('button', {
+                name: 'Show more of the oldest events',
+            })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('button', {
+                name: 'Show fewer of the most recent events',
+            })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('button', {
+                name: 'Show more of the most recent events',
+            })
         ).toBeInTheDocument()
     })
 

--- a/src/components/dimension-modal/conditions-modal-content/__tests__/repeated-events-tab-content.spec.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/__tests__/repeated-events-tab-content.spec.tsx
@@ -1,0 +1,120 @@
+import {
+    visUiConfigSlice,
+    initialState,
+    getVisUiConfigRepetitionsByDimension,
+    type RepetitionsObject,
+} from '@store/vis-ui-config-slice'
+import { renderWithReduxStoreProvider } from '@test-utils/render-with-redux-store-provider'
+import { setupStore } from '@test-utils/setup-store'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect } from 'vitest'
+import { RepeatedEventsTabContent } from '../repeated-events-tab-content'
+
+const DIMENSION_ID = 'de1'
+
+const setup = (
+    repetitionsByDimension: Record<string, RepetitionsObject | undefined> = {}
+) => {
+    const store = setupStore(
+        { visUiConfig: visUiConfigSlice.reducer },
+        { visUiConfig: { ...initialState, repetitionsByDimension } }
+    )
+
+    renderWithReduxStoreProvider(
+        <RepeatedEventsTabContent dimensionId={DIMENSION_ID} />,
+        store
+    )
+
+    return store
+}
+
+const repetitions = (store: ReturnType<typeof setup>) =>
+    getVisUiConfigRepetitionsByDimension(store.getState(), DIMENSION_ID)
+
+const value = (key: 'oldest' | 'most-recent') =>
+    screen.getByTestId(`${key}-value`).textContent
+
+describe('RepeatedEventsTabContent', () => {
+    it('shows the default values (1 most recent, 0 oldest) when nothing is persisted', () => {
+        setup()
+
+        expect(value('oldest')).toBe('0')
+        expect(value('most-recent')).toBe('1')
+    })
+
+    it('increments the "oldest" count', async () => {
+        const user = userEvent.setup()
+        const store = setup()
+
+        await user.click(screen.getByTestId('oldest-increment'))
+
+        expect(repetitions(store)).toEqual({ mostRecent: 1, oldest: 1 })
+    })
+
+    it('increments the "most recent" count', async () => {
+        const user = userEvent.setup()
+        const store = setup()
+
+        await user.click(screen.getByTestId('most-recent-increment'))
+
+        expect(repetitions(store)).toEqual({ mostRecent: 2, oldest: 0 })
+    })
+
+    it('decrements a count back down', async () => {
+        const user = userEvent.setup()
+        const store = setup({ [DIMENSION_ID]: { mostRecent: 0, oldest: 3 } })
+
+        await user.click(screen.getByTestId('oldest-decrement'))
+
+        expect(repetitions(store)).toEqual({ mostRecent: 0, oldest: 2 })
+    })
+
+    it('disables "oldest" decrement when it would drop the total below 1', () => {
+        setup({ [DIMENSION_ID]: { mostRecent: 0, oldest: 1 } })
+
+        expect(screen.getByTestId('oldest-decrement')).toBeDisabled()
+    })
+
+    it('disables "most recent" decrement when it would drop the total below 1', () => {
+        setup()
+
+        expect(screen.getByTestId('most-recent-decrement')).toBeDisabled()
+    })
+
+    it('exposes each stepper as a group labelled by its heading', () => {
+        setup()
+
+        expect(
+            screen.getByRole('group', { name: 'Oldest events' })
+        ).toBeInTheDocument()
+        expect(
+            screen.getByRole('group', { name: 'Most recent events' })
+        ).toBeInTheDocument()
+    })
+
+    it('marks a card active only when its count is above 0', () => {
+        setup({ [DIMENSION_ID]: { mostRecent: 2, oldest: 0 } })
+
+        expect(screen.getByTestId('oldest-card')).toHaveAttribute(
+            'data-active',
+            'false'
+        )
+        expect(screen.getByTestId('most-recent-card')).toHaveAttribute(
+            'data-active',
+            'true'
+        )
+    })
+
+    it('removes the repetition config when the selection returns to the default', async () => {
+        const user = userEvent.setup()
+        const store = setup({ [DIMENSION_ID]: { mostRecent: 2, oldest: 0 } })
+
+        await user.click(screen.getByTestId('most-recent-decrement'))
+
+        expect(
+            store.getState().visUiConfig.repetitionsByDimension[DIMENSION_ID]
+        ).toBeUndefined()
+        expect(value('most-recent')).toBe('1')
+    })
+})

--- a/src/components/dimension-modal/conditions-modal-content/repeated-events-tab-content.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/repeated-events-tab-content.tsx
@@ -42,12 +42,8 @@ const RepetitionStepper: FC<RepetitionStepperProps> = ({
         className={classes.repeatableCard}
         data-active={value > 0}
         data-test={`${dataTest}-card`}
-        role="group"
-        aria-labelledby={`${dataTest}-label`}
     >
-        <span id={`${dataTest}-label`} className={classes.repeatableCardHeader}>
-            {label}
-        </span>
+        <span className={classes.repeatableCardHeader}>{label}</span>
         <div className={classes.repeatableStepper}>
             <Button
                 secondary

--- a/src/components/dimension-modal/conditions-modal-content/repeated-events-tab-content.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/repeated-events-tab-content.tsx
@@ -1,5 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import { Input } from '@dhis2/ui'
+import { Button, IconAdd24, IconSubtract24 } from '@dhis2/ui'
 import { useAppDispatch, useAppSelector } from '@hooks'
 import {
     DEFAULT_REPETITIONS_OBJECT,
@@ -14,6 +14,67 @@ type RepeatedEventsTabContentProps = {
     dimensionId: string
 }
 
+const MIN_TOTAL_EVENTS = 1
+
+const getMinCount = (otherCount: number) =>
+    Math.max(0, MIN_TOTAL_EVENTS - otherCount)
+
+type RepetitionStepperProps = {
+    label: string
+    value: number
+    minValue: number
+    decrementLabel: string
+    incrementLabel: string
+    onChange: (value: number) => void
+    dataTest: string
+}
+
+const RepetitionStepper: FC<RepetitionStepperProps> = ({
+    label,
+    value,
+    minValue,
+    decrementLabel,
+    incrementLabel,
+    onChange,
+    dataTest,
+}) => (
+    <div
+        className={classes.repeatableCard}
+        data-active={value > 0}
+        data-test={`${dataTest}-card`}
+        role="group"
+        aria-labelledby={`${dataTest}-label`}
+    >
+        <span id={`${dataTest}-label`} className={classes.repeatableCardHeader}>
+            {label}
+        </span>
+        <div className={classes.repeatableStepper}>
+            <Button
+                secondary
+                icon={<IconSubtract24 />}
+                onClick={() => onChange(value - 1)}
+                disabled={value <= minValue}
+                aria-label={decrementLabel}
+                dataTest={`${dataTest}-decrement`}
+            />
+            <span
+                className={classes.repeatableValue}
+                data-test={`${dataTest}-value`}
+                aria-live="polite"
+            >
+                {value}
+            </span>
+            <Button
+                secondary
+                icon={<IconAdd24 />}
+                onClick={() => onChange(value + 1)}
+                aria-label={incrementLabel}
+                dataTest={`${dataTest}-increment`}
+            />
+        </div>
+    </div>
+)
+
 export const RepeatedEventsTabContent: FC<RepeatedEventsTabContentProps> = ({
     dimensionId,
 }) => {
@@ -22,11 +83,6 @@ export const RepeatedEventsTabContent: FC<RepeatedEventsTabContentProps> = ({
     const { mostRecent, oldest } = useAppSelector((state) =>
         getVisUiConfigRepetitionsByDimension(state, dimensionId)
     )
-
-    const parseInput = useCallback((value) => {
-        const parsedValue = parseInt(value, 10)
-        return parsedValue > 0 ? parsedValue : 0
-    }, [])
 
     const updateRepetitions = useCallback(
         (repetitions: RepetitionsObject) => {
@@ -37,7 +93,6 @@ export const RepeatedEventsTabContent: FC<RepeatedEventsTabContentProps> = ({
                 repetitions.mostRecent === defaultMostRecent &&
                 repetitions.oldest === defaultOldest
             ) {
-                // Remove repetitions configuration when the selection matches the default
                 dispatch(setVisUiConfigRepetitionsByDimension({ dimensionId }))
             } else {
                 dispatch(
@@ -51,57 +106,49 @@ export const RepeatedEventsTabContent: FC<RepeatedEventsTabContentProps> = ({
         [dimensionId, dispatch]
     )
 
-    const onMostRecentChange = useCallback(
-        (value) => updateRepetitions({ mostRecent: parseInput(value), oldest }),
-        [oldest, parseInput, updateRepetitions]
+    const onOldestChange = useCallback(
+        (oldestValue: number) =>
+            updateRepetitions({ mostRecent, oldest: oldestValue }),
+        [mostRecent, updateRepetitions]
     )
 
-    const onOldestChange = useCallback(
-        (value) => updateRepetitions({ mostRecent, oldest: parseInput(value) }),
-        [mostRecent, parseInput, updateRepetitions]
+    const onMostRecentChange = useCallback(
+        (mostRecentValue: number) =>
+            updateRepetitions({ mostRecent: mostRecentValue, oldest }),
+        [oldest, updateRepetitions]
     )
 
     return (
         <div>
-            <p className={classes.paragraph}>
+            <p className={classes.repeatableIntro}>
                 {i18n.t(
-                    'From stages with repeatable events, show values for this data element from:',
+                    'From stages with repeatable events, show values from:',
                     { nsSeparator: '^^' }
                 )}
             </p>
-            <div>
-                <div className={classes.repeatableWrapper}>
-                    <p className={classes.paragraph}>
-                        {i18n.t('Most recent events:', {
-                            nsSeparator: '^^',
-                        })}
-                    </p>
-                    <Input
-                        type="number"
-                        dense
-                        className={classes.repeatableInput}
-                        value={mostRecent.toString()}
-                        onChange={({ value }) => onMostRecentChange(value)}
-                        min="0"
-                        dataTest="most-recent-input"
-                    />
-                </div>
-                <div className={classes.repeatableWrapper}>
-                    <p className={classes.paragraph}>
-                        {i18n.t('Oldest events:', {
-                            nsSeparator: '^^',
-                        })}
-                    </p>
-                    <Input
-                        type="number"
-                        dense
-                        className={classes.repeatableInput}
-                        value={oldest.toString()}
-                        onChange={({ value }) => onOldestChange(value)}
-                        min="0"
-                        dataTest="oldest-input"
-                    />
-                </div>
+            <div className={classes.repeatableCards}>
+                <RepetitionStepper
+                    label={i18n.t('Oldest events')}
+                    value={oldest}
+                    minValue={getMinCount(mostRecent)}
+                    decrementLabel={i18n.t('Show fewer of the oldest events')}
+                    incrementLabel={i18n.t('Show more of the oldest events')}
+                    onChange={onOldestChange}
+                    dataTest="oldest"
+                />
+                <RepetitionStepper
+                    label={i18n.t('Most recent events')}
+                    value={mostRecent}
+                    minValue={getMinCount(oldest)}
+                    decrementLabel={i18n.t(
+                        'Show fewer of the most recent events'
+                    )}
+                    incrementLabel={i18n.t(
+                        'Show more of the most recent events'
+                    )}
+                    onChange={onMostRecentChange}
+                    dataTest="most-recent"
+                />
             </div>
         </div>
     )

--- a/src/components/dimension-modal/conditions-modal-content/styles/conditions-modal-content.module.css
+++ b/src/components/dimension-modal/conditions-modal-content/styles/conditions-modal-content.module.css
@@ -28,30 +28,69 @@
     margin-block-end: var(--spacers-dp16);
 }
 
-.repeatableWrapper {
-    display: flex;
-    align-items: center;
-    margin-inline-start: var(--spacers-dp8);
-}
-
-.repeatableWrapper:first-child {
-    margin-block-start: var(--spacers-dp16);
-}
-
-.repeatableWrapper:not(:last-child) {
-    margin-block-end: var(--spacers-dp12);
-}
-
-.repeatableInput {
-    inline-size: 100px;
-    margin-inline-start: var(--spacers-dp4);
-}
-
-.paragraph {
+.repeatableIntro {
     font-size: 14px;
     line-height: 19px;
     color: var(--colors-grey900);
     margin: 0;
+}
+
+.repeatableCards {
+    display: flex;
+    gap: var(--spacers-dp16);
+    margin-block-start: var(--spacers-dp16);
+}
+
+.repeatableCard {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--spacers-dp12);
+    padding: var(--spacers-dp16);
+    background-color: var(--colors-white);
+    border: 1px solid var(--colors-grey300);
+    border-radius: 4px;
+    transition: background-color 0.15s ease;
+}
+
+.repeatableCard[data-active='true'] {
+    background-color: color-mix(
+        in srgb,
+        var(--colors-teal050) 50%,
+        transparent
+    );
+    border-color: var(--colors-teal200);
+}
+
+.repeatableCardHeader {
+    font-size: 15px;
+    line-height: 19px;
+    color: var(--colors-grey700);
+}
+
+.repeatableCard[data-active='true'] .repeatableCardHeader {
+    color: var(--colors-teal900);
+}
+
+.repeatableStepper {
+    display: flex;
+    align-items: center;
+    gap: var(--spacers-dp16);
+}
+
+.repeatableValue {
+    min-inline-size: 32px;
+    font-size: 28px;
+    font-weight: 500;
+    line-height: 1;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    color: var(--colors-grey700);
+}
+
+.repeatableCard[data-active='true'] .repeatableValue {
+    color: var(--colors-teal900);
 }
 
 .mainSection {


### PR DESCRIPTION
Implements [DHIS2-21626](https://dhis2.atlassian.net/browse/DHIS2-21626)

### Description

This PR improves the UI of the Repeated Events tab in the dimension modal.
- Uses a card and stepper component, rather than bare `Input`.
- Disable 0 total events selection (previously this was allowed, but response  silently reverts to `most recent: 1`.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) _N/A_

---

### Screenshots

<img width="827" height="356" alt="image" src="https://github.com/user-attachments/assets/9a0badeb-3147-4e66-a5b3-ed164016906f" />

<img width="820" height="354" alt="image" src="https://github.com/user-attachments/assets/90b84d70-87f7-4a0c-b7ba-f8b967788a19" />



[DHIS2-21626]: https://dhis2.atlassian.net/browse/DHIS2-21626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ