### PR TITLE
feat: prevent analytics request spamming and plugin remount [DHIS2-21640]

### DIFF
--- a/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
@@ -102,8 +102,8 @@ export const getAdaptedVisualization = (
     }
 }
 
-/* The request as the visualization defines it, excluding the per-fetch runtime
- * layer (paging, interactive sorting, relativePeriodDate, displayProperty). */
+/* The request as the visualization defines it, excluding sorting, paging,
+ * relativePeriodDate and displayProperty (these refetch without a remount). */
 export const getBaseRequestIdentity = (
     visualization: CurrentVisualization
 ) => ({

--- a/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-line-list.ts
@@ -102,6 +102,16 @@ export const getAdaptedVisualization = (
     }
 }
 
+/* The request as the visualization defines it, excluding the per-fetch runtime
+ * layer (paging, interactive sorting, relativePeriodDate, displayProperty). */
+export const getBaseRequestIdentity = (
+    visualization: CurrentVisualization
+) => ({
+    ...getAdaptedVisualization(visualization),
+    programIds: (visualization.programDimensions ?? []).map((p) => p.id),
+    trackedEntityTypeId: visualization.trackedEntityType?.id,
+})
+
 const analyticsApiEndpointMap: Record<OutputType, string> = {
     ENROLLMENT: 'enrollments',
     EVENT: 'events',

--- a/src/components/plugin-wrapper/hooks/query-tools-pivot-table.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-pivot-table.ts
@@ -65,8 +65,8 @@ export const getCustomValueRequestParams = (
         : undefined
 
 /* Like the line-list version, but pivot has no interactive sorting or paging,
- * so sortOrder, topLimit, timeField and the custom value belong to the identity
- * rather than the runtime layer. */
+ * so sortOrder, topLimit, timeField and the custom value are part of the
+ * identity rather than excluded from it. */
 export const getBaseRequestIdentity = (
     visualization: CurrentVisualization
 ) => ({

--- a/src/components/plugin-wrapper/hooks/query-tools-pivot-table.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools-pivot-table.ts
@@ -51,3 +51,30 @@ export const getAdaptedVisualization = (
         parameters,
     }
 }
+
+/* Custom value is only sent when both value and aggregationType are set. Shared
+ * by the request builder and the identity so they can't disagree. */
+export const getCustomValueRequestParams = (
+    visualization: CurrentVisualization
+) =>
+    visualization.value && visualization.aggregationType
+        ? {
+              value: visualization.value.id,
+              aggregationType: visualization.aggregationType,
+          }
+        : undefined
+
+/* Like the line-list version, but pivot has no interactive sorting or paging,
+ * so sortOrder, topLimit, timeField and the custom value belong to the identity
+ * rather than the runtime layer. */
+export const getBaseRequestIdentity = (
+    visualization: CurrentVisualization
+) => ({
+    ...getAdaptedVisualization(visualization),
+    programIds: (visualization.programDimensions ?? []).map((p) => p.id),
+    trackedEntityTypeId: visualization.trackedEntityType?.id,
+    timeField: visualization.timeField,
+    sortOrder: visualization.sortOrder,
+    topLimit: visualization.topLimit,
+    ...getCustomValueRequestParams(visualization),
+})

--- a/src/components/plugin-wrapper/hooks/query-tools.spec.ts
+++ b/src/components/plugin-wrapper/hooks/query-tools.spec.ts
@@ -1,0 +1,124 @@
+import type { CurrentVisualization } from '@types'
+import { describe, it, expect } from 'vitest'
+import { getBaseRequestIdentity as getLineListBaseRequestIdentity } from './query-tools-line-list'
+import { getBaseRequestIdentity as getPivotTableBaseRequestIdentity } from './query-tools-pivot-table'
+
+const baseLineList = {
+    type: 'LINE_LIST',
+    outputType: 'EVENT',
+    columns: [{ dimension: 'ou', items: [{ id: 'ou1' }] }],
+    rows: [],
+    filters: [],
+    programDimensions: [{ id: 'p1' }],
+} as unknown as CurrentVisualization
+
+const basePivotTable = {
+    type: 'PIVOT_TABLE',
+    outputType: 'EVENT',
+    columns: [{ dimension: 'ou', items: [{ id: 'ou1' }] }],
+    rows: [],
+    filters: [],
+    programDimensions: [{ id: 'p1' }],
+} as unknown as CurrentVisualization
+
+const lineListKey = (vis: CurrentVisualization) =>
+    JSON.stringify(getLineListBaseRequestIdentity(vis))
+const pivotTableKey = (vis: CurrentVisualization) =>
+    JSON.stringify(getPivotTableBaseRequestIdentity(vis))
+
+describe('getRequestStructure (line list)', () => {
+    it('changes when the selected items of a dimension change', () => {
+        const next = {
+            ...baseLineList,
+            columns: [{ dimension: 'ou', items: [{ id: 'ou2' }] }],
+        } as unknown as CurrentVisualization
+
+        expect(lineListKey(next)).not.toBe(lineListKey(baseLineList))
+    })
+
+    it('changes when a filter dimension is added', () => {
+        const next = {
+            ...baseLineList,
+            filters: [
+                { dimension: 'eventStatus', items: [{ id: 'COMPLETED' }] },
+            ],
+        } as unknown as CurrentVisualization
+
+        expect(lineListKey(next)).not.toBe(lineListKey(baseLineList))
+    })
+
+    it('changes when the output type changes', () => {
+        const next = {
+            ...baseLineList,
+            outputType: 'ENROLLMENT',
+        } as unknown as CurrentVisualization
+
+        expect(lineListKey(next)).not.toBe(lineListKey(baseLineList))
+    })
+
+    it('does not change when only the sorting changes', () => {
+        const next = {
+            ...baseLineList,
+            sorting: [{ dimension: 'ou', direction: 'ASC' }],
+        } as unknown as CurrentVisualization
+
+        expect(lineListKey(next)).toBe(lineListKey(baseLineList))
+    })
+
+    it('does not change when only a client-side option changes', () => {
+        const next = {
+            ...baseLineList,
+            fontSize: 'LARGE',
+        } as unknown as CurrentVisualization
+
+        expect(lineListKey(next)).toBe(lineListKey(baseLineList))
+    })
+})
+
+describe('getRequestStructure (pivot table)', () => {
+    it('changes when the selected items of a dimension change', () => {
+        const next = {
+            ...basePivotTable,
+            columns: [{ dimension: 'ou', items: [{ id: 'ou2' }] }],
+        } as unknown as CurrentVisualization
+
+        expect(pivotTableKey(next)).not.toBe(pivotTableKey(basePivotTable))
+    })
+
+    it('changes when the top limit changes', () => {
+        const next = {
+            ...basePivotTable,
+            topLimit: 50,
+        } as unknown as CurrentVisualization
+
+        expect(pivotTableKey(next)).not.toBe(pivotTableKey(basePivotTable))
+    })
+
+    it('includes the custom value only when both value and aggregationType are set', () => {
+        const aggregationOnly = {
+            ...basePivotTable,
+            aggregationType: 'AVERAGE',
+        } as unknown as CurrentVisualization
+        const withCustomValue = {
+            ...basePivotTable,
+            value: { id: 'de1' },
+            aggregationType: 'AVERAGE',
+        } as unknown as CurrentVisualization
+
+        expect(pivotTableKey(aggregationOnly)).toBe(
+            pivotTableKey(basePivotTable)
+        )
+        expect(pivotTableKey(withCustomValue)).not.toBe(
+            pivotTableKey(basePivotTable)
+        )
+    })
+
+    it('does not change when only a client-side option changes', () => {
+        const next = {
+            ...basePivotTable,
+            fontSize: 'LARGE',
+        } as unknown as CurrentVisualization
+
+        expect(pivotTableKey(next)).toBe(pivotTableKey(basePivotTable))
+    })
+})

--- a/src/components/plugin-wrapper/hooks/use-in-flight-dedup.ts
+++ b/src/components/plugin-wrapper/hooks/use-in-flight-dedup.ts
@@ -1,0 +1,28 @@
+import { logger } from '@modules/logger'
+import { useCallback, useRef } from 'react'
+
+/* Guards against firing an analytics request identical to one already in
+ * flight. reserve claims a request signature and returns false when the same
+ * request is already running; call release once the request settles. */
+export const useInFlightDedup = () => {
+    const inFlightSignatureRef = useRef<string | null>(null)
+
+    const reserve = useCallback((signature: string) => {
+        if (inFlightSignatureRef.current === signature) {
+            logger.debug(
+                'Skipping analytics request, identical request already in flight'
+            )
+            return false
+        }
+        inFlightSignatureRef.current = signature
+        return true
+    }, [])
+
+    const release = useCallback((signature: string) => {
+        if (inFlightSignatureRef.current === signature) {
+            inFlightSignatureRef.current = null
+        }
+    }, [])
+
+    return { reserve, release }
+}

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -479,16 +479,13 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
             page = 1,
             onResponseReceived,
         }) => {
-            const runtime = {
+            const requestSignature = JSON.stringify({
+                ...getBaseRequestIdentity(visualization),
                 sorting: visualization.sorting ?? null,
                 page,
                 pageSize,
                 filters: filters ?? null,
                 displayProperty,
-            }
-            const requestSignature = JSON.stringify({
-                ...getBaseRequestIdentity(visualization),
-                ...runtime,
             })
 
             if (inFlightSignatureRef.current === requestSignature) {

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -27,12 +27,13 @@ import type {
     MetadataInputItem,
     UserOrgUnitMetadataItem,
 } from '@types'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { getAnalyticsEndpoint } from './query-tools-common'
 import {
     getAdaptedVisualization,
     getBaseRequestIdentity,
 } from './query-tools-line-list'
+import { useInFlightDedup } from './use-in-flight-dedup'
 
 type OptionSetMetaDataItem = MetadataInputItem & {
     options: Array<{ code?: string; uid?: string }>
@@ -468,7 +469,7 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
         data: null,
     })
 
-    const inFlightSignatureRef = useRef<string | null>(null)
+    const { reserve, release } = useInFlightDedup()
 
     const fetchAnalyticsData: FetchAnalyticsDataFn = useCallback(
         async ({
@@ -488,10 +489,9 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
                 displayProperty,
             })
 
-            if (inFlightSignatureRef.current === requestSignature) {
+            if (!reserve(requestSignature)) {
                 return
             }
-            inFlightSignatureRef.current = requestSignature
 
             setState((prevState) => ({
                 ...prevState,
@@ -556,12 +556,10 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
                     isFetching: false,
                 })
             } finally {
-                if (inFlightSignatureRef.current === requestSignature) {
-                    inFlightSignatureRef.current = null
-                }
+                release(requestSignature)
             }
         },
-        [analyticsEngine, dataEngine, metadataStore]
+        [analyticsEngine, dataEngine, metadataStore, reserve, release]
     )
 
     return [fetchAnalyticsData, state]

--- a/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-line-list-analytics-data.ts
@@ -27,9 +27,12 @@ import type {
     MetadataInputItem,
     UserOrgUnitMetadataItem,
 } from '@types'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { getAnalyticsEndpoint } from './query-tools-common'
-import { getAdaptedVisualization } from './query-tools-line-list'
+import {
+    getAdaptedVisualization,
+    getBaseRequestIdentity,
+} from './query-tools-line-list'
 
 type OptionSetMetaDataItem = MetadataInputItem & {
     options: Array<{ code?: string; uid?: string }>
@@ -465,6 +468,8 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
         data: null,
     })
 
+    const inFlightSignatureRef = useRef<string | null>(null)
+
     const fetchAnalyticsData: FetchAnalyticsDataFn = useCallback(
         async ({
             visualization,
@@ -474,6 +479,23 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
             page = 1,
             onResponseReceived,
         }) => {
+            const runtime = {
+                sorting: visualization.sorting ?? null,
+                page,
+                pageSize,
+                filters: filters ?? null,
+                displayProperty,
+            }
+            const requestSignature = JSON.stringify({
+                ...getBaseRequestIdentity(visualization),
+                ...runtime,
+            })
+
+            if (inFlightSignatureRef.current === requestSignature) {
+                return
+            }
+            inFlightSignatureRef.current = requestSignature
+
             setState((prevState) => ({
                 ...prevState,
                 isFetching: true,
@@ -536,6 +558,10 @@ const useLineListAnalyticsData = (): UseAnalyticsDataResult => {
                     error: error as FetchError,
                     isFetching: false,
                 })
+            } finally {
+                if (inFlightSignatureRef.current === requestSignature) {
+                    inFlightSignatureRef.current = null
+                }
             }
         },
         [analyticsEngine, dataEngine, metadataStore]

--- a/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
@@ -4,13 +4,14 @@ import { type FetchError, useDataEngine } from '@dhis2/app-runtime'
 import { logger } from '@modules/logger'
 import { getSingleProgramFromVisualization } from '@modules/visualization/program'
 import type { CurrentUser, CurrentVisualization } from '@types'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { getAnalyticsEndpoint } from './query-tools-common'
 import {
     getAdaptedVisualization,
     getBaseRequestIdentity,
     getCustomValueRequestParams,
 } from './query-tools-pivot-table'
+import { useInFlightDedup } from './use-in-flight-dedup'
 
 type FetchAnalyticsDataForPTInternalParams = {
     analyticsEngine: ReturnType<typeof Analytics.getAnalytics>
@@ -114,7 +115,7 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
         data: null,
     })
 
-    const inFlightSignatureRef = useRef<string | null>(null)
+    const { reserve, release } = useInFlightDedup()
 
     const fetchAnalyticsData: FetchAnalyticsDataFn = useCallback(
         async ({
@@ -129,10 +130,9 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
                 displayProperty,
             })
 
-            if (inFlightSignatureRef.current === requestSignature) {
+            if (!reserve(requestSignature)) {
                 return
             }
-            inFlightSignatureRef.current = requestSignature
 
             setState((prevState) => ({
                 ...prevState,
@@ -171,12 +171,10 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
                     isFetching: false,
                 })
             } finally {
-                if (inFlightSignatureRef.current === requestSignature) {
-                    inFlightSignatureRef.current = null
-                }
+                release(requestSignature)
             }
         },
-        [analyticsEngine]
+        [analyticsEngine, reserve, release]
     )
 
     return [fetchAnalyticsData, state]

--- a/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
@@ -4,9 +4,13 @@ import { type FetchError, useDataEngine } from '@dhis2/app-runtime'
 import { logger } from '@modules/logger'
 import { getSingleProgramFromVisualization } from '@modules/visualization/program'
 import type { CurrentUser, CurrentVisualization } from '@types'
-import { useCallback, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import { getAnalyticsEndpoint } from './query-tools-common'
-import { getAdaptedVisualization } from './query-tools-pivot-table'
+import {
+    getAdaptedVisualization,
+    getBaseRequestIdentity,
+    getCustomValueRequestParams,
+} from './query-tools-pivot-table'
 
 type FetchAnalyticsDataForPTInternalParams = {
     analyticsEngine: ReturnType<typeof Analytics.getAnalytics>
@@ -53,10 +57,11 @@ export const fetchAnalyticsDataForPT = async ({
     }
 
     // add custom value and aggregationType
-    if (visualization.value && visualization.aggregationType) {
+    const customValueParams = getCustomValueRequestParams(visualization)
+    if (customValueParams) {
         req = req
-            .withValue(visualization.value.id)
-            .withAggregationType(visualization.aggregationType)
+            .withValue(customValueParams.value)
+            .withAggregationType(customValueParams.aggregationType)
     }
 
     if (relativePeriodDate) {
@@ -109,6 +114,8 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
         data: null,
     })
 
+    const inFlightSignatureRef = useRef<string | null>(null)
+
     const fetchAnalyticsData: FetchAnalyticsDataFn = useCallback(
         async ({
             visualization,
@@ -116,6 +123,20 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
             displayProperty,
             onResponseReceived,
         }) => {
+            const runtime = {
+                filters: filters ?? null,
+                displayProperty,
+            }
+            const requestSignature = JSON.stringify({
+                ...getBaseRequestIdentity(visualization),
+                ...runtime,
+            })
+
+            if (inFlightSignatureRef.current === requestSignature) {
+                return
+            }
+            inFlightSignatureRef.current = requestSignature
+
             setState((prevState) => ({
                 ...prevState,
                 isFetching: true,
@@ -152,6 +173,10 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
                     error: error as FetchError,
                     isFetching: false,
                 })
+            } finally {
+                if (inFlightSignatureRef.current === requestSignature) {
+                    inFlightSignatureRef.current = null
+                }
             }
         },
         [analyticsEngine]

--- a/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
+++ b/src/components/plugin-wrapper/hooks/use-pivot-table-analytics-data.ts
@@ -123,13 +123,10 @@ const usePivotTableAnalyticsData = (): UseAnalyticsDataResult => {
             displayProperty,
             onResponseReceived,
         }) => {
-            const runtime = {
-                filters: filters ?? null,
-                displayProperty,
-            }
             const requestSignature = JSON.stringify({
                 ...getBaseRequestIdentity(visualization),
-                ...runtime,
+                filters: filters ?? null,
+                displayProperty,
             })
 
             if (inFlightSignatureRef.current === requestSignature) {

--- a/src/components/plugin-wrapper/plugin-wrapper.tsx
+++ b/src/components/plugin-wrapper/plugin-wrapper.tsx
@@ -1,5 +1,6 @@
 import { Center, CircularLoader } from '@dhis2/ui'
 import { useAppSelector } from '@hooks'
+import { assertNever } from '@modules/utils/guards'
 import { isVisualizationEmpty } from '@modules/visualization/state'
 import { createSelector } from '@reduxjs/toolkit'
 import type {
@@ -11,27 +12,32 @@ import type {
 } from '@types'
 import type { FC } from 'react'
 import { useCallback, useEffect, useState } from 'react'
+import { getBaseRequestIdentity as getLineListBaseRequestIdentity } from './hooks/query-tools-line-list'
+import { getBaseRequestIdentity as getPivotTableBaseRequestIdentity } from './hooks/query-tools-pivot-table'
 import { LineListPlugin } from './line-list-plugin'
 import { PivotTablePlugin } from './pivot-table-plugin'
 import classes from './styles/plugin-wrapper.module.css'
 
-const getCurrentVisLayoutKey = createSelector(
-    (state: RootState) => state.currentVis.outputType,
-    (state: RootState) => state.currentVis.columns,
-    (state: RootState) => state.currentVis.rows,
-    (state: RootState) => state.currentVis.filters,
-    (state: RootState) => state.currentVis.value?.id,
-    (state: RootState) => state.currentVis.aggregationType,
-    // eslint-disable-next-line max-params
-    (outputType, columns, rows, filters, valueId, aggregationType) =>
-        [
-            outputType ?? '',
-            valueId ?? '',
-            aggregationType ?? '',
-            ...[...(columns ?? []), ...(rows ?? []), ...(filters ?? [])].map(
-                (d) => d.dimension
-            ),
-        ].join('|')
+const getBaseRequestIdentity = (currentVis: CurrentVisualization) => {
+    switch (currentVis.type) {
+        case 'LINE_LIST':
+            return getLineListBaseRequestIdentity(currentVis)
+        case 'PIVOT_TABLE':
+            return getPivotTableBaseRequestIdentity(currentVis)
+        default:
+            return assertNever(currentVis.type)
+    }
+}
+
+/* The plugin's React key: it remounts (clearing the canvas, resetting sort and
+ * page) when the base request identity changes. Sorting and paging aren't in
+ * it, so they refetch in place instead of remounting. */
+const getCurrentVisRequestKey = createSelector(
+    (state: RootState) => state.currentVis,
+    (currentVis) =>
+        isVisualizationEmpty(currentVis)
+            ? ''
+            : JSON.stringify(getBaseRequestIdentity(currentVis))
 )
 
 type PluginWrapperProps = {
@@ -53,7 +59,7 @@ export const PluginWrapper: FC<PluginWrapperProps> = ({
     isVisualizationLoading = false,
     onDataSorted,
 }) => {
-    const layoutKey = useAppSelector(getCurrentVisLayoutKey)
+    const requestKey = useAppSelector(getCurrentVisRequestKey)
     const [hasAnalyticsData, setHasAnalyticsData] = useState(false)
 
     const onResponseReceived = useCallback(() => {
@@ -70,10 +76,10 @@ export const PluginWrapper: FC<PluginWrapperProps> = ({
     }, [isVisualizationLoading])
 
     useEffect(() => {
-        /* The visualization type specific plugin component remount when the layoutKey
-         * changes so this means the local state in this wrapper also needs to reset */
+        /* The plugin remounts when requestKey changes, so reset this wrapper's
+         * local state too */
         setHasAnalyticsData(false)
-    }, [layoutKey])
+    }, [requestKey])
 
     if (isVisualizationEmpty(visualization)) {
         return null
@@ -88,7 +94,7 @@ export const PluginWrapper: FC<PluginWrapperProps> = ({
             )}
             {visualization.type === 'LINE_LIST' && (
                 <LineListPlugin
-                    key={layoutKey}
+                    key={requestKey}
                     displayProperty={displayProperty}
                     visualization={visualization}
                     filters={filters}
@@ -100,7 +106,7 @@ export const PluginWrapper: FC<PluginWrapperProps> = ({
             )}
             {visualization.type === 'PIVOT_TABLE' && (
                 <PivotTablePlugin
-                    key={layoutKey}
+                    key={requestKey}
                     displayProperty={displayProperty}
                     visualization={visualization}
                     filters={filters}

--- a/src/modules/utils/guards.ts
+++ b/src/modules/utils/guards.ts
@@ -5,3 +5,9 @@ export const isObject = (input: unknown): input is Record<string, unknown> => {
 export const isPopulatedString = (input: unknown): input is string => {
     return typeof input === 'string' && input.trim().length > 0
 }
+
+/* Exhaustiveness guard: the default branch of an exhaustive switch narrows to
+ * `never`, so a new unhandled union member fails to type-check here. */
+export const assertNever = (value: never): never => {
+    throw new Error(`Unhandled value: ${JSON.stringify(value)}`)
+}


### PR DESCRIPTION
Implements [DHIS2-21640](https://dhis2.atlassian.net/browse/DHIS2-21640)

### Description

**DHIS2-21640** is about preventing identical analytics requests firing repeatedly. When I started on this issue it occurred to me that we could (partly) re-use the `layoutKey` used to remount the LL and PT plugin components. The basic idea was sound, but it led me to the conclusion that the way the `layoutKey` was being produced was not correct: it didn't take into account all fields that actually require the visualisation to fully reload. So I extended the scope of the issue to also include a fix for this, since both duplicate request prevention and component remounting should be based on the same mechanism: a unique request identifier.

#### Changes
- `getBaseRequestIdentity(vis)` added per `visType` (`query-tools-line-list.ts`, `query-tools-pivot-table.ts`), built on the existing `getAdaptedVisualization` so it can't drift from the real request. It's the request as the visualization defines it, excluding per-fetch inputs (sorting, paging, relativePeriodDate, displayProperty).
- `plugin-wrapper.tsx`: replaced `getCurrentVisLayoutKey` (dimension-ids only) with `getCurrentVisRequestKey = JSON.stringify(getBaseRequestIdentity(...))`, chosen via an exhaustive switch on visType. This fixes the stale-params bug — structural changes now remount + refetch, while sorting/paging stay out and refetch in place.
- Both analytics hooks: an in-flight dedup — a request signature (base identity + per-fetch inputs) held in a ref; a fetch is skipped when an identical request is already running.
- `getCustomValueRequestParams` extracted in the pivot query-tools and shared with the PT request builder so the request and the identity can't disagree.
- `assertNever` added to @modules/utils/guards, used by the visType switch.
- New `query-tools.spec.ts` tests (incl. the items-change regression).

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

[DHIS2-21640]: https://dhis2.atlassian.net/browse/DHIS2-21640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ