### PR TITLE
fix: improve layout resize handling [DHIS2-21641]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-06-26T08:33:32.300Z\n"
-"PO-Revision-Date: 2026-06-26T08:33:32.300Z\n"
+"POT-Creation-Date: 2026-06-29T08:16:30.297Z\n"
+"PO-Revision-Date: 2026-06-29T08:16:30.299Z\n"
 
 msgid "Some dimensions cannot be used in a {{visTypeName}}: {{list}}."
 msgstr "Some dimensions cannot be used in a {{visTypeName}}: {{list}}."
@@ -788,6 +788,9 @@ msgstr "Show interpretations and details"
 
 msgid "View"
 msgstr "View"
+
+msgid "Resize layout to fit"
+msgstr "Resize layout to fit"
 
 msgid "Reset dimensions sidebar width"
 msgstr "Reset dimensions sidebar width"

--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -269,6 +269,97 @@ describe('<LayoutPanel />', () => {
             })
     })
 
+    /* Storage key the axes resize hook reads/writes (private to axes.tsx). A
+     * stored value is treated as a user-defined height. */
+    const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
+
+    const pivotOptions = (layout: {
+        columns: string[]
+        rows: string[]
+        filters: string[]
+    }) =>
+        createMockOptions({
+            dimensionSelection: {
+                ...mockOptions.partialStore?.preloadedState.dimensionSelection,
+                dataSourceId: 'test-id',
+            },
+            visUiConfig: {
+                ...visUiConfigInitialState,
+                visualizationType: 'PIVOT_TABLE',
+                outputType: 'EVENT',
+                layout,
+                itemsByDimension: { ou: ['orgUnit1'] },
+            },
+        })
+
+    const getAxisRowTracks = () =>
+        cy.get('[class*="axisContainer"]').then(($el) => {
+            const tracks = getComputedStyle($el[0])
+                .gridTemplateRows.split(' ')
+                .map(parseFloat)
+
+            expect(tracks, 'two row tracks').to.have.length(2)
+
+            return tracks
+        })
+
+    it('PIVOT_TABLE sizes columns and rows to their own content in content-height mode', () => {
+        localStorage.removeItem(AXES_HEIGHT_STORAGE_KEY)
+        cy.viewport(420, 700)
+
+        cy.mount(
+            <MockAppWrapper
+                {...pivotOptions({
+                    columns: [
+                        'ou',
+                        'mchInfantFeeding',
+                        'mchNutrition',
+                        'ageAtVisit',
+                        'genderId',
+                    ],
+                    rows: [],
+                    filters: [],
+                })}
+            >
+                <LayoutPanel />
+            </MockAppWrapper>
+        )
+
+        cy.getByDataTest('axis-columns').should('be.visible')
+
+        // The chip-heavy columns axis is taller than the empty rows axis — the
+        // rows track is not dragged up to match (the equal-height bug).
+        getAxisRowTracks().then(([columnsTrack, rowsTrack]) => {
+            expect(columnsTrack).to.be.greaterThan(rowsTrack + 20)
+        })
+    })
+
+    it('PIVOT_TABLE mirrors columns and rows when a user-defined height exceeds the content', () => {
+        localStorage.setItem(AXES_HEIGHT_STORAGE_KEY, '600')
+        cy.viewport(1000, 800)
+
+        cy.mount(
+            <MockAppWrapper
+                {...pivotOptions({
+                    columns: ['ou', 'mchInfantFeeding'],
+                    rows: ['genderId'],
+                    filters: [],
+                })}
+            >
+                <LayoutPanel />
+            </MockAppWrapper>
+        )
+
+        cy.getByDataTest('axis-columns').should('be.visible')
+
+        // The stored 600px height far exceeds the content, so the extra space is
+        // shared equally: the two row tracks are the same height.
+        getAxisRowTracks().then(([columnsTrack, rowsTrack]) => {
+            expect(columnsTrack).to.be.greaterThan(100)
+            expect(Math.abs(columnsTrack - rowsTrack)).to.be.lessThan(2)
+        })
+    })
+
     it('renders the PIVOT_TABLE update buttons in the order enrollment, event, custom value', () => {
         const layoutPanelMockOptions = createMockOptions({
             dimensionSelection: {

--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -11,16 +11,16 @@ import {
     loaderSlice,
     initialState as loaderSliceInitialState,
 } from '@store/loader-slice'
-import { uiSlice, initialState as uiSliceInitialState } from '@store/ui-slice'
+import {
+    uiSlice,
+    initialState as uiSliceInitialState,
+    type LayoutPanelHeight,
+} from '@store/ui-slice'
 import {
     visUiConfigSlice,
     initialState as visUiConfigInitialState,
 } from '@store/vis-ui-config-slice'
 import { MockAppWrapper, type MockOptions } from '@test-utils/app-wrapper'
-import {
-    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
-    type LayoutPanelHeight,
-} from '../constants'
 import { LayoutPanel } from '../layout-panel'
 
 const mockOptions: MockOptions = {
@@ -279,7 +279,7 @@ describe('<LayoutPanel />', () => {
             rows: string[]
             filters: string[]
         },
-        layoutPanelHeight: LayoutPanelHeight = LAYOUT_PANEL_HEIGHT_AUTO_FIT
+        layoutPanelHeight: LayoutPanelHeight = 'AUTO_FIT'
     ) =>
         createMockOptions({
             dimensionSelection: {
@@ -333,8 +333,8 @@ describe('<LayoutPanel />', () => {
 
         cy.getByDataTest('axis-columns').should('be.visible')
 
-        // The chip-heavy columns axis is taller than the empty rows axis — the
-        // rows track is not dragged up to match (the equal-height bug).
+        // In content mode each axis keeps its own height: the chip-heavy columns
+        // axis is taller than the empty rows axis, which stays short.
         getAxisRowTracks().then(([columnsTrack, rowsTrack]) => {
             expect(columnsTrack).to.be.greaterThan(rowsTrack + 20)
         })

--- a/src/components/layout-panel/__tests__/layout-panel.cy.tsx
+++ b/src/components/layout-panel/__tests__/layout-panel.cy.tsx
@@ -17,6 +17,10 @@ import {
     initialState as visUiConfigInitialState,
 } from '@store/vis-ui-config-slice'
 import { MockAppWrapper, type MockOptions } from '@test-utils/app-wrapper'
+import {
+    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
+    type LayoutPanelHeight,
+} from '../constants'
 import { LayoutPanel } from '../layout-panel'
 
 const mockOptions: MockOptions = {
@@ -269,19 +273,22 @@ describe('<LayoutPanel />', () => {
             })
     })
 
-    /* Storage key the axes resize hook reads/writes (private to axes.tsx). A
-     * stored value is treated as a user-defined height. */
-    const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
-
-    const pivotOptions = (layout: {
-        columns: string[]
-        rows: string[]
-        filters: string[]
-    }) =>
+    const pivotOptions = (
+        layout: {
+            columns: string[]
+            rows: string[]
+            filters: string[]
+        },
+        layoutPanelHeight: LayoutPanelHeight = LAYOUT_PANEL_HEIGHT_AUTO_FIT
+    ) =>
         createMockOptions({
             dimensionSelection: {
                 ...mockOptions.partialStore?.preloadedState.dimensionSelection,
                 dataSourceId: 'test-id',
+            },
+            ui: {
+                ...uiSliceInitialState,
+                layoutPanelHeight,
             },
             visUiConfig: {
                 ...visUiConfigInitialState,
@@ -304,7 +311,6 @@ describe('<LayoutPanel />', () => {
         })
 
     it('PIVOT_TABLE sizes columns and rows to their own content in content-height mode', () => {
-        localStorage.removeItem(AXES_HEIGHT_STORAGE_KEY)
         cy.viewport(420, 700)
 
         cy.mount(
@@ -335,16 +341,18 @@ describe('<LayoutPanel />', () => {
     })
 
     it('PIVOT_TABLE mirrors columns and rows when a user-defined height exceeds the content', () => {
-        localStorage.setItem(AXES_HEIGHT_STORAGE_KEY, '600')
         cy.viewport(1000, 800)
 
         cy.mount(
             <MockAppWrapper
-                {...pivotOptions({
-                    columns: ['ou', 'mchInfantFeeding'],
-                    rows: ['genderId'],
-                    filters: [],
-                })}
+                {...pivotOptions(
+                    {
+                        columns: ['ou', 'mchInfantFeeding'],
+                        rows: ['genderId'],
+                        filters: [],
+                    },
+                    600
+                )}
             >
                 <LayoutPanel />
             </MockAppWrapper>
@@ -352,8 +360,8 @@ describe('<LayoutPanel />', () => {
 
         cy.getByDataTest('axis-columns').should('be.visible')
 
-        // The stored 600px height far exceeds the content, so the extra space is
-        // shared equally: the two row tracks are the same height.
+        // The user-set 600px height far exceeds the content, so the extra space
+        // is shared equally: the two row tracks are the same height.
         getAxisRowTracks().then(([columnsTrack, rowsTrack]) => {
             expect(columnsTrack).to.be.greaterThan(100)
             expect(Math.abs(columnsTrack - rowsTrack)).to.be.lessThan(2)

--- a/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
+++ b/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
@@ -182,38 +182,11 @@ describe('useResizeHandle', () => {
         expect(result.current.minReached).toBe(true)
     })
 
-    it('can be expanded past the content height it had at mount time', () => {
+    it('can be dragged past the content height, up to the max', () => {
         const target = createTarget()
         const { result } = renderResizeHandle({ min: 58, max: 300 })
 
-        // Mounts short (few chips).
-        const node = createNode(58)
-        act(() => {
-            result.current.containerRef(node)
-        })
-
-        // Chips are added: the live content grows, but containerRef is NOT
-        // called again (the bug was the cap staying stuck at the mount value).
-        ;(node as unknown as { scrollHeight: number }).scrollHeight = 220
-
-        act(() => {
-            result.current.eventHandlers.onPointerDown(
-                createPointerEvent(58, target)
-            )
-        })
-        act(() => {
-            result.current.eventHandlers.onPointerMove(
-                createPointerEvent(400, target)
-            )
-        })
-
-        expect(result.current.size).toBe(220)
-    })
-
-    it('stops dragging at the live content height', () => {
-        const target = createTarget()
-        const { result } = renderResizeHandle({ min: 58, max: 300 })
-
+        // Mounts short (few chips); the content height is 120.
         act(() => {
             result.current.containerRef(createNode(120))
         })
@@ -222,13 +195,29 @@ describe('useResizeHandle', () => {
                 createPointerEvent(120, target)
             )
         })
+        // Drag well past the content height: the panel keeps growing instead of
+        // stopping at the content, capped only by the max.
         act(() => {
             result.current.eventHandlers.onPointerMove(
                 createPointerEvent(400, target)
             )
         })
 
-        expect(result.current.size).toBe(120)
+        expect(result.current.size).toBe(300)
+    })
+
+    it('honors a stored size taller than the content height', () => {
+        localStorage.setItem(STORAGE_KEY, '250')
+
+        const { result } = renderResizeHandle({ min: 58, max: 300 })
+
+        // Content only needs 100, but the stored size is the user's choice and
+        // is not shrunk back down to the content height.
+        act(() => {
+            result.current.containerRef(createNode(100))
+        })
+
+        expect(result.current.size).toBe(250)
     })
 
     it('never drags taller than the max even with a large content', () => {
@@ -288,6 +277,28 @@ describe('useResizeHandle', () => {
         expect(result.current.size).toBe(60)
     })
 
+    it('resetToContentHeight discards the stored size and refits to content', () => {
+        localStorage.setItem(STORAGE_KEY, '250')
+
+        const { result } = renderResizeHandle({ min: 58, max: 300 })
+
+        const node = createNode(120)
+        act(() => {
+            result.current.containerRef(node)
+        })
+        // Honors the stored height initially.
+        expect(result.current.size).toBe(250)
+
+        act(() => {
+            result.current.resetToContentHeight()
+        })
+
+        // The user's stored height is cleared and the panel refits to the live
+        // content height. This is also the double-click handle behavior.
+        expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+        expect(result.current.size).toBe(120)
+    })
+
     it('re-fits to the new content when the layout changes', () => {
         const { result, rerender } = renderResizeHandle({
             min: 56,
@@ -327,6 +338,30 @@ describe('useResizeHandle', () => {
         rerender({ contentKey: 'b' })
 
         expect(result.current.size).toBe(90)
+    })
+
+    it('does not re-fit when the layout changes if the user has set a height', () => {
+        localStorage.setItem(STORAGE_KEY, '250')
+
+        const { result, rerender } = renderResizeHandle({
+            min: 56,
+            max: 300,
+            contentKey: 'a',
+        })
+
+        const node = createNode(100)
+        act(() => {
+            result.current.containerRef(node)
+        })
+        // Honors the user's stored height, not the content height.
+        expect(result.current.size).toBe(250)
+
+        // A chip is added: the live content grows, but the user-defined height
+        // holds and the content scrolls within it.
+        ;(node as unknown as { scrollHeight: number }).scrollHeight = 200
+        rerender({ contentKey: 'b' })
+
+        expect(result.current.size).toBe(250)
     })
 
     it('persists the size to local storage on pointer up', () => {

--- a/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
+++ b/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
@@ -1,6 +1,19 @@
-import { act, renderHook } from '@testing-library/react'
+import { uiSlice } from '@store/ui-slice'
+import { renderHookWithReduxStoreProvider } from '@test-utils/render-with-redux-store-provider'
+import { setupStore } from '@test-utils/setup-store'
+import { act } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
+    type LayoutPanelHeight,
+} from '../constants'
+import { setLayoutPanelHeightToLocalStorage } from '../local-storage'
 import { useResizeHandle } from '../use-resize-handle'
+
+vi.mock('../local-storage', () => ({
+    getLayoutPanelHeightFromLocalStorage: vi.fn(() => 'AUTO_FIT'),
+    setLayoutPanelHeightToLocalStorage: vi.fn(),
+}))
 
 type FakeTarget = {
     setPointerCapture: ReturnType<typeof vi.fn>
@@ -32,38 +45,60 @@ const createNode = (scrollHeight: number, clientHeight = scrollHeight) =>
         clientWidth: 0,
     }) as unknown as HTMLDivElement
 
-const STORAGE_KEY = 'test.axesHeight'
-
+/* The user-set height now lives in the Redux UI slice (`layoutPanelHeight`),
+ * not localStorage; seed it via the store. */
 const renderResizeHandle = (
     overrides: {
         min?: number
         max?: number
         collapseThreshold?: number
         contentKey?: string
+        layoutPanelHeight?: LayoutPanelHeight
     } = {}
-) =>
-    renderHook(
-        (props: { contentKey: string }) =>
-            useResizeHandle({
-                orientation: 'horizontal',
-                storageKey: STORAGE_KEY,
-                min: overrides.min ?? 56,
-                collapseThreshold: overrides.collapseThreshold ?? 24,
-                contentKey: props.contentKey,
-                max: overrides.max ?? 300,
-            }),
-        { initialProps: { contentKey: overrides.contentKey ?? 'a' } }
+) => {
+    const store = setupStore(
+        { [uiSlice.name]: uiSlice.reducer },
+        {
+            [uiSlice.name]: {
+                ...uiSlice.getInitialState(),
+                layoutPanelHeight:
+                    overrides.layoutPanelHeight ?? LAYOUT_PANEL_HEIGHT_AUTO_FIT,
+            },
+        }
     )
 
+    const contentKeyRef = { current: overrides.contentKey ?? 'a' }
+
+    const utils = renderHookWithReduxStoreProvider(
+        () =>
+            useResizeHandle({
+                orientation: 'horizontal',
+                min: overrides.min ?? 56,
+                collapseThreshold: overrides.collapseThreshold ?? 24,
+                contentKey: contentKeyRef.current,
+                max: overrides.max ?? 300,
+            }),
+        store
+    )
+
+    const setContentKey = (contentKey: string) => {
+        contentKeyRef.current = contentKey
+        utils.rerender()
+    }
+
+    return { ...utils, setContentKey }
+}
+
 afterEach(() => {
-    localStorage.clear()
+    vi.clearAllMocks()
 })
 
 describe('useResizeHandle', () => {
     it('lifts a stored size that is below the min up to the min', () => {
-        localStorage.setItem(STORAGE_KEY, '30')
-
-        const { result } = renderResizeHandle({ min: 116 })
+        const { result } = renderResizeHandle({
+            min: 116,
+            layoutPanelHeight: 30,
+        })
 
         act(() => {
             result.current.containerRef(createNode(200))
@@ -206,13 +241,15 @@ describe('useResizeHandle', () => {
         expect(result.current.size).toBe(300)
     })
 
-    it('honors a stored size taller than the content height', () => {
-        localStorage.setItem(STORAGE_KEY, '250')
+    it('honors a user-set height taller than the content height', () => {
+        const { result } = renderResizeHandle({
+            min: 58,
+            max: 300,
+            layoutPanelHeight: 250,
+        })
 
-        const { result } = renderResizeHandle({ min: 58, max: 300 })
-
-        // Content only needs 100, but the stored size is the user's choice and
-        // is not shrunk back down to the content height.
+        // Content only needs 100, but the user-set height is their choice and is
+        // not shrunk back down to the content height.
         act(() => {
             result.current.containerRef(createNode(100))
         })
@@ -277,30 +314,57 @@ describe('useResizeHandle', () => {
         expect(result.current.size).toBe(60)
     })
 
-    it('resetToContentHeight discards the stored size and refits to content', () => {
-        localStorage.setItem(STORAGE_KEY, '250')
-
-        const { result } = renderResizeHandle({ min: 58, max: 300 })
-
-        const node = createNode(120)
-        act(() => {
-            result.current.containerRef(node)
+    it('resetToContentHeight publishes AUTO_FIT and refits to content', () => {
+        const { result, store } = renderResizeHandle({
+            min: 58,
+            max: 300,
+            layoutPanelHeight: 250,
         })
-        // Honors the stored height initially.
+
+        act(() => {
+            result.current.containerRef(createNode(120))
+        })
+        // Honors the user-set height initially.
         expect(result.current.size).toBe(250)
 
         act(() => {
             result.current.resetToContentHeight()
         })
 
-        // The user's stored height is cleared and the panel refits to the live
-        // content height. This is also the double-click handle behavior.
-        expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+        // The user-set height is cleared (AUTO_FIT in the store and localStorage)
+        // and the panel refits to the live content. This is also the double-click
+        // handle behavior.
+        expect(store.getState().ui.layoutPanelHeight).toBe(
+            LAYOUT_PANEL_HEIGHT_AUTO_FIT
+        )
+        expect(setLayoutPanelHeightToLocalStorage).toHaveBeenCalledWith(
+            LAYOUT_PANEL_HEIGHT_AUTO_FIT
+        )
+        expect(result.current.size).toBe(120)
+    })
+
+    it('refits when AUTO_FIT is published from elsewhere (View menu)', () => {
+        const { result, store } = renderResizeHandle({
+            min: 58,
+            max: 300,
+            layoutPanelHeight: 250,
+        })
+
+        act(() => {
+            result.current.containerRef(createNode(120))
+        })
+        expect(result.current.size).toBe(250)
+
+        // The View menu dispatches AUTO_FIT directly (not via the hook).
+        act(() => {
+            store.dispatch(uiSlice.actions.setUiLayoutPanelHeight('AUTO_FIT'))
+        })
+
         expect(result.current.size).toBe(120)
     })
 
     it('re-fits to the new content when the layout changes', () => {
-        const { result, rerender } = renderResizeHandle({
+        const { result, setContentKey } = renderResizeHandle({
             min: 56,
             max: 300,
             contentKey: 'a',
@@ -314,13 +378,15 @@ describe('useResizeHandle', () => {
 
         // A chip is added: the live content grows to 200.
         ;(node as unknown as { scrollHeight: number }).scrollHeight = 200
-        rerender({ contentKey: 'b' })
+        act(() => {
+            setContentKey('b')
+        })
 
         expect(result.current.size).toBe(200)
     })
 
     it('re-fits smaller when the layout shrinks', () => {
-        const { result, rerender } = renderResizeHandle({
+        const { result, setContentKey } = renderResizeHandle({
             min: 56,
             max: 300,
             contentKey: 'a',
@@ -335,38 +401,41 @@ describe('useResizeHandle', () => {
         // Chips are removed: the live content shrinks to 90. The re-fit measures
         // the auto content, so the stale larger size does not skew it.
         ;(node as unknown as { scrollHeight: number }).scrollHeight = 90
-        rerender({ contentKey: 'b' })
+        act(() => {
+            setContentKey('b')
+        })
 
         expect(result.current.size).toBe(90)
     })
 
     it('does not re-fit when the layout changes if the user has set a height', () => {
-        localStorage.setItem(STORAGE_KEY, '250')
-
-        const { result, rerender } = renderResizeHandle({
+        const { result, setContentKey } = renderResizeHandle({
             min: 56,
             max: 300,
             contentKey: 'a',
+            layoutPanelHeight: 250,
         })
 
         const node = createNode(100)
         act(() => {
             result.current.containerRef(node)
         })
-        // Honors the user's stored height, not the content height.
+        // Honors the user-set height, not the content height.
         expect(result.current.size).toBe(250)
 
-        // A chip is added: the live content grows, but the user-defined height
-        // holds and the content scrolls within it.
+        // A chip is added: the live content grows, but the user-set height holds
+        // and the content scrolls within it.
         ;(node as unknown as { scrollHeight: number }).scrollHeight = 200
-        rerender({ contentKey: 'b' })
+        act(() => {
+            setContentKey('b')
+        })
 
         expect(result.current.size).toBe(250)
     })
 
-    it('persists the size to local storage on pointer up', () => {
+    it('persists the size to the store and localStorage on pointer up', () => {
         const target = createTarget()
-        const { result } = renderResizeHandle({ min: 56, max: 300 })
+        const { result, store } = renderResizeHandle({ min: 56, max: 300 })
 
         // Initial size is the content height (200).
         act(() => {
@@ -378,6 +447,7 @@ describe('useResizeHandle', () => {
             )
         })
 
-        expect(localStorage.getItem(STORAGE_KEY)).toBe('200')
+        expect(store.getState().ui.layoutPanelHeight).toBe(200)
+        expect(setLayoutPanelHeightToLocalStorage).toHaveBeenCalledWith(200)
     })
 })

--- a/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
+++ b/src/components/layout-panel/__tests__/use-resize-handle.spec.ts
@@ -1,12 +1,8 @@
-import { uiSlice } from '@store/ui-slice'
+import { uiSlice, type LayoutPanelHeight } from '@store/ui-slice'
 import { renderHookWithReduxStoreProvider } from '@test-utils/render-with-redux-store-provider'
 import { setupStore } from '@test-utils/setup-store'
 import { act } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import {
-    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
-    type LayoutPanelHeight,
-} from '../constants'
 import { setLayoutPanelHeightToLocalStorage } from '../local-storage'
 import { useResizeHandle } from '../use-resize-handle'
 
@@ -61,8 +57,7 @@ const renderResizeHandle = (
         {
             [uiSlice.name]: {
                 ...uiSlice.getInitialState(),
-                layoutPanelHeight:
-                    overrides.layoutPanelHeight ?? LAYOUT_PANEL_HEIGHT_AUTO_FIT,
+                layoutPanelHeight: overrides.layoutPanelHeight ?? 'AUTO_FIT',
             },
         }
     )
@@ -334,11 +329,9 @@ describe('useResizeHandle', () => {
         // The user-set height is cleared (AUTO_FIT in the store and localStorage)
         // and the panel refits to the live content. This is also the double-click
         // handle behavior.
-        expect(store.getState().ui.layoutPanelHeight).toBe(
-            LAYOUT_PANEL_HEIGHT_AUTO_FIT
-        )
+        expect(store.getState().ui.layoutPanelHeight).toBe('AUTO_FIT')
         expect(setLayoutPanelHeightToLocalStorage).toHaveBeenCalledWith(
-            LAYOUT_PANEL_HEIGHT_AUTO_FIT
+            'AUTO_FIT'
         )
         expect(result.current.size).toBe(120)
     })

--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -8,6 +8,7 @@ import { getDataSourceId } from '@store/dimensions-selection-slice'
 import { getIsVisualizationLoading } from '@store/loader-slice'
 import {
     getUiLayoutPanelExpanded,
+    getUiLayoutPanelHeightResetCounter,
     toggleUiLayoutPanelExpanded,
 } from '@store/ui-slice'
 import {
@@ -15,7 +16,7 @@ import {
     getVisUiConfigVisualizationType,
 } from '@store/vis-ui-config-slice'
 import cx from 'classnames'
-import { useEffect, useMemo, type FC } from 'react'
+import { useEffect, useMemo, useRef, type FC } from 'react'
 import { useWindowSize } from 'usehooks-ts'
 import { Axis } from './axis/axis'
 import { LayoutBlockedOverlay } from './layout-blocked-overlay'
@@ -72,12 +73,15 @@ export const Axes: FC = () => {
     const isVisualizationLoading = useAppSelector(getIsVisualizationLoading)
     const visualizationType = useAppSelector(getVisUiConfigVisualizationType)
     const { columns, filters, rows } = useAppSelector(getVisUiConfigLayout)
+    const heightResetCounter = useAppSelector(
+        getUiLayoutPanelHeightResetCounter
+    )
     const { height } = useWindowSize()
     const { active } = useDndContext()
     const activeDragData = getActiveDragData(active)
 
     const maxHeight = useMemo(
-        () => height * 0.2, // fallback to 20vh
+        () => height * 0.8, // fallback to 80vh
         [height]
     )
 
@@ -103,6 +107,7 @@ export const Axes: FC = () => {
         isDragging,
         minReached,
         resetSize,
+        resetToContentHeight,
         size,
     } = useResizeHandle({
         orientation: 'horizontal',
@@ -124,6 +129,16 @@ export const Axes: FC = () => {
             resetSize()
         }
     }, [isVisualizationLoading, resetSize])
+
+    /* "Resize layout to fit" in the View menu bumps a counter; refit to content
+     * on each change. The ref guards against firing on mount. */
+    const prevHeightResetCounterRef = useRef(heightResetCounter)
+    useEffect(() => {
+        if (heightResetCounter !== prevHeightResetCounterRef.current) {
+            prevHeightResetCounterRef.current = heightResetCounter
+            resetToContentHeight()
+        }
+    }, [heightResetCounter, resetToContentHeight])
 
     if (isVisualizationLoading) {
         return <LoadingSkeletons />

--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -161,6 +161,7 @@ export const Axes: FC = () => {
                         className={cx(classes.axisContainer, {
                             [classes.lineList]:
                                 visualizationType === 'LINE_LIST',
+                            [classes.fixedHeight]: size !== null,
                         })}
                         ref={containerRef}
                     >

--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -8,7 +8,6 @@ import { getDataSourceId } from '@store/dimensions-selection-slice'
 import { getIsVisualizationLoading } from '@store/loader-slice'
 import {
     getUiLayoutPanelExpanded,
-    getUiLayoutPanelHeightResetCounter,
     toggleUiLayoutPanelExpanded,
 } from '@store/ui-slice'
 import {
@@ -16,7 +15,7 @@ import {
     getVisUiConfigVisualizationType,
 } from '@store/vis-ui-config-slice'
 import cx from 'classnames'
-import { useEffect, useMemo, useRef, type FC } from 'react'
+import { useEffect, useMemo, type FC } from 'react'
 import { useWindowSize } from 'usehooks-ts'
 import { Axis } from './axis/axis'
 import { LayoutBlockedOverlay } from './layout-blocked-overlay'
@@ -55,8 +54,6 @@ const LoadingSkeletons: FC = () => (
     </div>
 )
 
-const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
-
 /* Height that keeps a single axis row (label + min content area + padding)
  * fully visible. LINE_LIST stacks one such row (columns/filters); PIVOT_TABLE
  * stacks two (columns over rows), so its min is twice as tall. */
@@ -73,9 +70,6 @@ export const Axes: FC = () => {
     const isVisualizationLoading = useAppSelector(getIsVisualizationLoading)
     const visualizationType = useAppSelector(getVisUiConfigVisualizationType)
     const { columns, filters, rows } = useAppSelector(getVisUiConfigLayout)
-    const heightResetCounter = useAppSelector(
-        getUiLayoutPanelHeightResetCounter
-    )
     const { height } = useWindowSize()
     const { active } = useDndContext()
     const activeDragData = getActiveDragData(active)
@@ -107,11 +101,9 @@ export const Axes: FC = () => {
         isDragging,
         minReached,
         resetSize,
-        resetToContentHeight,
         size,
     } = useResizeHandle({
         orientation: 'horizontal',
-        storageKey: AXES_HEIGHT_STORAGE_KEY,
         min: minHeight,
         collapseThreshold: AXES_COLLAPSE_THRESHOLD,
         contentKey,
@@ -129,16 +121,6 @@ export const Axes: FC = () => {
             resetSize()
         }
     }, [isVisualizationLoading, resetSize])
-
-    /* "Resize layout to fit" in the View menu bumps a counter; refit to content
-     * on each change. The ref guards against firing on mount. */
-    const prevHeightResetCounterRef = useRef(heightResetCounter)
-    useEffect(() => {
-        if (heightResetCounter !== prevHeightResetCounterRef.current) {
-            prevHeightResetCounterRef.current = heightResetCounter
-            resetToContentHeight()
-        }
-    }, [heightResetCounter, resetToContentHeight])
 
     if (isVisualizationLoading) {
         return <LoadingSkeletons />

--- a/src/components/layout-panel/axis/axis.tsx
+++ b/src/components/layout-panel/axis/axis.tsx
@@ -42,9 +42,8 @@ export const Axis: FC<AxisProps> = ({ axisId, dimensionIds = EMPTY_ARRAY }) => {
         disabled,
     })
 
-    /* The collision detector resolves a drop over a populated axis to one of its
-     * chips, not to the axis container, so the container's own `isOver` only
-     * fires on an empty axis. Read the active drop target's axis instead — both
+    /*
+     * Read the active drop target's axis — both
      * chip sortables and the axis container carry it — so the whole axis
      * highlights whether the drop lands on a chip or the empty area. */
     const overData = over?.data.current

--- a/src/components/layout-panel/axis/axis.tsx
+++ b/src/components/layout-panel/axis/axis.tsx
@@ -30,38 +30,48 @@ export const Axis: FC<AxisProps> = ({ axisId, dimensionIds = EMPTY_ARRAY }) => {
         [axisId]
     )
 
-    const { active } = useDndContext()
+    const { active, over } = useDndContext()
     const disabled = useMemo(
         () => getActiveDragData(active)?.isLayoutBlocked ?? false,
         [active]
     )
 
-    const { setNodeRef, isOver } = useDroppable({
+    const { setNodeRef } = useDroppable({
         id: axisId,
         data: axisContainerData,
         disabled,
     })
 
+    /* The collision detector resolves a drop over a populated axis to one of its
+     * chips, not to the axis container, so the container's own `isOver` only
+     * fires on an empty axis. Read the active drop target's axis instead — both
+     * chip sortables and the axis container carry it — so the whole axis
+     * highlights whether the drop lands on a chip or the empty area. */
+    const overData = over?.data.current
+    const isActiveDropTarget =
+        overData !== undefined && 'axis' in overData && overData.axis === axisId
+
     return (
         <SortableContext id={axisId} items={dimensionIds}>
             <div
+                ref={setNodeRef}
                 className={cx(classes.container, {
                     [classes.columns]: axisId === 'columns',
                     [classes.rows]: axisId === 'rows',
                     [classes.filters]: axisId === 'filters',
+                    [classes.activeDropTarget]: isActiveDropTarget,
                 })}
                 data-test={`axis-${axisId}`}
                 aria-disabled={disabled || undefined}
             >
                 <div className={classes.label}>{getAxisName(axisId)}</div>
                 <div
-                    ref={setNodeRef}
                     className={classes.content}
                     data-test={`axis-content-${axisId}`}
                 >
                     {dimensions.length === 0 ? (
                         <div className={classes.emptyAxisInsertMarkerAnchor}>
-                            {isOver && (
+                            {isActiveDropTarget && (
                                 <span className={insertMarkerClasses.marker} />
                             )}
                         </div>

--- a/src/components/layout-panel/axis/axis.tsx
+++ b/src/components/layout-panel/axis/axis.tsx
@@ -69,21 +69,19 @@ export const Axis: FC<AxisProps> = ({ axisId, dimensionIds = EMPTY_ARRAY }) => {
                     className={classes.content}
                     data-test={`axis-content-${axisId}`}
                 >
-                    {dimensions.length === 0 ? (
+                    {dimensions.length === 0 && isActiveDropTarget && (
                         <div className={classes.emptyAxisInsertMarkerAnchor}>
-                            {isActiveDropTarget && (
-                                <span className={insertMarkerClasses.marker} />
-                            )}
+                            <span className={insertMarkerClasses.marker} />
                         </div>
-                    ) : (
+                    )}
+                    {dimensions.length > 0 &&
                         dimensions.map((dimension) => (
                             <Chip
                                 key={dimension.id}
                                 dimension={dimension}
                                 axisId={axisId}
                             />
-                        ))
-                    )}
+                        ))}
                 </div>
             </div>
         </SortableContext>

--- a/src/components/layout-panel/axis/styles/axis.module.css
+++ b/src/components/layout-panel/axis/styles/axis.module.css
@@ -19,6 +19,17 @@
     border-inline-start: 1px solid var(--colors-grey300);
 }
 
+.container.activeDropTarget {
+    box-shadow:
+        inset 0 0 0 1px
+            color-mix(in srgb, var(--colors-blue400), transparent 65%),
+        inset 0 0 8px color-mix(in srgb, var(--colors-blue400), transparent 85%);
+}
+
+.container.activeDropTarget .label {
+    color: var(--colors-grey900);
+}
+
 .label {
     padding: 2px 0;
     font-size: 10px;
@@ -46,10 +57,6 @@
     flex-wrap: wrap;
     flex: 1;
     min-block-size: 32px;
-    /* One empty chip-row of drop space below the last chip. It lives inside the
-     * (scrollable) droppable content, so it stays reachable even when the panel
-     * is capped at its max height and scrolls. */
-    padding-block-end: 24px;
 }
 
 .emptyAxisInsertMarkerAnchor {

--- a/src/components/layout-panel/constants.ts
+++ b/src/components/layout-panel/constants.ts
@@ -1,0 +1,9 @@
+export const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
+
+/* Sentinel for "no user-set height": the panel fits its content. Stored in the
+ * UI slice alongside numeric user-set heights, so the height is
+ * `number | typeof LAYOUT_PANEL_HEIGHT_AUTO_FIT`. A named sentinel reads more
+ * clearly at call sites than a bare `null`. */
+export const LAYOUT_PANEL_HEIGHT_AUTO_FIT = 'AUTO_FIT'
+
+export type LayoutPanelHeight = number | typeof LAYOUT_PANEL_HEIGHT_AUTO_FIT

--- a/src/components/layout-panel/constants.ts
+++ b/src/components/layout-panel/constants.ts
@@ -1,9 +1,1 @@
 export const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
-
-/* Sentinel for "no user-set height": the panel fits its content. Stored in the
- * UI slice alongside numeric user-set heights, so the height is
- * `number | typeof LAYOUT_PANEL_HEIGHT_AUTO_FIT`. A named sentinel reads more
- * clearly at call sites than a bare `null`. */
-export const LAYOUT_PANEL_HEIGHT_AUTO_FIT = 'AUTO_FIT'
-
-export type LayoutPanelHeight = number | typeof LAYOUT_PANEL_HEIGHT_AUTO_FIT

--- a/src/components/layout-panel/constants.ts
+++ b/src/components/layout-panel/constants.ts
@@ -1,1 +1,0 @@
-export const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'

--- a/src/components/layout-panel/local-storage.ts
+++ b/src/components/layout-panel/local-storage.ts
@@ -1,0 +1,34 @@
+import {
+    AXES_HEIGHT_STORAGE_KEY,
+    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
+    type LayoutPanelHeight,
+} from './constants'
+
+export const getLayoutPanelHeightFromLocalStorage = (): LayoutPanelHeight => {
+    const stored = globalThis.localStorage.getItem(AXES_HEIGHT_STORAGE_KEY)
+
+    if (stored === null) {
+        return LAYOUT_PANEL_HEIGHT_AUTO_FIT
+    }
+
+    const parsed = Number.parseInt(stored)
+
+    return Number.isFinite(parsed) ? parsed : LAYOUT_PANEL_HEIGHT_AUTO_FIT
+}
+
+export const setLayoutPanelHeightToLocalStorage = (
+    height: LayoutPanelHeight
+): void => {
+    try {
+        if (height === LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
+            globalThis.localStorage.removeItem(AXES_HEIGHT_STORAGE_KEY)
+        } else {
+            globalThis.localStorage.setItem(
+                AXES_HEIGHT_STORAGE_KEY,
+                String(Math.round(height))
+            )
+        }
+    } catch {
+        // ignore
+    }
+}

--- a/src/components/layout-panel/local-storage.ts
+++ b/src/components/layout-panel/local-storage.ts
@@ -1,26 +1,23 @@
-import {
-    AXES_HEIGHT_STORAGE_KEY,
-    LAYOUT_PANEL_HEIGHT_AUTO_FIT,
-    type LayoutPanelHeight,
-} from './constants'
+import type { LayoutPanelHeight } from '@store/ui-slice'
+import { AXES_HEIGHT_STORAGE_KEY } from './constants'
 
 export const getLayoutPanelHeightFromLocalStorage = (): LayoutPanelHeight => {
     const stored = globalThis.localStorage.getItem(AXES_HEIGHT_STORAGE_KEY)
 
     if (stored === null) {
-        return LAYOUT_PANEL_HEIGHT_AUTO_FIT
+        return 'AUTO_FIT'
     }
 
     const parsed = Number.parseInt(stored)
 
-    return Number.isFinite(parsed) ? parsed : LAYOUT_PANEL_HEIGHT_AUTO_FIT
+    return Number.isFinite(parsed) ? parsed : 'AUTO_FIT'
 }
 
 export const setLayoutPanelHeightToLocalStorage = (
     height: LayoutPanelHeight
 ): void => {
     try {
-        if (height === LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
+        if (height === 'AUTO_FIT') {
             globalThis.localStorage.removeItem(AXES_HEIGHT_STORAGE_KEY)
         } else {
             globalThis.localStorage.setItem(

--- a/src/components/layout-panel/local-storage.ts
+++ b/src/components/layout-panel/local-storage.ts
@@ -1,5 +1,6 @@
 import type { LayoutPanelHeight } from '@store/ui-slice'
-import { AXES_HEIGHT_STORAGE_KEY } from './constants'
+
+const AXES_HEIGHT_STORAGE_KEY = 'dhis2.event-visualizer.axesHeight'
 
 export const getLayoutPanelHeightFromLocalStorage = (): LayoutPanelHeight => {
     const stored = globalThis.localStorage.getItem(AXES_HEIGHT_STORAGE_KEY)

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -19,7 +19,7 @@
     border-color: var(--colors-grey300);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.03);
     block-size: 100%;
-    max-block-size: 20vh;
+    max-block-size: 80vh;
     overflow-y: auto;
     scrollbar-gutter: stable;
 }

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -14,7 +14,12 @@
     grid-template-areas:
         'columns filters'
         'rows filters';
-    grid-template-rows: minmax(min-content, 1fr) minmax(min-content, 1fr);
+    /* No applied height yet (size is null): the grid height is indefinite while
+     * the panel is being measured. Auto rows report each axis's own content
+     * height; `fr` rows here would size every track up to the tallest and
+     * inflate the measurement. Once a height is applied, `.fixedHeight` takes
+     * over (see below). */
+    grid-template-rows: auto auto;
     gap: 1px;
     border-color: var(--colors-grey300);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.03);
@@ -24,6 +29,17 @@
     scrollbar-gutter: stable;
 }
 
+/* With a definite height applied, columns and rows share it equally: each floors
+ * at its own content (via the implicit min-content minimum, so nothing clips and
+ * overflow scrolls), and any extra space is mirrored 50/50. At exactly the
+ * content height this resolves back to the two content heights. */
+.axisContainer.fixedHeight {
+    grid-template-rows: 1fr 1fr;
+}
+
+/* LINE_LIST has a single row, so it never equalizes — one filling track works in
+ * both the measuring and applied states. Declared after `.fixedHeight` so it
+ * wins the row template when both classes are present. */
 .axisContainer.lineList {
     grid-template-areas: 'columns filters';
     grid-template-rows: minmax(min-content, 1fr);

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -14,11 +14,11 @@
     grid-template-areas:
         'columns filters'
         'rows filters';
-    /* No applied height yet (size is null): the grid height is indefinite while
-     * the panel is being measured. Auto rows report each axis's own content
-     * height; `fr` rows here would size every track up to the tallest and
-     * inflate the measurement. Once a height is applied, `.fixedHeight` takes
-     * over (see below). */
+    /* Auto rows while the panel height is indefinite (no applied height): each
+     * axis takes its own content height, which is what the panel measures to
+     * fit. `fr` rows can't size this state — in an indefinite-height grid an
+     * `fr` track grows every row to the tallest row's content. `.fixedHeight`
+     * applies once a height is set. */
     grid-template-rows: auto auto;
     gap: 1px;
     border-color: var(--colors-grey300);

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -1,4 +1,8 @@
+import { useAppDispatch, useAppSelector } from '@hooks'
+import { getUiLayoutPanelHeight, setUiLayoutPanelHeight } from '@store/ui-slice'
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { LAYOUT_PANEL_HEIGHT_AUTO_FIT } from './constants'
+import { setLayoutPanelHeightToLocalStorage } from './local-storage'
 
 type Orientation = 'horizontal' | 'vertical'
 
@@ -8,7 +12,6 @@ interface UseResizeHandleProps {
     collapseThreshold: number
     contentKey: string
     orientation: Orientation
-    storageKey: string
 }
 
 export const useResizeHandle = ({
@@ -17,8 +20,10 @@ export const useResizeHandle = ({
     collapseThreshold,
     contentKey,
     orientation,
-    storageKey,
 }: UseResizeHandleProps) => {
+    const dispatch = useAppDispatch()
+    const storeHeight = useAppSelector(getUiLayoutPanelHeight)
+
     const [size, setSize] = useState<number | null>(null)
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [minReached, setMinReached] = useState<boolean>(false)
@@ -28,21 +33,17 @@ export const useResizeHandle = ({
     const sizeRef = useRef<number | null>(size)
     const contentKeyRef = useRef<string>(contentKey)
     const refitPendingRef = useRef<boolean>(false)
-    const storedSizeRef = useRef<number | null>(
-        (() => {
-            const storedSize = localStorage.getItem(storageKey)
+    /* Redux owns the user-set height. Mirror it into a ref so the callbacks
+     * below read the latest value without being re-created on every change. */
+    const storeHeightRef = useRef(storeHeight)
 
-            return storedSize ? Number(storedSize) : null
-        })()
-    )
-
-    // Sync the ref with the size value
     sizeRef.current = size
+    storeHeightRef.current = storeHeight
 
-    /* On mount, a stored size is the user's explicit choice: honor it, clamped
-     * only to the visType min and the max. The min always wins so a size saved
-     * under a shorter visType can't hide an axis of the current one. With no
-     * stored size, fit to the content, capped at the max — then it scrolls. */
+    /* On node attach, apply the user-set height — clamped to the visType min and
+     * the max, where the min always wins so a height saved under a shorter
+     * visType can't hide an axis of the current one. With no user-set height
+     * (AUTO_FIT) fit to the content, capped at the max — then it scrolls. */
     const containerRef = useCallback(
         (node: HTMLDivElement | null) => {
             nodeRef.current = node
@@ -51,8 +52,10 @@ export const useResizeHandle = ({
                 return
             }
 
-            if (storedSizeRef.current) {
-                setSize(Math.max(min, Math.min(storedSizeRef.current, max)))
+            const userHeight = storeHeightRef.current
+
+            if (userHeight !== LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
+                setSize(Math.max(min, Math.min(userHeight, max)))
 
                 return
             }
@@ -82,10 +85,9 @@ export const useResizeHandle = ({
      * the chips as they are added or removed. This only applies while the user
      * has not set a height of their own: once they resize the panel, that
      * explicit height wins and the content scrolls within it instead of resizing
-     * the panel. The size is first
-     * dropped to `null` (auto) so the live content can be measured without the
-     * current fixed height skewing it; the next effect applies the fitted size
-     * once the auto layout has committed. */
+     * the panel. The size is first dropped to `null` (auto) so the live content
+     * can be measured without the current fixed height skewing it; the next
+     * effect applies the fitted size once the auto layout has committed. */
     useLayoutEffect(() => {
         if (contentKeyRef.current === contentKey) {
             return
@@ -93,7 +95,7 @@ export const useResizeHandle = ({
 
         contentKeyRef.current = contentKey
 
-        if (storedSizeRef.current !== null) {
+        if (storeHeightRef.current !== LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
             return
         }
 
@@ -119,6 +121,21 @@ export const useResizeHandle = ({
 
         setSize(Math.max(min, Math.min(contentSize, max)))
     }, [size, min, max, orientation])
+
+    /* React to AUTO_FIT being published to the store — by "Resize layout to fit"
+     * in the View menu, or by this hook's own reset — and re-fit to the content.
+     * Guarded on a mounted node so it can't leave a refit pending while the panel
+     * is unmounted; a numeric user height is applied on node attach and during
+     * the drag, so it needs no reaction here. */
+    useLayoutEffect(() => {
+        if (
+            storeHeight === LAYOUT_PANEL_HEIGHT_AUTO_FIT &&
+            nodeRef.current !== null
+        ) {
+            refitPendingRef.current = true
+            resetSize()
+        }
+    }, [storeHeight, resetSize])
 
     // Start dragging
     const onPointerDown = useCallback(
@@ -198,34 +215,24 @@ export const useResizeHandle = ({
             }
 
             if (size) {
-                try {
-                    storedSizeRef.current = +size.toFixed()
+                const height = Math.round(size)
 
-                    localStorage.setItem(storageKey, size.toFixed())
-                } catch {
-                    // ignore
-                }
+                dispatch(setUiLayoutPanelHeight(height))
+                setLayoutPanelHeightToLocalStorage(height)
             }
 
             setIsDragging(false)
         },
-        [storageKey]
+        [dispatch]
     )
 
-    /* Discard the user's stored height and re-fit to the content. Shared by the
-     * double-click handle gesture and the "Resize layout to fit" menu item. */
+    /* Discard the user's height and re-fit to the content by publishing AUTO_FIT
+     * (the refit itself runs in the reaction effect above, shared with the View
+     * menu's "Resize layout to fit"). Bound to the resize handle's double-click. */
     const resetToContentHeight = useCallback(() => {
-        try {
-            localStorage.removeItem(storageKey)
-        } catch {
-            // ignore
-        }
-
-        storedSizeRef.current = null
-        refitPendingRef.current = true
-
-        resetSize()
-    }, [resetSize, storageKey])
+        dispatch(setUiLayoutPanelHeight(LAYOUT_PANEL_HEIGHT_AUTO_FIT))
+        setLayoutPanelHeightToLocalStorage(LAYOUT_PANEL_HEIGHT_AUTO_FIT)
+    }, [dispatch])
 
     return {
         containerRef,

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -23,7 +23,6 @@ export const useResizeHandle = ({
     const [isDragging, setIsDragging] = useState<boolean>(false)
     const [minReached, setMinReached] = useState<boolean>(false)
     const nodeRef = useRef<HTMLDivElement | null>(null)
-    const dragMaxRef = useRef<number>(max)
     const preDragSizeRef = useRef<number | null>(null)
     const dragStartPosRef = useRef<number | null>(null)
     const sizeRef = useRef<number | null>(size)
@@ -40,36 +39,30 @@ export const useResizeHandle = ({
     // Sync the ref with the size value
     sizeRef.current = size
 
-    // Container ref callback
-    // Computes the effective max size, based on the container, max and stored size
+    /* On mount, a stored size is the user's explicit choice: honor it, clamped
+     * only to the visType min and the max. The min always wins so a size saved
+     * under a shorter visType can't hide an axis of the current one. With no
+     * stored size, fit to the content, capped at the max — then it scrolls. */
     const containerRef = useCallback(
         (node: HTMLDivElement | null) => {
             nodeRef.current = node
 
-            if (node !== null) {
-                const containerSize =
-                    orientation === 'horizontal'
-                        ? node.scrollHeight
-                        : node.scrollWidth
-
-                /* Fit to the content (which carries its own trailing drop-row
-                 * buffer in CSS), capped at the max — then it scrolls. */
-                const containerMaxSize = Math.min(containerSize, max)
-
-                /* The min always wins: a stored size (possibly saved under a
-                 * different visType) must never shrink the panel below the
-                 * height needed to show every axis of the current visType. */
-                if (storedSizeRef.current) {
-                    setSize(
-                        Math.max(
-                            min,
-                            Math.min(storedSizeRef.current, containerMaxSize)
-                        )
-                    )
-                } else {
-                    setSize(Math.max(containerMaxSize, min))
-                }
+            if (node === null) {
+                return
             }
+
+            if (storedSizeRef.current) {
+                setSize(Math.max(min, Math.min(storedSizeRef.current, max)))
+
+                return
+            }
+
+            const containerSize =
+                orientation === 'horizontal'
+                    ? node.scrollHeight
+                    : node.scrollWidth
+
+            setSize(Math.max(min, Math.min(containerSize, max)))
         },
         [max, min, orientation]
     )
@@ -85,17 +78,25 @@ export const useResizeHandle = ({
         setMinReached(false)
     }, [])
 
-    /* Re-fit the panel to the content whenever the layout changes, so it tracks
-     * the chips (and the trailing drop-row buffer they carry in CSS) as they are
-     * added or removed. The size is first dropped to `null` (auto) so the live
-     * content can be measured without the current fixed height skewing it; the
-     * next effect applies the fitted size once the auto layout has committed. */
+    /* Auto-fit the panel to the content when the layout changes, so it tracks
+     * the chips as they are added or removed. This only applies while the user
+     * has not set a height of their own: once they resize the panel, that
+     * explicit height wins and the content scrolls within it instead of resizing
+     * the panel. The size is first
+     * dropped to `null` (auto) so the live content can be measured without the
+     * current fixed height skewing it; the next effect applies the fitted size
+     * once the auto layout has committed. */
     useLayoutEffect(() => {
         if (contentKeyRef.current === contentKey) {
             return
         }
 
         contentKeyRef.current = contentKey
+
+        if (storedSizeRef.current !== null) {
+            return
+        }
+
         refitPendingRef.current = true
         setSize(null)
     }, [contentKey])
@@ -127,16 +128,6 @@ export const useResizeHandle = ({
             const node = nodeRef.current
             const horizontal = orientation === 'horizontal'
 
-            /* The drag ceiling is recomputed from the live content on every
-             * grab, so adding chips (which the cached size at mount can't see)
-             * lets the panel be dragged taller. The content carries its own
-             * trailing drop-row buffer in CSS. */
-            let contentSize = max
-            if (node) {
-                contentSize = horizontal ? node.scrollHeight : node.scrollWidth
-            }
-            dragMaxRef.current = Math.min(contentSize, max)
-
             /* When the panel has no explicit size (after a double-click reset)
              * fall back to its rendered size so the drag starts smoothly
              * instead of jumping to the min. */
@@ -156,7 +147,7 @@ export const useResizeHandle = ({
 
             setIsDragging(true)
         },
-        [max, orientation]
+        [orientation]
     )
 
     // Move the drag handle
@@ -191,15 +182,10 @@ export const useResizeHandle = ({
                 setMinReached(true)
                 setIsDragging(false)
             } else {
-                setSize(
-                    Math.max(
-                        collapseThreshold,
-                        Math.min(newSize, dragMaxRef.current)
-                    )
-                )
+                setSize(Math.max(collapseThreshold, Math.min(newSize, max)))
             }
         },
-        [collapseThreshold, min, orientation]
+        [collapseThreshold, max, min, orientation]
     )
 
     // Stop dragging
@@ -226,8 +212,9 @@ export const useResizeHandle = ({
         [storageKey]
     )
 
-    // Reset
-    const onDoubleClick = useCallback(() => {
+    /* Discard the user's stored height and re-fit to the content. Shared by the
+     * double-click handle gesture and the "Resize layout to fit" menu item. */
+    const resetToContentHeight = useCallback(() => {
         try {
             localStorage.removeItem(storageKey)
         } catch {
@@ -235,9 +222,6 @@ export const useResizeHandle = ({
         }
 
         storedSizeRef.current = null
-
-        /* Re-fit to the content so a double-click reset matches the auto-fit
-         * height applied elsewhere. */
         refitPendingRef.current = true
 
         resetSize()
@@ -247,13 +231,14 @@ export const useResizeHandle = ({
         containerRef,
         size,
         resetSize,
+        resetToContentHeight,
         isDragging,
         minReached,
         eventHandlers: {
             onPointerDown,
             onPointerMove,
             onPointerUp,
-            onDoubleClick,
+            onDoubleClick: resetToContentHeight,
         },
     }
 }

--- a/src/components/layout-panel/use-resize-handle.ts
+++ b/src/components/layout-panel/use-resize-handle.ts
@@ -1,7 +1,6 @@
-import { useAppDispatch, useAppSelector } from '@hooks'
+import { useAppDispatch, useAppSelector, useAppStore } from '@hooks'
 import { getUiLayoutPanelHeight, setUiLayoutPanelHeight } from '@store/ui-slice'
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
-import { LAYOUT_PANEL_HEIGHT_AUTO_FIT } from './constants'
 import { setLayoutPanelHeightToLocalStorage } from './local-storage'
 
 type Orientation = 'horizontal' | 'vertical'
@@ -22,6 +21,7 @@ export const useResizeHandle = ({
     orientation,
 }: UseResizeHandleProps) => {
     const dispatch = useAppDispatch()
+    const store = useAppStore()
     const storeHeight = useAppSelector(getUiLayoutPanelHeight)
 
     const [size, setSize] = useState<number | null>(null)
@@ -33,12 +33,8 @@ export const useResizeHandle = ({
     const sizeRef = useRef<number | null>(size)
     const contentKeyRef = useRef<string>(contentKey)
     const refitPendingRef = useRef<boolean>(false)
-    /* Redux owns the user-set height. Mirror it into a ref so the callbacks
-     * below read the latest value without being re-created on every change. */
-    const storeHeightRef = useRef(storeHeight)
 
     sizeRef.current = size
-    storeHeightRef.current = storeHeight
 
     /* On node attach, apply the user-set height — clamped to the visType min and
      * the max, where the min always wins so a height saved under a shorter
@@ -52,9 +48,9 @@ export const useResizeHandle = ({
                 return
             }
 
-            const userHeight = storeHeightRef.current
+            const userHeight = getUiLayoutPanelHeight(store.getState())
 
-            if (userHeight !== LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
+            if (userHeight !== 'AUTO_FIT') {
                 setSize(Math.max(min, Math.min(userHeight, max)))
 
                 return
@@ -67,7 +63,7 @@ export const useResizeHandle = ({
 
             setSize(Math.max(min, Math.min(containerSize, max)))
         },
-        [max, min, orientation]
+        [max, min, orientation, store]
     )
 
     // Callback for resetting the size, it's returned by the hook.
@@ -95,13 +91,13 @@ export const useResizeHandle = ({
 
         contentKeyRef.current = contentKey
 
-        if (storeHeightRef.current !== LAYOUT_PANEL_HEIGHT_AUTO_FIT) {
+        if (getUiLayoutPanelHeight(store.getState()) !== 'AUTO_FIT') {
             return
         }
 
         refitPendingRef.current = true
         setSize(null)
-    }, [contentKey])
+    }, [contentKey, store])
 
     useLayoutEffect(() => {
         if (!refitPendingRef.current || size !== null) {
@@ -128,10 +124,7 @@ export const useResizeHandle = ({
      * is unmounted; a numeric user height is applied on node attach and during
      * the drag, so it needs no reaction here. */
     useLayoutEffect(() => {
-        if (
-            storeHeight === LAYOUT_PANEL_HEIGHT_AUTO_FIT &&
-            nodeRef.current !== null
-        ) {
+        if (storeHeight === 'AUTO_FIT' && nodeRef.current !== null) {
             refitPendingRef.current = true
             resetSize()
         }
@@ -230,8 +223,8 @@ export const useResizeHandle = ({
      * (the refit itself runs in the reaction effect above, shared with the View
      * menu's "Resize layout to fit"). Bound to the resize handle's double-click. */
     const resetToContentHeight = useCallback(() => {
-        dispatch(setUiLayoutPanelHeight(LAYOUT_PANEL_HEIGHT_AUTO_FIT))
-        setLayoutPanelHeightToLocalStorage(LAYOUT_PANEL_HEIGHT_AUTO_FIT)
+        dispatch(setUiLayoutPanelHeight('AUTO_FIT'))
+        setLayoutPanelHeightToLocalStorage('AUTO_FIT')
     }, [dispatch])
 
     return {

--- a/src/components/toolbar/actions-bar/view-menu.tsx
+++ b/src/components/toolbar/actions-bar/view-menu.tsx
@@ -1,3 +1,4 @@
+import { LAYOUT_PANEL_HEIGHT_AUTO_FIT } from '@components/layout-panel/constants'
 import { SIDEBAR_DEFAULT_WIDTH } from '@components/sidebar/constants'
 import {
     HoverMenuDropdown,
@@ -10,11 +11,11 @@ import { getCurrentVisId } from '@store/current-vis-slice'
 import {
     getUiSidebarWidth,
     resetUiSidebarWidth,
-    getUiLayoutPanelExpanded,
+    getUiLayoutPanelHeight,
     getUiLayoutPanelVisible,
     getUiSidebarVisible,
     getUiDetailsPanelVisible,
-    resetUiLayoutPanelHeightCounter,
+    setUiLayoutPanelHeight,
     toggleUiDetailsPanelVisible,
     toggleUiLayoutPanelVisible,
     toggleUiSidebarVisible,
@@ -28,7 +29,7 @@ export const ViewMenu: FC = () => {
 
     const isSidebarVisible = useAppSelector(getUiSidebarVisible)
     const isLayoutPanelVisible = useAppSelector(getUiLayoutPanelVisible)
-    const isLayoutPanelExpanded = useAppSelector(getUiLayoutPanelExpanded)
+    const layoutPanelHeight = useAppSelector(getUiLayoutPanelHeight)
     const isDetailsPanelVisible = useAppSelector(getUiDetailsPanelVisible)
     const sidebarWidth = useAppSelector(getUiSidebarWidth)
     const id = useAppSelector(getCurrentVisId)
@@ -46,7 +47,7 @@ export const ViewMenu: FC = () => {
     }, [dispatch])
 
     const resizeLayoutToFit = useCallback(() => {
-        dispatch(resetUiLayoutPanelHeightCounter())
+        dispatch(setUiLayoutPanelHeight(LAYOUT_PANEL_HEIGHT_AUTO_FIT))
     }, [dispatch])
 
     const toggleDetailsPanelVisible = useCallback(() => {
@@ -76,7 +77,9 @@ export const ViewMenu: FC = () => {
                 <HoverMenuListItem
                     label={i18n.t('Resize layout to fit')}
                     onClick={resizeLayoutToFit}
-                    disabled={!isLayoutPanelVisible || !isLayoutPanelExpanded}
+                    disabled={
+                        layoutPanelHeight === LAYOUT_PANEL_HEIGHT_AUTO_FIT
+                    }
                 />
                 <HoverMenuListItem
                     label={toggleSidebarText}

--- a/src/components/toolbar/actions-bar/view-menu.tsx
+++ b/src/components/toolbar/actions-bar/view-menu.tsx
@@ -10,9 +10,11 @@ import { getCurrentVisId } from '@store/current-vis-slice'
 import {
     getUiSidebarWidth,
     resetUiSidebarWidth,
+    getUiLayoutPanelExpanded,
     getUiLayoutPanelVisible,
     getUiSidebarVisible,
     getUiDetailsPanelVisible,
+    resetUiLayoutPanelHeightCounter,
     toggleUiDetailsPanelVisible,
     toggleUiLayoutPanelVisible,
     toggleUiSidebarVisible,
@@ -26,6 +28,7 @@ export const ViewMenu: FC = () => {
 
     const isSidebarVisible = useAppSelector(getUiSidebarVisible)
     const isLayoutPanelVisible = useAppSelector(getUiLayoutPanelVisible)
+    const isLayoutPanelExpanded = useAppSelector(getUiLayoutPanelExpanded)
     const isDetailsPanelVisible = useAppSelector(getUiDetailsPanelVisible)
     const sidebarWidth = useAppSelector(getUiSidebarWidth)
     const id = useAppSelector(getCurrentVisId)
@@ -40,6 +43,10 @@ export const ViewMenu: FC = () => {
 
     const resetSidebarWidth = useCallback(() => {
         dispatch(resetUiSidebarWidth())
+    }, [dispatch])
+
+    const resizeLayoutToFit = useCallback(() => {
+        dispatch(resetUiLayoutPanelHeightCounter())
     }, [dispatch])
 
     const toggleDetailsPanelVisible = useCallback(() => {
@@ -65,6 +72,11 @@ export const ViewMenu: FC = () => {
                 <HoverMenuListItem
                     label={toggleLayoutPanelText}
                     onClick={toggleLayoutPanelVisible}
+                />
+                <HoverMenuListItem
+                    label={i18n.t('Resize layout to fit')}
+                    onClick={resizeLayoutToFit}
+                    disabled={!isLayoutPanelVisible || !isLayoutPanelExpanded}
                 />
                 <HoverMenuListItem
                     label={toggleSidebarText}

--- a/src/components/toolbar/actions-bar/view-menu.tsx
+++ b/src/components/toolbar/actions-bar/view-menu.tsx
@@ -1,4 +1,3 @@
-import { LAYOUT_PANEL_HEIGHT_AUTO_FIT } from '@components/layout-panel/constants'
 import { SIDEBAR_DEFAULT_WIDTH } from '@components/sidebar/constants'
 import {
     HoverMenuDropdown,
@@ -47,7 +46,7 @@ export const ViewMenu: FC = () => {
     }, [dispatch])
 
     const resizeLayoutToFit = useCallback(() => {
-        dispatch(setUiLayoutPanelHeight(LAYOUT_PANEL_HEIGHT_AUTO_FIT))
+        dispatch(setUiLayoutPanelHeight('AUTO_FIT'))
     }, [dispatch])
 
     const toggleDetailsPanelVisible = useCallback(() => {
@@ -77,9 +76,7 @@ export const ViewMenu: FC = () => {
                 <HoverMenuListItem
                     label={i18n.t('Resize layout to fit')}
                     onClick={resizeLayoutToFit}
-                    disabled={
-                        layoutPanelHeight === LAYOUT_PANEL_HEIGHT_AUTO_FIT
-                    }
+                    disabled={layoutPanelHeight === 'AUTO_FIT'}
                 />
                 <HoverMenuListItem
                     label={toggleSidebarText}

--- a/src/store/__tests__/ui-slice.spec.ts
+++ b/src/store/__tests__/ui-slice.spec.ts
@@ -9,9 +9,11 @@ import {
     toggleUiSidebarVisible,
     toggleUiLayoutPanelVisible,
     toggleUiShowExpandedVisualizationCanvas,
+    resetUiLayoutPanelHeightCounter,
     getUiShowExpandedVisualizationCanvas,
     getUiSidebarVisible,
     getUiLayoutPanelVisible,
+    getUiLayoutPanelHeightResetCounter,
     getUiDetailsPanelVisible,
     getUiUpdateAnimationShowingFor,
 } from '../ui-slice'
@@ -235,6 +237,29 @@ describe('uiSlice', () => {
         })
     })
 
+    describe('resetUiLayoutPanelHeightCounter', () => {
+        it('increments the counter without touching other state', () => {
+            const state = reducer(
+                initialState,
+                resetUiLayoutPanelHeightCounter()
+            )
+
+            expect(state.layoutPanelHeightResetCounter).toBe(1)
+            expect({
+                ...state,
+                layoutPanelHeightResetCounter:
+                    initialState.layoutPanelHeightResetCounter,
+            }).toEqual(initialState)
+        })
+
+        it('increments on each dispatch so repeat resets are distinct', () => {
+            let state = reducer(initialState, resetUiLayoutPanelHeightCounter())
+            state = reducer(state, resetUiLayoutPanelHeightCounter())
+
+            expect(state.layoutPanelHeightResetCounter).toBe(2)
+        })
+    })
+
     describe('setUiUpdateAnimationShowingFor', () => {
         it('records the output type whose update button should animate', () => {
             const state = reducer(
@@ -291,6 +316,14 @@ describe('uiSlice', () => {
             expect(getUiSidebarVisible(rootState)).toBe(true)
             expect(getUiLayoutPanelVisible(rootState)).toBe(false)
             expect(getUiDetailsPanelVisible(rootState)).toBe(true)
+        })
+
+        it('getUiLayoutPanelHeightResetCounter returns the counter value', () => {
+            const rootState = createRootState({
+                layoutPanelHeightResetCounter: 3,
+            })
+
+            expect(getUiLayoutPanelHeightResetCounter(rootState)).toBe(3)
         })
 
         it('getUiUpdateAnimationShowingFor returns the stored output type', () => {

--- a/src/store/__tests__/ui-slice.spec.ts
+++ b/src/store/__tests__/ui-slice.spec.ts
@@ -9,11 +9,11 @@ import {
     toggleUiSidebarVisible,
     toggleUiLayoutPanelVisible,
     toggleUiShowExpandedVisualizationCanvas,
-    resetUiLayoutPanelHeightCounter,
+    setUiLayoutPanelHeight,
     getUiShowExpandedVisualizationCanvas,
     getUiSidebarVisible,
     getUiLayoutPanelVisible,
-    getUiLayoutPanelHeightResetCounter,
+    getUiLayoutPanelHeight,
     getUiDetailsPanelVisible,
     getUiUpdateAnimationShowingFor,
 } from '../ui-slice'
@@ -237,26 +237,25 @@ describe('uiSlice', () => {
         })
     })
 
-    describe('resetUiLayoutPanelHeightCounter', () => {
-        it('increments the counter without touching other state', () => {
-            const state = reducer(
-                initialState,
-                resetUiLayoutPanelHeightCounter()
-            )
+    describe('setUiLayoutPanelHeight', () => {
+        it('stores a user-set numeric height', () => {
+            const state = reducer(initialState, setUiLayoutPanelHeight(420))
 
-            expect(state.layoutPanelHeightResetCounter).toBe(1)
-            expect({
-                ...state,
-                layoutPanelHeightResetCounter:
-                    initialState.layoutPanelHeightResetCounter,
-            }).toEqual(initialState)
+            expect(state.layoutPanelHeight).toBe(420)
         })
 
-        it('increments on each dispatch so repeat resets are distinct', () => {
-            let state = reducer(initialState, resetUiLayoutPanelHeightCounter())
-            state = reducer(state, resetUiLayoutPanelHeightCounter())
+        it('stores the AUTO_FIT sentinel for "fit to content"', () => {
+            const withHeight: UiState = {
+                ...initialState,
+                layoutPanelHeight: 420,
+            }
 
-            expect(state.layoutPanelHeightResetCounter).toBe(2)
+            const state = reducer(
+                withHeight,
+                setUiLayoutPanelHeight('AUTO_FIT')
+            )
+
+            expect(state.layoutPanelHeight).toBe('AUTO_FIT')
         })
     })
 
@@ -318,12 +317,16 @@ describe('uiSlice', () => {
             expect(getUiDetailsPanelVisible(rootState)).toBe(true)
         })
 
-        it('getUiLayoutPanelHeightResetCounter returns the counter value', () => {
-            const rootState = createRootState({
-                layoutPanelHeightResetCounter: 3,
-            })
+        it('getUiLayoutPanelHeight returns a stored numeric height', () => {
+            const rootState = createRootState({ layoutPanelHeight: 360 })
 
-            expect(getUiLayoutPanelHeightResetCounter(rootState)).toBe(3)
+            expect(getUiLayoutPanelHeight(rootState)).toBe(360)
+        })
+
+        it('getUiLayoutPanelHeight returns the AUTO_FIT sentinel', () => {
+            const rootState = createRootState({ layoutPanelHeight: 'AUTO_FIT' })
+
+            expect(getUiLayoutPanelHeight(rootState)).toBe('AUTO_FIT')
         })
 
         it('getUiUpdateAnimationShowingFor returns the stored output type', () => {

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -1,10 +1,12 @@
-import type { LayoutPanelHeight } from '@components/layout-panel/constants'
 import { getLayoutPanelHeightFromLocalStorage } from '@components/layout-panel/local-storage'
 import { SIDEBAR_DEFAULT_WIDTH } from '@components/sidebar/constants'
 import { getSidebarWidthFromLocalStorage } from '@components/sidebar/local-storage'
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { OutputType } from '@types'
+
+/* A user-set height in px, or 'AUTO_FIT' to fit the content. */
+export type LayoutPanelHeight = number | 'AUTO_FIT'
 
 interface PanelVisibility {
     isDetailsPanelVisible: boolean

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -1,3 +1,5 @@
+import type { LayoutPanelHeight } from '@components/layout-panel/constants'
+import { getLayoutPanelHeightFromLocalStorage } from '@components/layout-panel/local-storage'
 import { SIDEBAR_DEFAULT_WIDTH } from '@components/sidebar/constants'
 import { getSidebarWidthFromLocalStorage } from '@components/sidebar/local-storage'
 import type { PayloadAction } from '@reduxjs/toolkit'
@@ -16,7 +18,7 @@ export interface UiState {
     isLayoutPanelExpanded: boolean
     isLayoutPanelVisible: boolean
     isSidebarVisible: boolean
-    layoutPanelHeightResetCounter: number
+    layoutPanelHeight: LayoutPanelHeight
     sidebarWidth: number
     savedPanelVisibility: PanelVisibility | null
     updateAnimationShowingFor: OutputType | null
@@ -28,7 +30,7 @@ export const initialState: UiState = {
     isLayoutPanelExpanded: true,
     isLayoutPanelVisible: true,
     isSidebarVisible: true,
-    layoutPanelHeightResetCounter: 0,
+    layoutPanelHeight: getLayoutPanelHeightFromLocalStorage(),
     sidebarWidth: getSidebarWidthFromLocalStorage(),
     savedPanelVisibility: null,
     updateAnimationShowingFor: null,
@@ -100,11 +102,15 @@ export const uiSlice = createSlice({
         toggleUiLayoutPanelExpanded: (state) => {
             state.isLayoutPanelExpanded = !state.isLayoutPanelExpanded
         },
-        /* Bumps a nonce that the layout panel observes to refit its height to
-         * the content. It carries no height value of its own — the actual fit
-         * is measured from the DOM in the panel's resize hook. */
-        resetUiLayoutPanelHeightCounter: (state) => {
-            state.layoutPanelHeightResetCounter += 1
+        /* The user-set layout panel height, or AUTO_FIT for "no user-set height,
+         * fit to content". AUTO_FIT is how "Resize layout to fit" (and the
+         * resize handle's double-click) ask the panel to re-fit — the panel
+         * measures the content itself, since the fit height is DOM-computed. */
+        setUiLayoutPanelHeight: (
+            state,
+            action: PayloadAction<LayoutPanelHeight>
+        ) => {
+            state.layoutPanelHeight = action.payload
         },
         toggleUiLayoutPanelVisible: (state) => {
             state.isLayoutPanelVisible = !state.isLayoutPanelVisible
@@ -125,8 +131,7 @@ export const uiSlice = createSlice({
             state.updateAnimationShowingFor,
         getUiDetailsPanelVisible: (state) => state.isDetailsPanelVisible,
         getUiLayoutPanelExpanded: (state) => state.isLayoutPanelExpanded,
-        getUiLayoutPanelHeightResetCounter: (state) =>
-            state.layoutPanelHeightResetCounter,
+        getUiLayoutPanelHeight: (state) => state.layoutPanelHeight,
         getUiLayoutPanelVisible: (state) => state.isLayoutPanelVisible,
         getUiSidebarVisible: (state) => state.isSidebarVisible,
         getUiSidebarWidth: (state) => state.sidebarWidth,
@@ -145,7 +150,7 @@ export const {
     setUiActiveDimensionModal,
     toggleUiDetailsPanelVisible,
     toggleUiLayoutPanelExpanded,
-    resetUiLayoutPanelHeightCounter,
+    setUiLayoutPanelHeight,
     toggleUiLayoutPanelVisible,
     toggleUiSidebarVisible,
     toggleUiShowExpandedVisualizationCanvas,
@@ -155,7 +160,7 @@ export const {
     getUiUpdateAnimationShowingFor,
     getUiDetailsPanelVisible,
     getUiLayoutPanelExpanded,
-    getUiLayoutPanelHeightResetCounter,
+    getUiLayoutPanelHeight,
     getUiLayoutPanelVisible,
     getUiSidebarVisible,
     getUiSidebarWidth,

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -104,10 +104,6 @@ export const uiSlice = createSlice({
         toggleUiLayoutPanelExpanded: (state) => {
             state.isLayoutPanelExpanded = !state.isLayoutPanelExpanded
         },
-        /* The user-set layout panel height, or AUTO_FIT for "no user-set height,
-         * fit to content". AUTO_FIT is how "Resize layout to fit" (and the
-         * resize handle's double-click) ask the panel to re-fit — the panel
-         * measures the content itself, since the fit height is DOM-computed. */
         setUiLayoutPanelHeight: (
             state,
             action: PayloadAction<LayoutPanelHeight>

--- a/src/store/ui-slice.ts
+++ b/src/store/ui-slice.ts
@@ -16,6 +16,7 @@ export interface UiState {
     isLayoutPanelExpanded: boolean
     isLayoutPanelVisible: boolean
     isSidebarVisible: boolean
+    layoutPanelHeightResetCounter: number
     sidebarWidth: number
     savedPanelVisibility: PanelVisibility | null
     updateAnimationShowingFor: OutputType | null
@@ -27,6 +28,7 @@ export const initialState: UiState = {
     isLayoutPanelExpanded: true,
     isLayoutPanelVisible: true,
     isSidebarVisible: true,
+    layoutPanelHeightResetCounter: 0,
     sidebarWidth: getSidebarWidthFromLocalStorage(),
     savedPanelVisibility: null,
     updateAnimationShowingFor: null,
@@ -98,6 +100,12 @@ export const uiSlice = createSlice({
         toggleUiLayoutPanelExpanded: (state) => {
             state.isLayoutPanelExpanded = !state.isLayoutPanelExpanded
         },
+        /* Bumps a nonce that the layout panel observes to refit its height to
+         * the content. It carries no height value of its own — the actual fit
+         * is measured from the DOM in the panel's resize hook. */
+        resetUiLayoutPanelHeightCounter: (state) => {
+            state.layoutPanelHeightResetCounter += 1
+        },
         toggleUiLayoutPanelVisible: (state) => {
             state.isLayoutPanelVisible = !state.isLayoutPanelVisible
             state.savedPanelVisibility = null
@@ -117,6 +125,8 @@ export const uiSlice = createSlice({
             state.updateAnimationShowingFor,
         getUiDetailsPanelVisible: (state) => state.isDetailsPanelVisible,
         getUiLayoutPanelExpanded: (state) => state.isLayoutPanelExpanded,
+        getUiLayoutPanelHeightResetCounter: (state) =>
+            state.layoutPanelHeightResetCounter,
         getUiLayoutPanelVisible: (state) => state.isLayoutPanelVisible,
         getUiSidebarVisible: (state) => state.isSidebarVisible,
         getUiSidebarWidth: (state) => state.sidebarWidth,
@@ -135,6 +145,7 @@ export const {
     setUiActiveDimensionModal,
     toggleUiDetailsPanelVisible,
     toggleUiLayoutPanelExpanded,
+    resetUiLayoutPanelHeightCounter,
     toggleUiLayoutPanelVisible,
     toggleUiSidebarVisible,
     toggleUiShowExpandedVisualizationCanvas,
@@ -144,6 +155,7 @@ export const {
     getUiUpdateAnimationShowingFor,
     getUiDetailsPanelVisible,
     getUiLayoutPanelExpanded,
+    getUiLayoutPanelHeightResetCounter,
     getUiLayoutPanelVisible,
     getUiSidebarVisible,
     getUiSidebarWidth,


### PR DESCRIPTION
Implements [DHIS2-21641](https://dhis2.atlassian.net/browse/DHIS2-21641)

### Description

Improvements for the layout resize.
This has been simplified from the original spec.

See the ticket for a description of how it should work.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---


### Screenshots

New "Resize layout to fit" item in View menu:
<img width="292" height="244" alt="Screenshot 2026-06-29 at 12 35 50" src="https://github.com/user-attachments/assets/d9f442d4-e743-4ca8-a1b3-17f9e8f6d0c0" />

Active drop target style:
<img width="650" height="218" alt="Screenshot 2026-06-29 at 12 39 07" src="https://github.com/user-attachments/assets/eb71c1f6-ec07-4af8-80d6-cec5d8be37a3" />

Max height limit at 80vh, regardless of content:
<img width="999" height="883" alt="Screenshot 2026-06-29 at 12 40 15" src="https://github.com/user-attachments/assets/acbbb245-6533-4e39-9dbe-fa263fcadfe1" />

Auto resize when adding/removing chips, fit to content:
<img width="783" height="256" alt="Screenshot 2026-06-29 at 15 44 04" src="https://github.com/user-attachments/assets/22a6f4d6-32a3-42da-83dd-8f71f86855b6" />

Auto resize when adding/removing chips, with user-defined height axes are equally sized in PT:
<img width="956" height="250" alt="Screenshot 2026-06-29 at 12 41 31" src="https://github.com/user-attachments/assets/110e48ae-ded1-4d52-9815-0781edae775f" />



[DHIS2-21641]: https://dhis2.atlassian.net/browse/DHIS2-21641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ