### PR TITLE
fix: provide option set name when adding to metadata store

### DIFF
--- a/src/components/dimension-modal/conditions-modal-content/option-set-condition/option-set-condition.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/option-set-condition/option-set-condition.tsx
@@ -61,26 +61,39 @@ export const OptionSetCondition: FC<OptionSetConditionProps> = ({
 
     const data = rawData as FetchResult['items']
 
-    const setValues = (selected) => {
-        const optionsMetadata = selected.reduce((options, selectedId) => {
-            const option = data?.find(({ code }) => code === selectedId)
+    const setValues = (selected: string[]) => {
+        const optionsMetadata = selected.reduce<FetchResult['items']>(
+            (options, selectedId) => {
+                const option = data?.find(({ code }) => code === selectedId)
 
-            if (option) {
-                options.push(option)
-            }
+                if (option) {
+                    options.push(option)
+                }
 
-            return options
-        }, [])
+                return options
+            },
+            []
+        )
 
         // add each single option
         // this is to keep the metadata store consistent, as the single options are also added when loading a visualization
         addMetadata(optionsMetadata)
 
-        // update options in the optionSet metadata used for the lookup of the correct
-        // name from code (options for different option sets have the same code)
+        // add the optionSet so option labels can be looked up by code
+        // (codes are not unique across option sets)
+        const optionSetName =
+            data?.[0]?.optionSet?.name ?? optionSetMetadata?.name
+
+        if (!optionSetName) {
+            throw new Error(
+                `Could not resolve a name for option set "${optionSetId}"`
+            )
+        }
+
         addMetadata({
             ...(optionSetMetadata ?? {}),
             id: optionSetId,
+            name: optionSetName,
             options: optionsMetadata,
         })
 

--- a/src/components/dimension-modal/conditions-modal-content/option-set-condition/options-api.ts
+++ b/src/components/dimension-modal/conditions-modal-content/option-set-condition/options-api.ts
@@ -9,7 +9,12 @@ export type FetchOptionsByOptionSetQueryArgs = {
 }
 
 export type FetchResult = {
-    items: { code: string; id: string; name: string }[]
+    items: {
+        code: string
+        id: string
+        name: string
+        optionSet?: { id: string; name: string }
+    }[]
     nextPage: number | null
 }
 
@@ -39,7 +44,7 @@ export const optionsApi = api.injectEndpoints({
                         options: {
                             resource: 'options',
                             params: {
-                                fields: `code,${nameProp}~rename(name),id`,
+                                fields: `code,${nameProp}~rename(name),id,optionSet[id,${nameProp}~rename(name)]`,
                                 filter: filters,
                                 paging: true,
                                 page,


### PR DESCRIPTION
Implements N/A Demo feature

### Description

- Selecting an option in the conditions modal (e.g. double-clicking "Cholera" under CS - Initial Diagnosis) threw `Error: New metadata item "..." does not have a name`. On first selection, `optionSetMetadata` from the store was `undefined`, so the spread of `optionSetMetadata ?? {}` produced an option-set entry without a `name`, and `normalizeMetadataInputItem` requires one.
- Include the option set on each option in the options API response via `optionSet[id,nameProp~rename(name)]`, then read the name from `data[0]?.optionSet?.name` and pass it explicitly to `addMetadata`. Tightened the implicit `any` on `setValues` and the reduce accumulator while we were here.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A


