### PR TITLE
chore(deps): stop Dependabot proposing TypeScript 7.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,13 @@ updates:
           - dependency-name: '@types/react-dom'
             versions:
                 - '>=19'
+          # TypeScript 7.0 is the native rewrite and ships no compiler API, so
+          # openapi-typescript (our type generator) can't run under it. The API
+          # returns in 7.1 — bound the ignore to the 7.0 line so Dependabot
+          # resumes proposing upgrades automatically once 7.1 lands.
+          - dependency-name: typescript
+            versions:
+                - '7.0.x'
       groups:
           security:
               applies-to: security-updates


### PR DESCRIPTION
TypeScript 7.0 is the native rewrite and ships no compiler API, so openapi-typescript (used in generate-types) crashes under it and the install/CI fails. The API returns in 7.1 so we instruct dependabot to stop producing PRs until is released.

Note that even though TypeScript v7.1 will ship with a JavaScript compiler API, this doesn't mean that openapi-typescript will start working again out-of-the-box. It could, but it's also possible that it won't and then there is going to be a period where dependabot starts creating PRs for a TS upgrade that we cannot merge. This is annoying but I don't think there is a way around this.
