### PR TITLE
chore: claude sandbox tweaks and prevent vitest warning

### DIFF
--- a/docs/claude-sandboxes.md
+++ b/docs/claude-sandboxes.md
@@ -80,3 +80,5 @@ Extra Claude flags are forwarded — pass them after `--`, e.g. `pnpm sbx:mount 
 ## Tooling and constraints
 
 **Tooling inside the sandbox:** the `typescript-lsp`, `context7`, and `superpowers` plugins, the `grep` MCP, and the prettier/eslint format hook all work. Only project-level config (committed `.claude/`) is picked up — your _host_ user-level MCP servers are not propagated in. **GitHub auth (`gh`) is deliberately not available inside sandboxes** — the agent has no push/PR power, so a misbehaving session can't touch your repos; do GitHub operations on the host.
+
+`/doctor` shows the `chrome-devtools-mcp` plugin as "enabled in project settings but not installed" — this is **expected**: the plugin is enabled for host use (it drives the host's Chrome), can't be disabled sandbox-locally (it's enabled at project scope = the committed file), and isn't installed in the sandbox, so it loads no tools and the warning is harmless. Browser automation comes from the sandbox-local `chrome-devtools` server (see above). This goes away once Google ships Chrome for arm64 Linux and the sandbox can install it.

--- a/import-aliases.ts
+++ b/import-aliases.ts
@@ -1,0 +1,13 @@
+import path from 'node:path'
+
+export const importAliases = {
+    '@types': path.resolve(__dirname, 'src/types/index.ts'),
+    '@hooks': path.resolve(__dirname, 'src/hooks/index.ts'),
+    '@api': path.resolve(__dirname, 'src/api'),
+    '@assets': path.resolve(__dirname, 'src/assets'),
+    '@components': path.resolve(__dirname, 'src/components'),
+    '@constants': path.resolve(__dirname, 'src/constants'),
+    '@modules': path.resolve(__dirname, 'src/modules'),
+    '@store': path.resolve(__dirname, 'src/store'),
+    '@test-utils': path.resolve(__dirname, 'src/test-utils'),
+}

--- a/scripts/sbx.sh
+++ b/scripts/sbx.sh
@@ -9,12 +9,6 @@ DEV_PORT=3000
 MARKETPLACE="anthropics/claude-plugins-official"
 PNPM_VERSION="$(node -p "require('$REPO_ROOT/package.json').packageManager.split('@')[1].split('+')[0]" 2>/dev/null || echo latest)"
 
-# The committed .claude/settings.json enables the chrome-devtools-mcp plugin, which on the host
-# drives the host's own Chrome. The sandbox has no such Chrome — browser automation is provided
-# instead by a sandbox-local headless server (see setup_browser). Disable the plugin
-# per-run via --settings (CLI scope wins over project settings) so it does not error as "enabled
-# but not installed", without writing to the bind-mounted repo (which would disable it for the host).
-DISABLE_HOST_CHROME_PLUGIN='{"enabledPlugins":{"chrome-devtools-mcp@claude-plugins-official":false}}'
 
 require_sbx() {
     if ! command -v sbx >/dev/null 2>&1; then
@@ -58,6 +52,17 @@ provision_sandbox() {
         claude plugin install typescript-lsp@claude-plugins-official >/dev/null
         claude plugin install context7@claude-plugins-official >/dev/null
         claude plugin install superpowers@claude-plugins-official >/dev/null
+        # The project settings enable chrome-devtools-mcp for host use, but sandboxes get
+        # browser automation via a user-scoped MCP server (see setup_browser) — the plugin
+        # would conflict and error in /doctor. Disable it at user scope so it wins over the
+        # project setting without touching the committed settings file.
+        node -e "
+            const fs = require(\"fs\"), p = process.env.HOME + \"/.claude/settings.json\";
+            let s = {}; try { s = JSON.parse(fs.readFileSync(p, \"utf8\")); } catch(e) {}
+            s.enabledPlugins = s.enabledPlugins || {};
+            s.enabledPlugins[\"chrome-devtools-mcp@claude-plugins-official\"] = false;
+            fs.writeFileSync(p, JSON.stringify(s, null, 4) + \"\n\");
+        "
         # Cypress/Electron e2e needs GTK + X libs to actually run (the binary itself installs
         # from the allow-listed CDN during pnpm install). Best-effort; wait out startup apt lock.
         for _ in $(seq 1 30); do sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || break; sleep 2; done
@@ -388,7 +393,6 @@ cmd_mount() {
     local note="${BASE_NOTE}"$'\n\n'"${MOUNT_NOTE}"
     sbx run "$MOUNT_NAME" -- \
         --dangerously-skip-permissions \
-        --settings "$DISABLE_HOST_CHROME_PLUGIN" \
         --append-system-prompt "$note" \
         "$@"
 }
@@ -432,7 +436,6 @@ cmd_clone() {
     local note="${BASE_NOTE}"$'\n\n'"${CLONE_NOTE}"
     sbx run "$CLONE_NAME" -- \
         --dangerously-skip-permissions \
-        --settings "$DISABLE_HOST_CHROME_PLUGIN" \
         --append-system-prompt "$note" \
         "$@"
     echo

--- a/scripts/sbx.sh
+++ b/scripts/sbx.sh
@@ -52,17 +52,6 @@ provision_sandbox() {
         claude plugin install typescript-lsp@claude-plugins-official >/dev/null
         claude plugin install context7@claude-plugins-official >/dev/null
         claude plugin install superpowers@claude-plugins-official >/dev/null
-        # The project settings enable chrome-devtools-mcp for host use, but sandboxes get
-        # browser automation via a user-scoped MCP server (see setup_browser) — the plugin
-        # would conflict and error in /doctor. Disable it at user scope so it wins over the
-        # project setting without touching the committed settings file.
-        node -e "
-            const fs = require(\"fs\"), p = process.env.HOME + \"/.claude/settings.json\";
-            let s = {}; try { s = JSON.parse(fs.readFileSync(p, \"utf8\")); } catch(e) {}
-            s.enabledPlugins = s.enabledPlugins || {};
-            s.enabledPlugins[\"chrome-devtools-mcp@claude-plugins-official\"] = false;
-            fs.writeFileSync(p, JSON.stringify(s, null, 4) + \"\n\");
-        "
         # Cypress/Electron e2e needs GTK + X libs to actually run (the binary itself installs
         # from the allow-listed CDN during pnpm install). Best-effort; wait out startup apt lock.
         for _ in $(seq 1 30); do sudo fuser /var/lib/apt/lists/lock /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || break; sleep 2; done
@@ -82,6 +71,7 @@ Dependencies are already installed: the host install includes the Linux binaries
 DO NOT branch or commit — the human reviews your diffs and commits on the host.
 A dev server you start (e.g. `pnpm start`) is reachable from the host at http://localhost:3000.
 Browser automation is available: the chrome-devtools tools drive an in-sandbox headless Chrome. Use them to load and inspect your running app — start the dev server, then navigate to http://localhost:3000.
+The `chrome-devtools-mcp` plugin shows an "enabled in project settings but not installed" warning in /doctor here — that is EXPECTED and harmless. Do NOT install or enable it (it needs a Chrome the sandbox can't provide); the in-sandbox server above already gives you the chrome-devtools tools.
 EOF
 
 read -r -d '' CLONE_NOTE <<'EOF' || true
@@ -92,6 +82,7 @@ Git reads are fine: you CAN `git fetch`/`git pull` from `origin` (GitHub, public
 How your work reaches the human: this sandbox also publishes its repository back to the host over a read-only git remote, and the human fetches your branch from it to review — so committing to your feature branch is all that is needed.
 Dependencies are already installed, including the Cypress binary (the e2e CDN is allow-listed).
 Browser automation is available: the chrome-devtools tools drive an in-sandbox headless Chrome. Start the dev server (`pnpm start`) and navigate to http://localhost:3000 to load and inspect the app.
+The `chrome-devtools-mcp` plugin shows an "enabled in project settings but not installed" warning in /doctor here — that is EXPECTED and harmless. Do NOT install or enable it (it needs a Chrome the sandbox can't provide); the in-sandbox server above already gives you the chrome-devtools tools.
 A read-only copy of the host's working tree is also at /run/sandbox/source for any UNPUSHED local changes; pull them with `git pull /run/sandbox/source <branch>`.
 EOF
 

--- a/vite-cypress.config.ts
+++ b/vite-cypress.config.ts
@@ -1,6 +1,6 @@
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
-import { importAliases } from './vitest.config'
+import { importAliases } from './import-aliases'
 
 // This config is used for Cypress component testing
 

--- a/vite-extensions.config.mts
+++ b/vite-extensions.config.mts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite'
-import { importAliases } from './vitest.config'
+import { importAliases } from './import-aliases'
 
 const viteConfig = defineConfig(async (configEnv) => {
     const { mode } = configEnv

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,19 +1,7 @@
-import path from 'node:path'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 import { configDefaults } from 'vitest/config'
-
-export const importAliases = {
-    '@types': path.resolve(__dirname, 'src/types/index.ts'),
-    '@hooks': path.resolve(__dirname, 'src/hooks/index.ts'),
-    '@api': path.resolve(__dirname, 'src/api'),
-    '@assets': path.resolve(__dirname, 'src/assets'),
-    '@components': path.resolve(__dirname, 'src/components'),
-    '@constants': path.resolve(__dirname, 'src/constants'),
-    '@modules': path.resolve(__dirname, 'src/modules'),
-    '@store': path.resolve(__dirname, 'src/store'),
-    '@test-utils': path.resolve(__dirname, 'src/test-utils'),
-}
+import { importAliases } from './import-aliases'
 
 // https://vitejs.dev/config/
 


### PR DESCRIPTION
- Accept the Claude Chrome plugin cannot run in the sandbox and that this will show up as a problem when running `/doctor` in Claude. Add some instructions to prevent Claude from attempting to install the plugin and use the plain MCP server instead. This can be fixed once Chrome is made available for ARM64 Linux
- Get rid of a vitest warning
