### PR TITLE
fix: layout expand control states

### DIFF
--- a/src/components/layout-panel/axes.tsx
+++ b/src/components/layout-panel/axes.tsx
@@ -1,7 +1,7 @@
 import { getActiveDragData } from '@components/app-wrapper/drag-and-drop-provider/dnd-data'
 import { SkeletonChip } from '@components/shared/skeleton-chip'
 import i18n from '@dhis2/d2-i18n'
-import { IconMore16, colors } from '@dhis2/ui'
+import { IconMore16 } from '@dhis2/ui'
 import { useDndContext } from '@dnd-kit/core'
 import { useAppDispatch, useAppSelector } from '@hooks'
 import { getDataSourceId } from '@store/dimensions-selection-slice'
@@ -36,7 +36,7 @@ const ExpandLayoutPanelButton: FC = () => {
                 }
             }}
         >
-            <IconMore16 color={colors.grey800} />
+            <IconMore16 color="currentColor" />
         </button>
     )
 }

--- a/src/components/layout-panel/styles/axes.module.css
+++ b/src/components/layout-panel/styles/axes.module.css
@@ -47,18 +47,28 @@
     align-items: center;
     justify-content: center;
     padding: 2px;
+    border: none;
     box-shadow:
         inset 0 4px 8px -6px rgba(40, 60, 85, 0.05),
         inset 0 -4px 8px -6px rgba(40, 60, 85, 0.05);
     background-color: var(--colors-white);
+    color: var(--colors-grey600);
     cursor: pointer;
-    transition:
-        background-color 0.15s ease,
-        color 0.15s ease;
 }
 
 .expandButton:hover {
-    background-color: var(--colors-grey100);
+    background-color: var(--colors-grey50);
+    color: var(--colors-grey900);
+    box-shadow: inset 0 0 0 1px var(--colors-grey400);
+}
+
+.expandButton:focus {
+    outline: 3px solid var(--theme-focus);
+    outline-offset: -3px;
+}
+
+.expandButton:focus:not(:focus-visible) {
+    outline: none;
 }
 
 .loadingSkeletons {


### PR DESCRIPTION
### Description

This PR implements proper `hover` and `focus` states for the Layout expand control.

---

### Quality checklist

Add _N/A_ to items that are not applicable and check them.

<!--Checkmate-->

- [x] Dashboard tested  _N/A_
- [x] Cypress and/or Jest tests added/updated  _N/A_
- [x] Docs added  _N/A_
- [x] d2-ci dependency replaced (requires <https://github.com/dhis2/analytics/pull/XXX>)  _N/A_

---

### Screenshots

before: 

<img width="875" height="120" alt="image" src="https://github.com/user-attachments/assets/24514c33-d544-42ba-9d72-407c2d9ed8cb" />

after:

<img width="857" height="118" alt="image" src="https://github.com/user-attachments/assets/d83187de-2752-4002-a17a-7fe1ded20cbd" />

