### PR TITLE
fix: register program metadata for tracked entity visualizations

### DIFF
--- a/src/modules/metadata/__tests__/store.spec.ts
+++ b/src/modules/metadata/__tests__/store.spec.ts
@@ -1162,4 +1162,72 @@ describe('MetadataStore — TEA enrichment with trackedEntityTypeId', () => {
         expect(snapshot['teaFirst']).toBeDefined()
         expect(snapshot['teaFirst']).not.toHaveProperty('trackedEntityTypeId')
     })
+
+    it('TEI vis stores an org unit for every scope: registration, enrollment and stage', () => {
+        const store = new TestMetadataStore({}, [])
+
+        const orgUnitColumn = (
+            qualifiers: Record<string, { id: string }>,
+            dimension = 'ou'
+        ) => ({
+            dimension,
+            dimensionType: 'ORGANISATION_UNIT',
+            items: [{ id: 'USER_ORGUNIT' }],
+            ...qualifiers,
+        })
+
+        const vis = {
+            outputType: 'TRACKED_ENTITY_INSTANCE',
+            type: 'LINE_LIST',
+            trackedEntityType: { id: 'tetA', name: 'Person' },
+            programDimensions: [
+                {
+                    id: 'progA',
+                    name: 'Child Programme',
+                    programType: 'WITH_REGISTRATION',
+                    trackedEntityType: { id: 'tetA', name: 'Person' },
+                    programStages: [
+                        { id: 'stageA', name: 'Birth' },
+                        { id: 'stageB', name: 'Baby Postnatal' },
+                    ],
+                },
+            ],
+            columns: [
+                orgUnitColumn({}),
+                orgUnitColumn({ program: { id: 'progA' } }, 'enrollmentOu'),
+                orgUnitColumn({
+                    program: { id: 'progA' },
+                    programStage: { id: 'stageA' },
+                }),
+                orgUnitColumn({
+                    program: { id: 'progA' },
+                    programStage: { id: 'stageB' },
+                }),
+            ],
+            rows: [],
+            filters: [],
+            metaData: {},
+        } as unknown as SavedVisualization
+
+        store.setVisualizationMetadata(vis)
+
+        expect(store.getMetadataItem('tetA.enrollmentOu')).toMatchObject({
+            dimensionId: 'enrollmentOu',
+            trackedEntityTypeId: 'tetA',
+        })
+        expect(store.getMetadataItem('progA.enrollmentOu')).toMatchObject({
+            dimensionId: 'enrollmentOu',
+            programId: 'progA',
+        })
+        expect(store.getMetadataItem('progA.stageA.ou')).toMatchObject({
+            dimensionId: 'ou',
+            programId: 'progA',
+            programStageId: 'stageA',
+        })
+        expect(store.getMetadataItem('progA.stageB.ou')).toMatchObject({
+            dimensionId: 'ou',
+            programId: 'progA',
+            programStageId: 'stageB',
+        })
+    })
 })

--- a/src/modules/metadata/__tests__/visualization.spec.ts
+++ b/src/modules/metadata/__tests__/visualization.spec.ts
@@ -359,7 +359,7 @@ describe('extractProgramDimensionsMetadata', () => {
         })
     })
 
-    it('should return empty object for TRACKED_ENTITY_INSTANCE outputType', () => {
+    it('should return programs for TRACKED_ENTITY_INSTANCE outputType', () => {
         const visualization = {
             outputType: 'TRACKED_ENTITY_INSTANCE' as const,
             programDimensions: [
@@ -372,7 +372,10 @@ describe('extractProgramDimensionsMetadata', () => {
 
         const result = extractProgramDimensionsMetadata(visualization)
 
-        expect(result).toEqual({})
+        expect(result.program1).toMatchObject({
+            id: 'program1',
+            name: 'Program 1',
+        })
     })
 })
 

--- a/src/modules/metadata/visualization.ts
+++ b/src/modules/metadata/visualization.ts
@@ -81,10 +81,6 @@ export const extractProgramDimensionsMetadata = (
 ): MetadataInputMap => {
     const programDimensionsMetadata: MetadataInputMap = {}
 
-    if (visualization.outputType === 'TRACKED_ENTITY_INSTANCE') {
-        return programDimensionsMetadata
-    }
-
     // addMetadata will store the stages and TET alongside the program.
     visualization.programDimensions?.forEach((program) => {
         programDimensionsMetadata[program.id] = program


### PR DESCRIPTION
Implements [DHIS2-21990](https://dhis2.atlassian.net/browse/DHIS2-21990)

### Description

Loading a saved tracked entity visualization crashes with missing metadata:

> No context metadata found for dimension with compound ID "IpHINAT79UW.enrollmentOu"

`extractProgramDimensionsMetadata` returned early for `TRACKED_ENTITY_INSTANCE`, so the program was never added to the metadata store. But `getFixedDimensionOverrides` has no such guard and still builds dimensions like `IpHINAT79UW.enrollmentOu` from the same program list.

The store needs the program. `IpHINAT79UW.enrollmentOu` and `nEenWmSyUEp.enrollmentOu` look the same but mean different things — one is a program, the other a tracked entity type. The store tells them apart by looking up the first part. It wasn't there, so it threw. The throw is caught by the RTK query, so the whole visualization fails to load.

This hits any tracked entity visualization whose layout references a program, whatever dimensions are in it — the fixed dimensions are generated per program and per stage, not per dimension actually in the layout.

I removed the guard so the program is registered for every output type.

The guard looks like a leftover of incorrectly implemented code. When the function was introduced in #75 it also built time-dimension keys that were program-prefixed for `TRACKED_ENTITY_INSTANCE` only, so maybe the guard was meant for that — but it was far too broad, since it also skipped registering the program. #190 moved the time-dimension generation out, leaving the guard with nothing to do and making it completely safe to remove. And the same PR also added the `getFixedDimensionOverrides` that produces the program-prefixed IDs, which is where the bug starts.

---

### Quality checklist

<!--Checkmate-->

- [x] Dashboard tested N/A
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added N/A
- [x] d2-ci dependency replaced N/A

---


[DHIS2-21990]: https://dhis2.atlassian.net/browse/DHIS2-21990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ