### PR TITLE
fix: solve React error in condition modal Tabs [DHIS2-20947]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-07-03T12:42:31.329Z\n"
-"PO-Revision-Date: 2026-07-03T12:42:31.331Z\n"
+"POT-Creation-Date: 2026-08-04T13:38:19.672Z\n"
+"PO-Revision-Date: 2026-08-04T13:38:19.673Z\n"
 
 msgid ""
 "Some dimensions were not added because they cannot be used in a "
@@ -37,14 +37,14 @@ msgstr "Case sensitive"
 msgid "Delete filter"
 msgstr "Delete filter"
 
+msgid "Only available for repeatable stages"
+msgstr "Only available for repeatable stages"
+
 msgid "Repeated events"
 msgstr "Repeated events"
 
 msgid "Data"
 msgstr "Data"
-
-msgid "Only available for repeatable stages"
-msgstr "Only available for repeatable stages"
 
 msgid "{{valueType}} type dimensions cannot be filtered."
 msgstr "{{valueType}} type dimensions cannot be filtered."

--- a/src/components/dimension-modal/conditions-modal-content/conditions-modal-content.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/conditions-modal-content.tsx
@@ -3,7 +3,13 @@ import { Tooltip, TabBar, Tab } from '@dhis2/ui'
 import { useAppSelector, useProgramStageMetadataItem } from '@hooks'
 import { getVisUiConfigVisualizationType } from '@store/vis-ui-config-slice.js'
 import type { DimensionMetadataItem } from '@types'
-import { forwardRef, useState, type FC, type ReactNode, type Ref } from 'react'
+import {
+    forwardRef,
+    useState,
+    type FC,
+    type MutableRefObject,
+    type ReactNode,
+} from 'react'
 import { ConditionsTabContent } from './conditions-tab-content'
 import { RepeatedEventsTabContent } from './repeated-events-tab-content'
 import classes from './styles/conditions-modal-content.module.css'
@@ -11,45 +17,40 @@ import classes from './styles/conditions-modal-content.module.css'
 const TAB_CONDITIONS = 'CONDITIONS'
 const TAB_REPEATABLE_EVENTS = 'REPEATABLE_EVENTS'
 
-const assignRef = <T,>(ref: Ref<T>, node: T | null): void => {
-    if (typeof ref === 'function') {
-        ref(node)
-    } else if (ref) {
-        ;(ref as { current: T | null }).current = node
-    }
-}
-
-/*
- * TabBar injects a ref into each direct child and calls .focus() on it for
- * keyboard navigation, so a child must resolve to a DOM node. Tooltip is not a
- * forwardRef component, so it can't be that child directly. This wrapper is the
- * direct child instead: it forwards TabBar's ref onto the same <span> the
- * tooltip anchors to, and that span (not the disabled tab) receives the hover
- * that opens the tooltip.
- */
-const RepeatableEventsTabTooltip = forwardRef<
+/* TabBar injects a ref into each direct child, so we must use a component
+ * that accepts a ref. The Tooltip renderProps params also expose a ref
+ * that needs to be attached to the returned element. So we need to attach
+ * two refs to one node. Both refs are object refs (TabBar's via createRef,
+ * Tooltip's via useRef), but their declared types are wider, so we narrow
+ * them to assign the span node. */
+const TooltipWithForwardRef = forwardRef<
     HTMLSpanElement,
     { children: ReactNode }
->(function RepeatableEventsTabTooltip({ children }, tabBarRef) {
+>(function RepeatableEventsTabTooltip({ children }, ref) {
+    const tabBarRef = ref as MutableRefObject<HTMLSpanElement | null>
     return (
         <Tooltip
             placement="bottom"
             content={i18n.t('Only available for repeatable stages')}
             dataTest="repeatable-events-tooltip"
         >
-            {({ onMouseOver, onMouseOut, ref: tooltipRef }) => (
-                <span
-                    ref={(node) => {
-                        assignRef(tabBarRef, node)
-                        assignRef(tooltipRef, node)
-                    }}
-                    onMouseOver={onMouseOver}
-                    onMouseOut={onMouseOut}
-                    className={classes.tooltipReference}
-                >
-                    {children}
-                </span>
-            )}
+            {({ onMouseOver, onMouseOut, ref }) => {
+                const tooltipRef =
+                    ref as MutableRefObject<HTMLSpanElement | null>
+                return (
+                    <span
+                        ref={(node) => {
+                            tabBarRef.current = node
+                            tooltipRef.current = node
+                        }}
+                        onMouseOver={onMouseOver}
+                        onMouseOut={onMouseOut}
+                        className={classes.tooltipReference}
+                    >
+                        {children}
+                    </span>
+                )
+            }}
         </Tooltip>
     )
 })
@@ -94,9 +95,9 @@ export const ConditionsModalContent: FC<ConditionsModalContentProps> = ({
                         {i18n.t('Data')}
                     </Tab>
                     {disableRepeatableTab ? (
-                        <RepeatableEventsTabTooltip key={TAB_REPEATABLE_EVENTS}>
+                        <TooltipWithForwardRef key={TAB_REPEATABLE_EVENTS}>
                             {repeatableTab}
-                        </RepeatableEventsTabTooltip>
+                        </TooltipWithForwardRef>
                     ) : (
                         repeatableTab
                     )}

--- a/src/components/dimension-modal/conditions-modal-content/conditions-modal-content.tsx
+++ b/src/components/dimension-modal/conditions-modal-content/conditions-modal-content.tsx
@@ -2,14 +2,57 @@ import i18n from '@dhis2/d2-i18n'
 import { Tooltip, TabBar, Tab } from '@dhis2/ui'
 import { useAppSelector, useProgramStageMetadataItem } from '@hooks'
 import { getVisUiConfigVisualizationType } from '@store/vis-ui-config-slice.js'
-import type { DimensionMetadataItem /*, ValueType */ } from '@types'
-import { useState, type FC, type ReactNode } from 'react'
+import type { DimensionMetadataItem } from '@types'
+import { forwardRef, useState, type FC, type ReactNode, type Ref } from 'react'
 import { ConditionsTabContent } from './conditions-tab-content'
 import { RepeatedEventsTabContent } from './repeated-events-tab-content'
 import classes from './styles/conditions-modal-content.module.css'
 
 const TAB_CONDITIONS = 'CONDITIONS'
 const TAB_REPEATABLE_EVENTS = 'REPEATABLE_EVENTS'
+
+const assignRef = <T,>(ref: Ref<T>, node: T | null): void => {
+    if (typeof ref === 'function') {
+        ref(node)
+    } else if (ref) {
+        ;(ref as { current: T | null }).current = node
+    }
+}
+
+/*
+ * TabBar injects a ref into each direct child and calls .focus() on it for
+ * keyboard navigation, so a child must resolve to a DOM node. Tooltip is not a
+ * forwardRef component, so it can't be that child directly. This wrapper is the
+ * direct child instead: it forwards TabBar's ref onto the same <span> the
+ * tooltip anchors to, and that span (not the disabled tab) receives the hover
+ * that opens the tooltip.
+ */
+const RepeatableEventsTabTooltip = forwardRef<
+    HTMLSpanElement,
+    { children: ReactNode }
+>(function RepeatableEventsTabTooltip({ children }, tabBarRef) {
+    return (
+        <Tooltip
+            placement="bottom"
+            content={i18n.t('Only available for repeatable stages')}
+            dataTest="repeatable-events-tooltip"
+        >
+            {({ onMouseOver, onMouseOut, ref: tooltipRef }) => (
+                <span
+                    ref={(node) => {
+                        assignRef(tabBarRef, node)
+                        assignRef(tooltipRef, node)
+                    }}
+                    onMouseOver={onMouseOver}
+                    onMouseOut={onMouseOut}
+                    className={classes.tooltipReference}
+                >
+                    {children}
+                </span>
+            )}
+        </Tooltip>
+    )
+})
 
 type ConditionsModalContentProps = {
     dimension: DimensionMetadataItem
@@ -51,16 +94,9 @@ export const ConditionsModalContent: FC<ConditionsModalContentProps> = ({
                         {i18n.t('Data')}
                     </Tab>
                     {disableRepeatableTab ? (
-                        <Tooltip
-                            key="repeatable-tooltip"
-                            placement="bottom"
-                            content={i18n.t(
-                                'Only available for repeatable stages'
-                            )}
-                            dataTest="repeatable-events-tooltip"
-                        >
+                        <RepeatableEventsTabTooltip key={TAB_REPEATABLE_EVENTS}>
                             {repeatableTab}
-                        </Tooltip>
+                        </RepeatableEventsTabTooltip>
                     ) : (
                         repeatableTab
                     )}


### PR DESCRIPTION
Implements [DHIS2-20947](https://dhis2.atlassian.net/browse/DHIS2-20947)

### Description

Opening the conditions modal for a data element on a non-repeatable stage (e.g. Child Programme → MCH Apgar Score) logged a React warning on first load:

> Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()? 
> Check the render method of Tabs.

`@dhis2/ui`'s `TabBar` renders an internal `Tabs` component that clones each direct child and injects a ref into it (used to call .focus() for keyboard navigation).
This works for `Tab` because it's a `forwardRef` component.
The disabled "Repeated events" tab was wrapped in a `Tooltip`, making `Tooltip` — a non-forwardRef function component — the direct child of `TabBar`. The injected ref hit the function component and triggered the warning.

The fix Introduced a small `forwardRef` wrapper (`RepeatableEventsTabTooltip`) that is now the direct child of `TabBar`. It forwards `TabBar`'s ref and the `Tooltip`'s anchor ref onto a single `<span>` element (via an `assignRef` helper), with the disabled `Tab` nested inside.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated N/A
- [x] Docs added N/A
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) N/A

---

### Screenshots

React error in console for reference:

<img width="1975" height="959" alt="Screenshot 2026-08-04 at 15 48 20" src="https://github.com/user-attachments/assets/f232bf04-88dd-43b8-8e76-0f53d0edf182" />


[DHIS2-20947]: https://dhis2.atlassian.net/browse/DHIS2-20947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ