### PR TITLE
fix: fetch the selected legend set when not already in the store

### DIFF
--- a/src/components/dimension-modal/conditions-modal-content/numeric-condition/numeric-condition.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/numeric-condition/numeric-condition.tsx
@@ -132,6 +132,12 @@ export const NumericCondition: FC<NumericConditionProps> = ({
         }
     }, [dimension.id, legendSet, addMetadata])
 
+    useEffect(() => {
+        if (selectedLegendSetId && !legendSet) {
+            fetchLegendSet(selectedLegendSetId)
+        }
+    }, [selectedLegendSetId, legendSet, fetchLegendSet])
+
     const { valueInputId, focusValueInput } = useValueInputFocus()
 
     const setOperator = useCallback(
@@ -175,12 +181,6 @@ export const NumericCondition: FC<NumericConditionProps> = ({
             })
         }
     }, [fetchLegendSets, dimension.id, dimension.dimensionType, legendSets])
-
-    const onLegendSetLegendsDropdownFocus = useCallback(() => {
-        if (!legendSet && selectedLegendSetId) {
-            fetchLegendSet(selectedLegendSetId)
-        }
-    }, [fetchLegendSet, selectedLegendSetId, legendSet])
 
     return (
         <div className={classes.container}>
@@ -272,7 +272,6 @@ export const NumericCondition: FC<NumericConditionProps> = ({
                                         selectedLegendSetId
                                     )
                                 }
-                                onFocus={onLegendSetLegendsDropdownFocus}
                                 loading={
                                     isLoadingLegendSet || isFetchingLegendSet
                                 }


### PR DESCRIPTION
Implements N/A

### Description

**Reproduce:**
1. New visualization, pick a program with a numeric dimension that has a legend set (e.g. E2E program → "E2E - Negative Integer" on `dev.im.dhis2.org/ever-playground`).
2. Open the dimension modal → Filter → "is one of preset options".
3. Pick a legend set from the first dropdown.
4. Click **Hide**, then click the dimension again to reopen the modal.

**Before this PR:** the first dropdown is empty on reopen — no legend-set name. `getLegendSet` was only triggered when the legends (second) dropdown was focused, so closing before that step left the legend set out of the metadata store.

**With this PR:** the dropdown shows the legend-set name on reopen.

Add a `useEffect` that fetches whenever a `legendSetId` is selected (or restored from the visualization). The previous `onFocus={onLegendSetLegendsDropdownFocus}` trigger is removed — the effect supersedes it.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added — N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) — N/A

---
