### PR TITLE
fix: various visual style fixes

### DIFF
--- a/src/components/layout-panel/bottom-bar/styles/bottom-bar.module.css
+++ b/src/components/layout-panel/bottom-bar/styles/bottom-bar.module.css
@@ -10,6 +10,10 @@
     block-size: 29px;
 }
 
+.bottomBar.empty {
+    border-block-start-color: transparent;
+}
+
 .container {
     display: flex;
     align-items: center;

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -26,7 +26,6 @@
     block-size: 100%;
     max-block-size: 80vh;
     overflow-y: auto;
-    scrollbar-gutter: stable;
 }
 
 /* With a definite height applied, columns and rows share it equally: each floors

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -20,8 +20,6 @@
      * `fr` track grows every row to the tallest row's content. `.fixedHeight`
      * applies once a height is set. */
     grid-template-rows: auto auto;
-    gap: 1px;
-    border-color: var(--colors-grey300);
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.03);
     block-size: 100%;
     max-block-size: 80vh;

--- a/src/components/sidebar/data-source-select/styles/data-source-select-listbox.module.css
+++ b/src/components/sidebar/data-source-select/styles/data-source-select-listbox.module.css
@@ -30,6 +30,7 @@
     font-size: 13px;
     cursor: pointer;
     color: var(--colors-grey600);
+    text-decoration: underline;
 }
 .showMoreButton:focus {
     outline: 3px solid var(--theme-focus);


### PR DESCRIPTION
### Description

This PR makes several visual style fixes:
- hide 1px border on the layoutBottomBar in true empty state
- align the datasource menu _show more_ action with the dimension card's _load more_ style
- remove the `scrollbar-gutter: stable` on the layout axes container
    - I initially added the stable gutter to avoid chip reflow when a scrollbar is introduced, but it makes the dropzone outline glow look much worse because it leaves a static 6px gap at all times. So we'll live with the potential for a reflow to avoid the gap.
- removed a stale `gap: 1px` on the layout axis container which was visible when the dropzone outline was present. The `gap` seems to be left over from when it was used as a border. But it was non-functional (layout background is white). The axis containers have proper borders now, so no need for `gap` anyway.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested _N/A_
- [x] Cypress and/or Jest tests added/updated _N/A_
- [x] Docs added _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>) _N/A_

---

### Screenshots

Before:
<img width="1276" height="229" alt="image" src="https://github.com/user-attachments/assets/5c0e05a8-0d02-4036-9fd7-63431b728680" />

After:
<img width="1277" height="239" alt="image" src="https://github.com/user-attachments/assets/93f38840-269c-4452-a18f-548bac241806" />

---

Before:
<img width="403" height="141" alt="image" src="https://github.com/user-attachments/assets/bcf2ba83-28a8-4aa6-b5bd-c56e9b7c0e8d" />

After:
<img width="399" height="133" alt="image" src="https://github.com/user-attachments/assets/11490ef7-e71b-4f7d-9d08-41be9dfcdf16" />

---

Before:
<img width="334" height="206" alt="image" src="https://github.com/user-attachments/assets/20b3263b-2c26-4ec3-8de5-ec7777032465" />

After:
<img width="324" height="220" alt="image" src="https://github.com/user-attachments/assets/ce0fe1e0-a57d-4cef-9ee2-d95062aa84db" />

---

Before:
<img width="597" height="103" alt="image" src="https://github.com/user-attachments/assets/3513dd2b-9632-4042-ba42-296731873dc7" />

After:
<img width="596" height="108" alt="image" src="https://github.com/user-attachments/assets/8fbe2777-aef4-4cde-9e67-ba007ff0718f" />

