### PR TITLE
chore(sbx): stop the mount sandbox from claiming host port 3000

### DIFF
--- a/.sbx/mount.md
+++ b/.sbx/mount.md
@@ -1,5 +1,3 @@
 These are the human's LIVE working files, bind-mounted from the host; your edits appear immediately in their editor. Run tests and builds directly: `pnpm test`, `pnpm lint`, `pnpm start`.
 
 DO NOT branch or commit — the human reviews your diffs and commits on the host.
-
-A dev server you start (e.g. `pnpm start`) is reachable from the host at http://localhost:3000.

--- a/docs/claude-sandboxes.md
+++ b/docs/claude-sandboxes.md
@@ -36,7 +36,7 @@ This logs in to Docker, sets the default network policy, **builds the sandbox im
 
 ## Mount sandbox — hands-on, live files (`pnpm sbx:mount`)
 
-The agent edits your live working tree (changes show up in your editor immediately) and can run tests/build inside the sandbox, with no permission prompts but a constrained network. You review diffs and commit on the host. A dev server the agent starts is published to `http://localhost:3000`.
+The agent edits your live working tree (changes show up in your editor immediately) and can run tests/build inside the sandbox, with no permission prompts but a constrained network. You review diffs and commit on the host. The agent's dev server stays inside the sandbox (it drives it there with `playwright-cli`); to view the app yourself, run `pnpm start` on the host against the same live files.
 
 > **node_modules isolation:** on every mount the script overlays `node_modules` with a container-local directory (`sudo mount --bind` of `/home/agent/nm` over the repo's `node_modules`) and runs `pnpm install` into it — so everything the agent installs stays inside the sandbox and your host `node_modules` is never touched. This is **mandatory**: if the overlay can't be established the mount **aborts** rather than falling back to the host-backed `node_modules`. The install runs on first mount (a few minutes; reused while the lockfile is unchanged), and a guarded remount in the sandbox's startup re-applies the overlay if the sandbox ever restarts. Changed dependencies while the sandbox is up? `./scripts/sbx.sh refresh-deps`.
 

--- a/scripts/sbx.sh
+++ b/scripts/sbx.sh
@@ -5,7 +5,6 @@ REPO_ROOT="$(git rev-parse --show-toplevel)"
 PROJECT="$(basename "$REPO_ROOT")"
 MOUNT_NAME="${PROJECT}-mount"
 CLONE_NAME="${PROJECT}-clone"
-DEV_PORT=3000
 IMAGE_TAG="${PROJECT}-sbx:latest"
 SBX_DIR="$REPO_ROOT/.sbx"
 PNPM_VERSION="$(node -p "require('$REPO_ROOT/package.json').packageManager.split('@')[1].split('+')[0]" 2>/dev/null || echo latest)"
@@ -330,7 +329,6 @@ cmd_mount() {
         # Neovim; a RW mount let the sandbox's failed connect delete the host's lock.
         if [ -d "$(ide_dir)" ]; then extra+=("$(ide_dir):ro"); fi
         sbx create -t "$IMAGE_TAG" claude "$REPO_ROOT" ${extra[@]+"${extra[@]}"} --name "$MOUNT_NAME"
-        sbx ports "$MOUNT_NAME" --publish "${DEV_PORT}:${DEV_PORT}" || true
         configure_policy "$MOUNT_NAME"
         accept_trust "$MOUNT_NAME"
         link_host_dirs "$MOUNT_NAME"


### PR DESCRIPTION
The mount sandbox published its dev-server port (3000) to the host at creation time. Publishing makes the host-side sbx process bind and listen on port 3000 for the sandbox's whole lifetime, so the host's own `pnpm start` could no longer use 3000 and fell back to 3001 — even when nothing inside the sandbox was serving.

The publish had no real benefit in mount mode: the agent drives its dev server in-sandbox via playwright-cli (reaching the sandbox's own localhost:3000 directly), and the human shares the same live files so can just run the dev server on the host. Remove the publish and the now-unused DEV_PORT, and update the docs and mount note accordingly. It can still be published on demand with `sbx ports <name> --publish 3000:3000`.

_I'm going to merge this without approval as soon as the checks are green_