### PR TITLE
fix: show coming soon types in vis type menu

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-08-13T18:13:55.581Z\n"
-"PO-Revision-Date: 2026-08-13T18:13:55.582Z\n"
+"POT-Creation-Date: 2026-08-20T08:58:29.430Z\n"
+"PO-Revision-Date: 2026-08-20T08:58:29.431Z\n"
 
 msgid ""
 "Some dimensions were not added because they cannot be used in a "
@@ -415,6 +415,21 @@ msgstr "{{- names}} will be removed. Are you sure?"
 
 msgid "Convert"
 msgstr "Convert"
+
+msgid "Column"
+msgstr "Column"
+
+msgid "Bar"
+msgstr "Bar"
+
+msgid "Line"
+msgstr "Line"
+
+msgid "Area"
+msgstr "Area"
+
+msgid "Coming soon"
+msgstr "Coming soon"
 
 msgid "Individual data view"
 msgstr "Individual data view"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-08-20T08:58:29.430Z\n"
-"PO-Revision-Date: 2026-08-20T08:58:29.431Z\n"
+"POT-Creation-Date: 2026-08-20T09:13:16.339Z\n"
+"PO-Revision-Date: 2026-08-20T09:13:16.339Z\n"
 
 msgid ""
 "Some dimensions were not added because they cannot be used in a "
@@ -415,18 +415,6 @@ msgstr "{{- names}} will be removed. Are you sure?"
 
 msgid "Convert"
 msgstr "Convert"
-
-msgid "Column"
-msgstr "Column"
-
-msgid "Bar"
-msgstr "Bar"
-
-msgid "Line"
-msgstr "Line"
-
-msgid "Area"
-msgstr "Area"
 
 msgid "Coming soon"
 msgstr "Coming soon"

--- a/src/components/layout-panel/top-bar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
+++ b/src/components/layout-panel/top-bar/visualization-type-selector/__tests__/visualization-type-selector.spec.tsx
@@ -46,6 +46,10 @@ describe('VisualizationTypeSelector', () => {
         expect(modal).toBeInTheDocument()
         expect(within(modal).getByText('Line list')).toBeInTheDocument()
         expect(within(modal).getByText('Pivot table')).toBeInTheDocument()
+        expect(within(modal).getByText('Column')).toBeInTheDocument()
+        expect(within(modal).getByText('Bar')).toBeInTheDocument()
+        expect(within(modal).getByText('Line')).toBeInTheDocument()
+        expect(within(modal).getByText('Area')).toBeInTheDocument()
     })
 
     it('changes vis type directly when nothing is discarded', async () => {

--- a/src/components/layout-panel/top-bar/visualization-type-selector/styles/visualization-type-selector.module.css
+++ b/src/components/layout-panel/top-bar/visualization-type-selector/styles/visualization-type-selector.module.css
@@ -56,6 +56,7 @@
     border: 1px solid var(--colors-grey300);
     box-shadow: var(--elevations-e400);
     padding: var(--spacers-dp8);
+    padding-inline-end: var(--spacers-dp16);
 }
 
 .section {
@@ -75,11 +76,12 @@
 
 .grid {
     display: grid;
-    grid-template-columns: repeat(7, 1fr);
+    grid-template-columns: repeat(5, 1fr);
     gap: 4px;
 }
 
 .gridItem {
+    position: relative;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -90,8 +92,36 @@
     background: var(--colors-grey100);
     cursor: pointer;
     transition: all 0.15s ease;
-    min-inline-size: 88px;
-    inline-size: 88px;
+    min-inline-size: 108px;
+    inline-size: 108px;
+}
+
+.gridItem.comingSoon {
+    cursor: default;
+    pointer-events: none;
+    background-color: var(--colors-grey050);
+    color: color-mix(in srgb, var(--colors-grey500) 75%, transparent);
+}
+.gridItem.comingSoon .gridItemLabel {
+    color: var(--colors-grey500);
+}
+
+.comingSoonBadge {
+    position: absolute;
+    inset-block-start: -6px;
+    inset-inline-end: -6px;
+    z-index: 1;
+    padding: 2px 4px;
+    border-radius: 3px;
+    background-color: var(--colors-white);
+    outline: 1px solid
+        color-mix(in srgb, var(--colors-grey500) 20%, transparent);
+    color: var(--colors-grey700);
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 1.2;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
 }
 
 .gridItem:hover:not(.disabled) {

--- a/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
@@ -23,7 +23,7 @@ import {
     getVisUiConfigLayout,
     getVisUiConfigVisualizationType,
 } from '@store/vis-ui-config-slice'
-import type { Layout, VisualizationType } from '@types'
+import type { EventVisualizationType, Layout, VisualizationType } from '@types'
 import cx from 'classnames'
 import type { FC, ReactNode } from 'react'
 import { useState, useRef } from 'react'
@@ -35,12 +35,21 @@ const visTypeIcons: Record<VisualizationType, ReactNode> = {
     PIVOT_TABLE: <IconVisualizationPivotTable16 />,
 }
 
-const COMING_SOON_VIS_TYPES: Array<{ label: string; icon: ReactNode }> = [
-    { label: i18n.t('Column'), icon: <IconVisualizationColumn16 /> },
-    { label: i18n.t('Bar'), icon: <IconVisualizationBar16 /> },
-    { label: i18n.t('Line'), icon: <IconVisualizationLine16 /> },
-    { label: i18n.t('Area'), icon: <IconVisualizationArea16 /> },
-]
+const COMING_SOON_VIS_TYPES = [
+    'COLUMN',
+    'BAR',
+    'LINE',
+    'AREA',
+] as const satisfies ReadonlyArray<EventVisualizationType>
+
+type ComingSoonVisType = (typeof COMING_SOON_VIS_TYPES)[number]
+
+const comingSoonVisTypeIcons: Record<ComingSoonVisType, ReactNode> = {
+    COLUMN: <IconVisualizationColumn16 />,
+    BAR: <IconVisualizationBar16 />,
+    LINE: <IconVisualizationLine16 />,
+    AREA: <IconVisualizationArea16 />,
+}
 
 type ListItemProps = {
     visType: VisualizationType
@@ -69,17 +78,18 @@ export const ListItem: FC<ListItemProps> = ({
     )
 }
 
-const ComingSoonListItem: FC<{ label: string; icon: ReactNode }> = ({
-    label,
-    icon,
+const ComingSoonListItem: FC<{ visType: ComingSoonVisType }> = ({
+    visType,
 }) => (
     <div
         className={cx(classes.gridItem, classes.comingSoon)}
         aria-disabled="true"
     >
         <span className={classes.comingSoonBadge}>{i18n.t('Coming soon')}</span>
-        {icon}
-        <span className={classes.gridItemLabel}>{label}</span>
+        {comingSoonVisTypeIcons[visType]}
+        <span className={classes.gridItemLabel}>
+            {visTypeDisplayNames[visType]}
+        </span>
     </div>
 )
 
@@ -209,15 +219,12 @@ export const VisualizationTypeSelector: FC = () => {
                                             />
                                         )
                                     )}
-                                    {COMING_SOON_VIS_TYPES.map(
-                                        ({ label, icon }) => (
-                                            <ComingSoonListItem
-                                                key={label}
-                                                label={label}
-                                                icon={icon}
-                                            />
-                                        )
-                                    )}
+                                    {COMING_SOON_VIS_TYPES.map((visType) => (
+                                        <ComingSoonListItem
+                                            key={visType}
+                                            visType={visType}
+                                        />
+                                    ))}
                                 </div>
                             </div>
                         </div>

--- a/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
+++ b/src/components/layout-panel/top-bar/visualization-type-selector/visualization-type-selector.tsx
@@ -10,6 +10,10 @@ import {
     IconChevronDown16,
     IconVisualizationLinelist16,
     IconVisualizationPivotTable16,
+    IconVisualizationColumn16,
+    IconVisualizationBar16,
+    IconVisualizationLine16,
+    IconVisualizationArea16,
 } from '@dhis2/ui'
 import { useAppDispatch, useAppSelector, useMetadataStore } from '@hooks'
 import { convertLayoutForVisType } from '@modules/layout'
@@ -30,6 +34,13 @@ const visTypeIcons: Record<VisualizationType, ReactNode> = {
     LINE_LIST: <IconVisualizationLinelist16 />,
     PIVOT_TABLE: <IconVisualizationPivotTable16 />,
 }
+
+const COMING_SOON_VIS_TYPES: Array<{ label: string; icon: ReactNode }> = [
+    { label: i18n.t('Column'), icon: <IconVisualizationColumn16 /> },
+    { label: i18n.t('Bar'), icon: <IconVisualizationBar16 /> },
+    { label: i18n.t('Line'), icon: <IconVisualizationLine16 /> },
+    { label: i18n.t('Area'), icon: <IconVisualizationArea16 /> },
+]
 
 type ListItemProps = {
     visType: VisualizationType
@@ -57,6 +68,20 @@ export const ListItem: FC<ListItemProps> = ({
         </button>
     )
 }
+
+const ComingSoonListItem: FC<{ label: string; icon: ReactNode }> = ({
+    label,
+    icon,
+}) => (
+    <div
+        className={cx(classes.gridItem, classes.comingSoon)}
+        aria-disabled="true"
+    >
+        <span className={classes.comingSoonBadge}>{i18n.t('Coming soon')}</span>
+        {icon}
+        <span className={classes.gridItemLabel}>{label}</span>
+    </div>
+)
 
 type PendingConversion = {
     targetVisType: VisualizationType
@@ -181,6 +206,15 @@ export const VisualizationTypeSelector: FC = () => {
                                                 onClick={handleListItemClick(
                                                     visType
                                                 )}
+                                            />
+                                        )
+                                    )}
+                                    {COMING_SOON_VIS_TYPES.map(
+                                        ({ label, icon }) => (
+                                            <ComingSoonListItem
+                                                key={label}
+                                                label={label}
+                                                icon={icon}
                                             />
                                         )
                                     )}


### PR DESCRIPTION
### Description

This PR adds _coming soon_ visualization types to the visualization type dropdown menu. _Coming soon_ types are static and not selectable.

Visualization type display names come from analytics. I kept the `COMING_SOON_VIS_TYPES`s local to the `visualization-type-selector.tsx` rather than in the "real" `constants/visualization-types.ts` because this temporary thing might not survive to a `x.1` release. But happy to make that change if preferred.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated
- [x] Docs added _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) _N/A_

---


### Screenshots

<img width="680" height="289" alt="image" src="https://github.com/user-attachments/assets/135768e2-2e4f-4070-aa6c-476d053d9e8b" />