### PR TITLE
fix: show correct label for repeatable column headers

### DIFF
--- a/src/modules/__tests__/visualization.spec.ts
+++ b/src/modules/__tests__/visualization.spec.ts
@@ -481,6 +481,21 @@ describe('analyticsHeaderToCanonicalDimensionId', () => {
         ).toBe(`${SID}.eventDate`)
     })
 
+    it('strips the repetition index from a repeated stage prefix', () => {
+        expect(
+            analyticsHeaderToCanonicalDimensionId(
+                `${SID}[-1].${UID}`,
+                buildVis()
+            )
+        ).toBe(`${SID}.${UID}`)
+        expect(
+            analyticsHeaderToCanonicalDimensionId(
+                `${SID}[0].${UID}`,
+                buildVis()
+            )
+        ).toBe(`${SID}.${UID}`)
+    })
+
     it('rewrites bare `ou` to `tetId.enrollmentOu` in TE', () => {
         const vis = buildVis({
             outputType: 'TRACKED_ENTITY_INSTANCE',

--- a/src/modules/metadata-store/dimension.ts
+++ b/src/modules/metadata-store/dimension.ts
@@ -15,7 +15,7 @@ export type DimensionIdentifier = Pick<
 >
 
 // Pattern to match repetition index like [0], [1], [-1] etc.
-const REPETITION_INDEX_PATTERN = /\[(-?\d+)\]/
+export const REPETITION_INDEX_PATTERN = /\[(-?\d+)\]/
 
 export const isCompoundDimensionId = (input: unknown): input is string =>
     isPopulatedString(input) && input.includes('.')

--- a/src/modules/visualization.ts
+++ b/src/modules/visualization.ts
@@ -2,6 +2,7 @@ import { getRequestOptions } from '@components/plugin-wrapper/hooks/query-tools-
 import { DEFAULT_OPTIONS } from '@constants/options'
 import { layoutGetAllDimensions } from '@dhis2/analytics'
 import i18n from '@dhis2/d2-i18n'
+import { REPETITION_INDEX_PATTERN } from '@modules/metadata-store/dimension'
 import type {
     ApiSavedVisualization,
     DimensionArray,
@@ -118,7 +119,11 @@ export const analyticsHeaderToCanonicalDimensionId = (
 
     const lastDotIndex = headerName.lastIndexOf('.')
     const prefix =
-        lastDotIndex === -1 ? undefined : headerName.slice(0, lastDotIndex)
+        lastDotIndex === -1
+            ? undefined
+            : headerName
+                  .slice(0, lastDotIndex)
+                  .replace(REPETITION_INDEX_PATTERN, '')
     const wireDim =
         lastDotIndex === -1 ? headerName : headerName.slice(lastDotIndex + 1)
 


### PR DESCRIPTION
### Description

This PR fixes an issue where the repeatable event column headings were showing compound IDs instead of the item labels.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) _N/A_

---

### Screenshots

**Before:**

<img width="1277" height="579" alt="image" src="https://github.com/user-attachments/assets/5e279f86-e97a-4aa6-b32d-1b5575e86390" />


**After:**

<img width="1272" height="532" alt="image" src="https://github.com/user-attachments/assets/a36b2d6b-04a9-4934-b4a4-8393e08c7b6a" />


