### PR TITLE
fix: split multi-text values to correctly lookup metadata

### DIFF
--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.spec.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.spec.ts
@@ -6,7 +6,7 @@ import type {
     DimensionMetadataItem,
 } from '@types'
 import { describe, it, expect } from 'vitest'
-import { extractHeaders } from './use-line-list-analytics-data'
+import { extractHeaders, formatRowValue } from './use-line-list-analytics-data'
 
 const visualization = {
     outputType: 'EVENT',
@@ -90,5 +90,101 @@ describe('extractHeaders', () => {
 
         expect(secondHeaders[0].column).toBe('Scheduled date')
         expect(secondHeaders[0].dimensionSuffix).toBe('Birth')
+    })
+})
+
+describe('formatRowValue', () => {
+    const optionSetMetaData = {
+        os1: {
+            options: [
+                { code: 'A', uid: 'optA' },
+                { code: 'B', uid: 'optB' },
+                { code: 'C', uid: 'optC' },
+            ],
+        },
+        optA: { name: 'Apple' },
+        optB: { name: 'Banana' },
+        optC: { name: 'Cherry' },
+    }
+
+    const optionSetHeader = { valueType: 'TEXT', optionSet: 'os1' }
+
+    it('resolves an option set value to its option name', () => {
+        expect(
+            formatRowValue({
+                rowValue: 'A',
+                header: optionSetHeader,
+                metaDataItems: optionSetMetaData,
+                isUndefined: false,
+            })
+        ).toBe('Apple')
+    })
+
+    it('resolves each code of a multi-text value and joins the option names', () => {
+        expect(
+            formatRowValue({
+                rowValue: 'A,B,C',
+                header: optionSetHeader,
+                metaDataItems: optionSetMetaData,
+                isUndefined: false,
+            })
+        ).toBe('Apple, Banana, Cherry')
+    })
+
+    /* The analytics API can omit metadata for some option codes (the option's
+     * uid entry or its presence in the option set's options array). The missing
+     * codes must fall back to the raw code instead of breaking the whole value. */
+    it('falls back to the raw code for multi-text codes missing from the metadata', () => {
+        const metaDataItemsMissingOption = {
+            os1: {
+                options: [
+                    { code: 'A', uid: 'optA' },
+                    { code: 'C', uid: 'optC' },
+                ],
+            },
+            optA: { name: 'Apple' },
+            optC: { name: 'Cherry' },
+        }
+
+        expect(
+            formatRowValue({
+                rowValue: 'A,B,C',
+                header: optionSetHeader,
+                metaDataItems: metaDataItemsMissingOption,
+                isUndefined: false,
+            })
+        ).toBe('Apple, B, Cherry')
+    })
+
+    it('falls back to the raw code when the option uid entry is missing', () => {
+        const metaDataItemsMissingName = {
+            os1: {
+                options: [
+                    { code: 'A', uid: 'optA' },
+                    { code: 'B', uid: 'optB' },
+                ],
+            },
+            optA: { name: 'Apple' },
+        }
+
+        expect(
+            formatRowValue({
+                rowValue: 'A,B',
+                header: optionSetHeader,
+                metaDataItems: metaDataItemsMissingName,
+                isUndefined: false,
+            })
+        ).toBe('Apple, B')
+    })
+
+    it('falls back to every raw code when the option set metadata is absent', () => {
+        expect(
+            formatRowValue({
+                rowValue: 'A,B',
+                header: optionSetHeader,
+                metaDataItems: {},
+                isUndefined: false,
+            })
+        ).toBe('A, B')
     })
 })

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -50,7 +50,12 @@ const NOT_DEFINED_VALUE = 'ND'
 export const cellIsUndefined = (rowContext = {}, rowIndex, columnIndex) =>
     (rowContext[rowIndex] || {})[columnIndex]?.valueStatus === NOT_DEFINED_VALUE
 
-const formatRowValue = ({ rowValue, header, metaDataItems, isUndefined }) => {
+export const formatRowValue = ({
+    rowValue,
+    header,
+    metaDataItems,
+    isUndefined,
+}) => {
     if (!rowValue) {
         return rowValue
     }
@@ -61,13 +66,17 @@ const formatRowValue = ({ rowValue, header, metaDataItems, isUndefined }) => {
             return !isUndefined ? getBooleanValues()[rowValue] : ''
         default: {
             if (header.optionSet) {
-                return (
-                    lookupOptionSetOptionMetadata(
-                        header.optionSet,
-                        rowValue,
-                        metaDataItems
-                    )?.name || rowValue
-                )
+                return rowValue
+                    .split(',')
+                    .map(
+                        (code) =>
+                            lookupOptionSetOptionMetadata(
+                                header.optionSet,
+                                code,
+                                metaDataItems
+                            )?.name || code
+                    )
+                    .join(', ')
             }
 
             return metaDataItems[rowValue]?.name || rowValue


### PR DESCRIPTION
Implements [DHIS2-21636](https://dhis2.atlassian.net/browse/DHIS2-21636)

### Description

With multi-text values there is a bug where the metadata lookup of each value in a multi-text string does not work correctly.

The bug needs a fix in both backend and frontend.

This PR addresses the frontend part only.



---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

Screenshot showing the issue. Look at the value on the 2nd row compared to 4th and 6th:

<img width="1144" height="789" alt="image (11)" src="https://github.com/user-attachments/assets/90aafd38-9e0b-4ba6-b781-72d695678751" />





[DHIS2-21636]: https://dhis2.atlassian.net/browse/DHIS2-21636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ