### PR TITLE
feat: disable modals update buttons when no visualization is shown [DHIS2-21637]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -103,9 +103,6 @@ msgstr "Show more of the most recent events"
 msgid "Hide"
 msgstr "Hide"
 
-msgid "Update"
-msgstr "Update"
-
 msgid "Start and end dates are inclusive and will be included in the outputs."
 msgstr "Start and end dates are inclusive and will be included in the outputs."
 
@@ -379,6 +376,12 @@ msgstr "Aggregation"
 msgid "Cancel"
 msgstr "Cancel"
 
+msgid "Update"
+msgstr "Update"
+
+msgid "Select a value before updating"
+msgstr "Select a value before updating"
+
 msgid ""
 "\"{{- itemName}}\" is from a different stage than the dimensions in the "
 "layout. Choose another item."
@@ -602,6 +605,9 @@ msgstr "Table subtitle"
 
 msgid "Labels"
 msgstr "Labels"
+
+msgid "Create a {{- visType}} before updating"
+msgstr "Create a {{- visType}} before updating"
 
 msgid "Metadata"
 msgstr "Metadata"

--- a/src/components/dimension-modal/dimension-modal.tsx
+++ b/src/components/dimension-modal/dimension-modal.tsx
@@ -1,5 +1,6 @@
 import type { LayoutDimension } from '@components/layout-panel/axis/chip'
 import { useDimensionSuffix } from '@components/layout-panel/use-layout-dimensions'
+import { UpdateButton } from '@components/shared/update-button'
 import i18n from '@dhis2/d2-i18n'
 import {
     Modal,
@@ -112,14 +113,10 @@ export const DimensionModal: FC<DimensionModalProps> = ({ onClose }) => {
                         {i18n.t('Hide')}
                     </Button>
                     {isInLayout ? (
-                        <Button
-                            type="button"
-                            primary
+                        <UpdateButton
                             onClick={onUpdate}
                             dataTest={`${dataTest}-action-confirm`}
-                        >
-                            {i18n.t('Update')}
-                        </Button>
+                        />
                     ) : (
                         <AddToLayoutButton
                             onClick={onClose}

--- a/src/components/layout-panel/custom-value-modal/__tests__/custom-value-modal.spec.tsx
+++ b/src/components/layout-panel/custom-value-modal/__tests__/custom-value-modal.spec.tsx
@@ -225,10 +225,11 @@ describe('CustomValueModal', () => {
             expect(screen.getByText('Weight in kg')).toBeInTheDocument()
         })
 
-        const updateButton = screen.getByRole('button', { name: 'Update' })
-        expect(updateButton).toBeDisabled()
+        expect(screen.getByRole('button', { name: 'Update' })).toBeDisabled()
 
         await user.click(screen.getByText('Weight in kg'))
+
+        const updateButton = screen.getByRole('button', { name: 'Update' })
         expect(updateButton).toBeEnabled()
 
         await user.click(updateButton)

--- a/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
+++ b/src/components/layout-panel/custom-value-modal/custom-value-modal.tsx
@@ -15,6 +15,7 @@ import {
     NoticeBox,
     SingleSelectField,
     SingleSelectOption,
+    Tooltip,
 } from '@dhis2/ui'
 import {
     useAppDispatch,
@@ -251,14 +252,35 @@ export const CustomValueModal: FC<CustomValueModalProps> = ({ onClose }) => {
                     <Button type="button" secondary onClick={onClose}>
                         {i18n.t('Cancel')}
                     </Button>
-                    <Button
-                        type="button"
-                        primary
-                        onClick={onUpdate}
-                        disabled={!selectedItemId}
-                    >
-                        {i18n.t('Update')}
-                    </Button>
+                    {selectedItemId ? (
+                        <Button type="button" primary onClick={onUpdate}>
+                            {i18n.t('Update')}
+                        </Button>
+                    ) : (
+                        <Tooltip
+                            content={i18n.t('Select a value before updating')}
+                        >
+                            {({
+                                onMouseOver,
+                                onMouseOut,
+                                onFocus,
+                                onBlur,
+                                ref,
+                            }) => (
+                                <span
+                                    onMouseOver={onMouseOver}
+                                    onMouseOut={onMouseOut}
+                                    onFocus={onFocus}
+                                    onBlur={onBlur}
+                                    ref={ref}
+                                >
+                                    <Button type="button" primary disabled>
+                                        {i18n.t('Update')}
+                                    </Button>
+                                </span>
+                            )}
+                        </Tooltip>
+                    )}
                 </ButtonStrip>
             </ModalActions>
         </Modal>

--- a/src/components/options/options-modal.tsx
+++ b/src/components/options/options-modal.tsx
@@ -1,3 +1,4 @@
+import { UpdateButton } from '@components/shared/update-button'
 import i18n from '@dhis2/d2-i18n'
 import {
     Button,
@@ -11,8 +12,6 @@ import {
 } from '@dhis2/ui'
 import { useAppDispatch, useAppSelector } from '@hooks'
 import { getOptionsTabsForVisType } from '@modules/options'
-import { isVisualizationEmpty } from '@modules/visualization/state'
-import { getCurrentVis } from '@store/current-vis-slice'
 import { tUpdateCurrentVisFromVisUiConfig } from '@store/thunks'
 import { getVisUiConfigVisualizationType } from '@store/vis-ui-config-slice'
 import type { OptionsTabKey } from '@types'
@@ -29,7 +28,6 @@ export const OptionsModal: FC<OptionsModalProps> = ({ onClose }) => {
     const dispatch = useAppDispatch()
 
     const visType = useAppSelector(getVisUiConfigVisualizationType)
-    const currentVis = useAppSelector(getCurrentVis)
 
     const [activeTabKey, setActiveTabKey] = useState<OptionsTabKey>('data')
 
@@ -80,15 +78,11 @@ export const OptionsModal: FC<OptionsModalProps> = ({ onClose }) => {
                     >
                         {i18n.t('Hide')}
                     </Button>
-                    <Button
+                    <UpdateButton
                         dataTest={'options-modal-action-confirm'}
                         form={FORM_ID}
                         type="submit"
-                        primary
-                        disabled={isVisualizationEmpty(currentVis)}
-                    >
-                        {i18n.t('Update')}
-                    </Button>
+                    />
                 </ButtonStrip>
             </ModalActions>
         </Modal>

--- a/src/components/shared/__tests__/update-button.spec.tsx
+++ b/src/components/shared/__tests__/update-button.spec.tsx
@@ -1,0 +1,103 @@
+import { UpdateButton } from '@components/shared/update-button'
+import { visTypeDisplayNames } from '@dhis2/analytics'
+import { currentVisSlice } from '@store/current-vis-slice'
+import {
+    initialState as visUiConfigInitialState,
+    visUiConfigSlice,
+} from '@store/vis-ui-config-slice'
+import { renderWithReduxStoreProvider } from '@test-utils/render-with-redux-store-provider'
+import { setupStore } from '@test-utils/setup-store'
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { RootState, VisualizationType } from '@types'
+import { describe, it, expect, vi } from 'vitest'
+
+const setupTestStore = (
+    currentVis: RootState['currentVis'],
+    visualizationType: VisualizationType = 'PIVOT_TABLE'
+) =>
+    setupStore(
+        {
+            [currentVisSlice.name]: currentVisSlice.reducer,
+            [visUiConfigSlice.name]: visUiConfigSlice.reducer,
+        },
+        {
+            currentVis,
+            visUiConfig: { ...visUiConfigInitialState, visualizationType },
+        }
+    )
+
+const emptyVis: RootState['currentVis'] = {}
+const populatedVis = { type: 'PIVOT_TABLE' } as RootState['currentVis']
+
+describe('UpdateButton', () => {
+    it('renders an enabled primary button that calls onClick when the visualization is populated', async () => {
+        const user = userEvent.setup()
+        const onClick = vi.fn()
+
+        renderWithReduxStoreProvider(
+            <UpdateButton onClick={onClick} />,
+            setupTestStore(populatedVis)
+        )
+
+        const button = screen.getByRole('button', { name: 'Update' })
+        expect(button).toBeEnabled()
+
+        await user.click(button)
+        expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it('disables the button and shows the create tooltip when the visualization is empty', async () => {
+        const user = userEvent.setup()
+        const onClick = vi.fn()
+
+        renderWithReduxStoreProvider(
+            <UpdateButton onClick={onClick} />,
+            setupTestStore(emptyVis, 'PIVOT_TABLE')
+        )
+
+        const button = screen.getByRole('button', { name: 'Update' })
+        expect(button).toBeDisabled()
+
+        await user.hover(button)
+        await expect(
+            screen.findByText(
+                `Create a ${visTypeDisplayNames['PIVOT_TABLE']} before updating`
+            )
+        ).resolves.toBeInTheDocument()
+
+        await user.click(button)
+        expect(onClick).not.toHaveBeenCalled()
+    })
+
+    it('names the visualization type in the tooltip', async () => {
+        const user = userEvent.setup()
+
+        renderWithReduxStoreProvider(
+            <UpdateButton onClick={vi.fn()} />,
+            setupTestStore(emptyVis, 'LINE_LIST')
+        )
+
+        await user.hover(screen.getByRole('button', { name: 'Update' }))
+        await expect(
+            screen.findByText(
+                `Create a ${visTypeDisplayNames['LINE_LIST']} before updating`
+            )
+        ).resolves.toBeInTheDocument()
+    })
+
+    it('submits the associated form when used as a submit button', async () => {
+        const user = userEvent.setup()
+        const onSubmit = vi.fn((e) => e.preventDefault())
+
+        renderWithReduxStoreProvider(
+            <form id="test-form" onSubmit={onSubmit}>
+                <UpdateButton type="submit" form="test-form" />
+            </form>,
+            setupTestStore(populatedVis)
+        )
+
+        await user.click(screen.getByRole('button', { name: 'Update' }))
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+    })
+})

--- a/src/components/shared/update-button.tsx
+++ b/src/components/shared/update-button.tsx
@@ -1,0 +1,66 @@
+import { visTypeDisplayNames } from '@dhis2/analytics'
+import i18n from '@dhis2/d2-i18n'
+import { Button, Tooltip } from '@dhis2/ui'
+import { useAppSelector } from '@hooks'
+import { isVisualizationEmpty } from '@modules/visualization/state'
+import { getCurrentVis } from '@store/current-vis-slice'
+import { getVisUiConfigVisualizationType } from '@store/vis-ui-config-slice'
+import { type FC } from 'react'
+
+type UpdateButtonProps = {
+    onClick?: () => void
+    dataTest?: string
+    type?: 'button' | 'submit'
+    form?: string
+}
+
+export const UpdateButton: FC<UpdateButtonProps> = ({
+    onClick,
+    dataTest = 'update-button',
+    type = 'button',
+    form,
+}) => {
+    const currentVis = useAppSelector(getCurrentVis)
+    const visType = useAppSelector(getVisUiConfigVisualizationType)
+
+    if (isVisualizationEmpty(currentVis)) {
+        return (
+            <Tooltip
+                content={i18n.t('Create a {{- visType}} before updating', {
+                    visType: visTypeDisplayNames[visType],
+                })}
+            >
+                {({ onMouseOver, onMouseOut, onFocus, onBlur, ref }) => (
+                    <span
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                        onFocus={onFocus}
+                        onBlur={onBlur}
+                        ref={ref}
+                    >
+                        <Button
+                            disabled
+                            type={type}
+                            form={form}
+                            dataTest={dataTest}
+                        >
+                            {i18n.t('Update')}
+                        </Button>
+                    </span>
+                )}
+            </Tooltip>
+        )
+    }
+
+    return (
+        <Button
+            type={type}
+            form={form}
+            primary
+            onClick={onClick}
+            dataTest={dataTest}
+        >
+            {i18n.t('Update')}
+        </Button>
+    )
+}


### PR DESCRIPTION
Implements [DHIS2-21637](https://dhis2.atlassian.net/browse/DHIS2-21637)

### Description

Disable the update button in dimension and options modals when no visualization is shown in the canvas.
The `outputType` needs to be set before the update can take place.
The button also gets a tooltip explaining why it is disabled.

The update button in the Options modal had already the disabling logic, but lacked the tooltip.
The update button in the Dimension modal didn't have any logic and was always updated.

The update button in the custom value modal is a bit different because it sets the `outputType` to `EVENT` and thus the visualization can be rendered.
The button is disabled when there is no custom value selection.

A new shared component has been added and used in both the dimension and options modals.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---


### Screenshots

Update button disabled in dimension modal:
<img width="878" height="669" alt="Screenshot 2026-07-06 at 15 33 22" src="https://github.com/user-attachments/assets/9405b207-32b8-4ae0-8317-0022fe5c43ec" />

Update button disabled in options modal:
<img width="875" height="289" alt="Screenshot 2026-07-06 at 15 41 08" src="https://github.com/user-attachments/assets/87701da7-e257-43f8-9cb8-53a999740bc3" />

Update button enabled when a visualization is present in the canvas:
<img width="1023" height="732" alt="Screenshot 2026-07-06 at 15 33 59" src="https://github.com/user-attachments/assets/90805dc6-5da0-4b09-9049-c8e3b9c1ed4d" />

Update button disabled in custom value modal:
<img width="853" height="522" alt="Screenshot 2026-07-06 at 15 33 13" src="https://github.com/user-attachments/assets/518c3ad5-31d5-4572-bf1b-c94e59a763cc" />

Update button enabled when a custom value is selected (even with no visualization in the canvas):
<img width="824" height="528" alt="Screenshot 2026-07-06 at 15 42 29" src="https://github.com/user-attachments/assets/15ad5463-fc6a-4f49-aa36-373b411c5ed8" />


[DHIS2-21637]: https://dhis2.atlassian.net/browse/DHIS2-21637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ